### PR TITLE
Add vtexrc for custom request

### DIFF
--- a/src/lib/file-manager.coffee
+++ b/src/lib/file-manager.coffee
@@ -37,7 +37,7 @@ class FileManager
       configObj = {}
       for prop in config
         confKey = /^(\w*)=?/.exec(prop)[1]
-        confVal = /"(.*)"/.exec(prop)[1]
+        confVal = /"(.*)"/.exec(prop)[1].replace(/\/$/, '')
         configObj[confKey] = confVal
       return configObj
     ).catch((e) => return [])

--- a/src/lib/file-manager.coffee
+++ b/src/lib/file-manager.coffee
@@ -32,6 +32,11 @@ class FileManager
             .catch -> readIgnore(ignoreFile('.gitignore'))
     return file
 
+  readVtexRc: =>
+    vtexRc = path.resolve(process.cwd(), '.vtexrc')
+    file = Q.nfcall(fs.readFile, vtexRc, "utf8")
+    return file
+
   compressFiles: (app, version) =>
     @listFiles().then((result) =>
       zipPath = @getZipFilePath(app, version)

--- a/src/lib/file-manager.coffee
+++ b/src/lib/file-manager.coffee
@@ -11,10 +11,15 @@ class FileManager
 
   listFiles: =>
     deferred = Q.defer()
-    @getIgnoredPatterns().then((ignoredPatterns) =>
+    Q.all([@getIgnoredPatterns(), @getRequestConfig()]).spread((ignoredPatterns, requestConfig) =>
       ignoredPatterns.push('**/.*', '**/*__', '**/*~')
       glob "**", nodir: true, ignore: ignoredPatterns, (er, files) =>
-        deferred.resolve {files: files, ignore: ignoredPatterns}
+        deferred.resolve({
+          files: files
+          ignore: ignoredPatterns
+          endpoint: requestConfig.GalleryEndpoint
+          header: requestConfig.AcceptHeader
+        })
     )
     deferred.promise
 

--- a/src/lib/file-manager.coffee
+++ b/src/lib/file-manager.coffee
@@ -25,6 +25,18 @@ class FileManager
       ignored.map((item) => if item.substr(-1) is "/" then item += "**" else item)
     ).catch((e) => return [])
 
+  getRequestConfig: =>
+    @readVtexRc().then((vtexRc) =>
+      lines = vtexRc.match(/[^\r\n]+/g)
+      config = lines.filter((line) => line.charAt(0) != '#' and line != '')
+      configObj = {}
+      for prop in config
+        confKey = /^(\w*)=?/.exec(prop)[1]
+        confVal = /"(.*)"/.exec(prop)[1]
+        configObj[confKey] = confVal
+      return configObj
+    ).catch((e) => return [])
+
   readVtexIgnore: =>
     ignoreFile = (file) -> path.resolve process.cwd(), file
     readIgnore = (ignore) -> Q.nfcall(fs.readFile, ignore, "utf8")

--- a/src/lib/watch.coffee
+++ b/src/lib/watch.coffee
@@ -19,7 +19,7 @@ class Watcher
   lrPortInUse: false
 
   constructor: (@app, @vendor, @sandbox, @credentials) ->
-    @endpoint = "http://api.beta.vtex.com/#{@vendor}/sandboxes/#{@sandbox}/#{@app}/files"
+    @endpoint = "http://api.beta.vtex.com/"
     @acceptHeader = "application/vnd.vtex.gallery.v0+json"
     @lrRun(35729)
 
@@ -112,7 +112,7 @@ class Watcher
 
   sendChanges: (batchChanges, refresh) =>
     options =
-      url: @endpoint
+      url: @endpoint + "/#{@vendor}/sandboxes/#{@sandbox}/#{@app}/files"
       method: 'POST'
       json: batchChanges
       headers: {

--- a/src/lib/watch.coffee
+++ b/src/lib/watch.coffee
@@ -163,11 +163,11 @@ class Watcher
 
   getSandboxFiles: =>
     options =
-      url: "http://api.beta.vtex.com/#{@vendor}/sandboxes/#{@sandbox}/#{@app}/files"
+      url: @endpoint + "/#{@vendor}/sandboxes/#{@sandbox}/#{@app}/files"
       method: 'GET'
       headers: {
         Authorization: 'token ' + @credentials.token
-        'Accept': "application/vnd.vtex.gallery.v0+json"
+        'Accept': @acceptHeader
         'Content-Type': "application/json"
         'x-vtex-accept-snapshot': false
       }

--- a/src/lib/watch.coffee
+++ b/src/lib/watch.coffee
@@ -19,6 +19,8 @@ class Watcher
   lrPortInUse: false
 
   constructor: (@app, @vendor, @sandbox, @credentials) ->
+    @endpoint = "http://api.beta.vtex.com/#{@vendor}/sandboxes/#{@sandbox}/#{@app}/files"
+    @acceptHeader = "application/vnd.vtex.gallery.v0+json"
     @lrRun(35729)
 
   watch: =>
@@ -108,12 +110,12 @@ class Watcher
 
   sendChanges: (batchChanges, refresh) =>
     options =
-      url: "http://api.beta.vtex.com/#{@vendor}/sandboxes/#{@sandbox}/#{@app}/files"
+      url: @endpoint
       method: 'POST'
       json: batchChanges
       headers: {
         Authorization: 'token ' + @credentials.token
-        'Accept': "application/vnd.vtex.gallery.v0+json"
+        'Accept': @acceptHeader
         'Content-Type': "application/json"
         'x-vtex-accept-snapshot': false
       }

--- a/src/lib/watch.coffee
+++ b/src/lib/watch.coffee
@@ -28,6 +28,8 @@ class Watcher
     usePolling = (process.platform is 'win32') ? false
     fileManager.listFiles().then (result) =>
       deferred = Q.defer()
+      @endpoint = result.endpoint if result.endpoint
+      @acceptHeader = result.header if result.header
       ignore = (path.join(root, ignorePath) for ignorePath in result.ignore)
 
       watcher = chokidar.watch(root, {


### PR DESCRIPTION
Fix #33 

Add the possibility of creating a .vtexrc file on the root path of your project to define custom request configs.

For now, only the endpoint and accept header can be customized:

    GalleryEndpoint = "your_endpoint"
    AcceptHeader = "your_accept_header"

You can comment the lines by prepending them with     #:

    # GalleryEndpoint = "your_endpoint"
    # AcceptHeader = "your_accept_header"