### PR TITLE
Corrige o watch para usar o .vtexignore

### DIFF
--- a/src/lib/watch.coffee
+++ b/src/lib/watch.coffee
@@ -25,11 +25,15 @@ class Watcher
     fileManager.listFiles().then (result) =>
       deferred = Q.defer()
 
+      for ignore, index in result.ignore
+        result.ignore[index] = path.join root, ignore
+      result.ignore.push /(^[.#]|(?:__|~)$)/
+
       watcher = chokidar.watch(root, {
         persistent: true,
         usePolling: usePolling,
         ignoreInitial: true,
-        ignored: ((filePath) -> /(^[.#]|(?:__|~)$)/.test path.basename(filePath), result.ignore)
+        ignored: result.ignore
       })
 
       watcher

--- a/src/lib/watch.coffee
+++ b/src/lib/watch.coffee
@@ -25,8 +25,7 @@ class Watcher
     fileManager.listFiles().then (result) =>
       deferred = Q.defer()
 
-      for ignore, index in result.ignore
-        result.ignore[index] = path.join root, ignore
+      result.ignore[i] = path.join(root, ignore) for ignore, i in result.ignore
       result.ignore.push /(^[.#]|(?:__|~)$)/
 
       watcher = chokidar.watch(root, {


### PR DESCRIPTION
Corrige o watch para usar o .vtexignore devidamente.

Após detectado o bug, percebi que o watch estava olhando pra a pasta root inteira do projeto, e não somente para os arquivos já filtrados anteriormente pelo listFile() (função que devolve os arquivos para observar e o que ignorar). 

Isso faz com que qualquer mudança na pasta do projeto ignore o que é definido em .vtexignore. Então, a solução proposta é fazer o watch "olhar" apenas os arquivos já filtrados.

**EDIT**
Agora olha para o root e ignora de acordo no ignored do watcher!
Está funcional mas creio que pode ser refinado, irei trabalhar isso conforme faço o teste.

- [x] Implementação da correção
- [ ] Teste para o watch