### PR TITLE
Create change migrator

### DIFF
--- a/src/bin/vtex-watch.js
+++ b/src/bin/vtex-watch.js
@@ -8,17 +8,20 @@ import WebpackRunner from '../lib/webpack';
 import chalk from 'chalk';
 import vtexsay from 'vtexsay';
 
-const SERVER_INDEX = process.argv.length - 1;
-const WEBPACK_INDEX = process.argv.length - 2;
+const SERVER_INDEX = process.argv.length - 2;
+const WEBPACK_INDEX = process.argv.length - 3;
+const MIGRATE_CHANGES = process.argv.length - 1;
 
 const serverFlag = process.argv[SERVER_INDEX];
 const webpackFlag = process.argv[WEBPACK_INDEX];
+const migrateChagesFlag = process.argv[MIGRATE_CHANGES];
+
 const isFlagActive = webpackFlag === 'true' || serverFlag === 'true';
+const isMigrateSet = migrateChagesFlag === 'true';
 
 function runWatcher(credentials, meta) {
   const { name, vendor } = meta;
-
-  const watcher = new Watcher(name, vendor, credentials, serverFlag);
+  const watcher = new Watcher(name, vendor, credentials, serverFlag, isMigrateSet);
   return watcher.watch();
 }
 

--- a/src/bin/vtex.js
+++ b/src/bin/vtex.js
@@ -10,7 +10,7 @@ const doc = `
     vtex login
     vtex logout
     vtex publish
-    vtex watch [--webpack | --server]
+    vtex watch [--webpack | --server] [--changes]
     vtex --help
     vtex --version
 
@@ -25,6 +25,7 @@ const doc = `
     -v --version  Show version
     -w --webpack  Start with webpack
     -s --server   Start with dev server
+    -c --changes  Start with changes mode
 
 `;
 
@@ -82,7 +83,7 @@ if (options.login) {
   if (options['--server']) {
     env = 'HOT';
   }
-  argv = [options['--webpack'], options['--server']];
+  argv = [options['--webpack'], options['--server'], options['--changes']];
 }
 
 run(command, argv, env);

--- a/src/lib/changes-migrator.js
+++ b/src/lib/changes-migrator.js
@@ -1,0 +1,310 @@
+import path from 'path';
+import fs from 'fs';
+import shell from 'shelljs';
+import Q from 'q';
+
+import {
+  getSandboxFiles,
+  generateComponentFilesHash,
+  generateRouteFilesHash,
+  generateAreaFilesHash,
+  passToChanges
+} from './file-hash-generator';
+
+let ChangeAction = {
+  Save: 'save',
+  Remove: 'remove'
+};
+
+let Path = {
+  Routes: 'storefront/setup/routes.json',
+  Areas: 'storefront/setup/areas.json',
+  Components: 'storefront/components/',
+  Component: 'storefront/component/',
+  Assets: 'storefront/assets/',
+  Root: process.cwd()
+};
+
+let buildSetUpChanges = (meta) => {
+  return getSandboxFiles(meta).then((sandboxFiles) => {
+    return discoverComponentChanges(sandboxFiles).then((componentChanges) => {
+      return Q.all([discoverRouteChanges(sandboxFiles), discoverAreaChanges(sandboxFiles, componentChanges.components)])
+        .spread((routeChanges, areaChanges) => {
+          let route = getRouteChanges(routeChanges);
+          let component = getComponentChanges(componentChanges);
+          let areas = getAreasChanges(areaChanges, componentChanges.components);
+          return route.concat(areas, component);
+        });
+    });
+  });
+};
+
+let discoverComponentChanges = (sandboxFiles) => {
+  let filterSandboxFiles = (sandboxFiles) => {
+    let filesToCompare = {};
+    Object.keys(sandboxFiles).forEach((file) => {
+      if (isComponentFile(file)) {
+        filesToCompare[file] = sandboxFiles[file];
+      }
+    });
+    return filesToCompare;
+  };
+
+  let assetFiles = listFiles(Path.Assets);
+  return Q.all(generateComponentFilesHash(assetFiles)).then((componentFiles) => {
+      if (sandboxFiles != null) {
+        let filesToCompare = filterSandboxFiles(sandboxFiles);
+        return {
+            changes: passToChanges(filesToCompare, componentFiles.fileHashes),
+            components: componentFiles.merged
+          };
+      }
+      return {
+          changes: passToChanges(componentFiles.fileHashes),
+          components: componentFiles.merged
+        };
+  });
+};
+
+let discoverRouteChanges = (sandboxFiles) => {
+  let filterSandboxFiles = (sandboxFiles) => {
+    let filesToCompare = {};
+    Object.keys(sandboxFiles).forEach((file) => {
+      if (isRouteFile(file)) {
+        filesToCompare[file] = sandboxFiles[file];
+      }
+    });
+    return filesToCompare;
+  };
+
+  return Q.all(generateRouteFilesHash(Path.Routes)).then((routeFiles) => {
+      if (sandboxFiles != null) {
+        let filesToCompare = filterSandboxFiles(sandboxFiles);
+        return {
+            changes: passToChanges(filesToCompare, routeFiles.fileHashes),
+            routes: routeFiles.allRoutes
+          };
+      }
+      return {
+          changes: passToChanges(routeFiles.fileHashes),
+          routes: componentFiles.allRoutes
+        };
+  });
+};
+
+let discoverAreaChanges = (sandboxFiles, componentAreas) => {
+  let filterSandboxFiles = (sandboxFiles) => {
+    let filesToCompare = {};
+    Object.keys(sandboxFiles).forEach((file) => {
+      if (isAreaFile(file)) {
+        filesToCompare[file] = sandboxFiles[file];
+      }
+    });
+    return filesToCompare;
+  };
+
+  return Q.all(generateAreaFilesHash(Path.Areas, componentAreas)).then((areaFiles) => {
+    if (sandboxFiles != null) {
+      let filesToCompare = filterSandboxFiles(sandboxFiles);
+      return {
+          changes: passToChanges(filesToCompare, areaFiles.fileHashes),
+          areas: areaFiles.allAreas
+      };
+    }
+    return {
+        changes: passToChanges(areaFiles.fileHashes),
+        areas: areaFiles.allAreas
+    };
+  });
+};
+
+let getComponentChanges = (componentChanges) => {
+  componentChanges.changes = formatChanges(componentChanges.changes)
+
+  let changes = [];
+  componentChanges.changes.forEach((componentChange) => {
+    if (componentChange.action === ChangeAction.Save) {
+      let componentName = getFileName(componentChange.path);
+      let content = componentChanges.components[componentName];
+      changes.push(getChange(componentChange.path, content, componentChange.action));
+    }
+
+    if (componentChange.action === ChangeAction.Remove) {
+      let change = { 'path': componentChange.path, 'action': componentChange.action };
+      changes.push(change);
+    }
+  });
+  return changes;
+};
+
+let getRouteChanges = (routeChanges) => {
+  let changes = [];
+  let routes = routeChanges.routes;
+  routeChanges.changes = formatChanges(routeChanges.changes);
+
+  routeChanges.changes.forEach((routeChange) => {
+    if (routeChange.action === ChangeAction.Save) {
+      let routeName = getFileName(routeChange.path);
+      let content = routes[routeName];
+      changes.push(getChange(routeChange.path, content, routeChange.action));
+    }
+
+    if (routeChange.action === ChangeAction.Remove) {
+      changes.push({ 'path': routeChange.path, 'action': routeChange.action });
+    }
+  });
+
+  return changes;
+};
+
+let getAreasChanges = (areaChanges, componentAreas) => {
+ let allAreas = areaChanges.areas;
+ let changes = [];
+ areaChanges.changes = formatChanges(areaChanges.changes)
+
+ let getAreaFromPath = (filePath) => {
+   let regex = /storefront\/areas\/([^/]*)\/(.*).json/;
+   let match = filePath.match(regex);
+   if (match != null) {
+     return { id: `/${match[2]}`, rootArea: `${match[1]}` };
+   }
+
+   let rootAreaPattern = /storefront\/areas\/([^/]*).json/;
+   let result = filePath.match(rootAreaPattern);
+   if (result != null) {
+     return { id: '/', rootArea: result[1] };
+   }
+ };
+
+ areaChanges.changes.forEach((areaChange) => {
+   let area = getAreaFromPath(areaChange.path);
+   let intention = getAreaIntention(area.id, componentAreas);
+
+   let route = area ? allAreas[area.rootArea] : undefined;
+   let locator = intention ? intention : area.id;
+
+   try {
+       if (areaChange.action === ChangeAction.Save) {
+         changes.push(getChange(areaChange.path, route[locator], areaChange.action));
+       } else {
+         changes.push(areaChange);
+       }
+   } catch (err){ console.log(err); }
+ });
+ return changes;
+};
+
+let getAreaIntention = (areaId, componentAreas) => {
+  let intentions = [];
+  for (let component of Object.keys(componentAreas)) {
+    let areas = componentAreas[component].areas;
+    areas.forEach((area) => {
+      if (area.id === areaId) {
+        intentions.push(area.intention);
+      }
+    });
+  };
+  return intentions[0];
+};
+
+let filterSourceFiles = (files) => {
+  return files.filter((item) => !isRoutesFile(item) && !isAreasFile(item));
+};
+
+let filterSourceChanges = (batch) => {
+  let areaChanges = batch.filter((item) =>
+    isAreasFile(normalizePath(item.path)));
+
+  let routeChanges = batch.filter((item) =>
+    isRoutesFile(normalizePath(item.path)));
+
+  return batch.filter((item) => areaChanges.indexOf(item) === -1 &&
+      routeChanges.indexOf(item) === -1);
+};
+
+let getFileName = (filePath) => { return path.basename(filePath, '.json'); };
+
+let getAreasPathFromChanges = (batchChanges) => {
+  let areasFile = batchChanges.filter((item) =>
+    isAreasFile(item.path) && item.action === ChangeAction.Save);
+  return areasFile.length > 0 ? areasFile[0].path : '';
+};
+
+let getSourceFiles = (files) => {
+  return files.filter((item) => !isRoutesFile(item) && !isAreasFile(item));
+};
+
+let getAreasFilePath = (files) => {
+  let areasFile = files.filter((item) => isAreasFile(item));
+  return areasFile.length > 0 ? areasFile[0] : '';
+};
+
+let getRouteFilePath = (files) => {
+  let areasFile = files.filter((item) => isRoutesFile(item));
+  return areasFile.length > 0 ? areasFile[0] : '';
+};
+
+let isRouteFile = (filePath) => {
+  let input = 'storefront/routes/';
+  return filePath.substring(0, input.length) === input;
+};
+
+let isAreaFile = (filePath) => {
+  let input = 'storefront/areas/';
+  return filePath.substring(0, input.length) === input;
+};
+
+let isRoutesFile = (filePath) => {
+  return filePath.substring(0, Path.Routes.length) === Path.Routes;
+};
+
+let isAreasFile = (filePath) => {
+  return filePath.substring(0, Path.Areas.length) === Path.Areas;
+};
+
+let isComponentFile = (filePath) => {
+  return filePath.substring(0, Path.Component.length) === Path.Component;
+};
+
+let normalizePath = (filePath) => {
+  let root = path.resolve('');
+  return filePath.substring(root.length + 1).replace(/\\/g, '/');
+};
+
+let listFiles = (filePath) => {
+  let componentDir = normalizePath(`${Path.Root}/${filePath}`);
+  return test('-e', componentDir) ? shell.ls('-R', componentDir) : [];
+};
+
+let getChange = (changePath, content, action) => {
+  let base64 = new Buffer(JSON.stringify(content)).toString('base64');
+  return {
+    'path': changePath,
+    'content': base64,
+    'encoding': 'base64',
+    'action': action
+  }
+};
+
+let formatChanges = (changes) => {
+  let batch = [];
+  for (let filePath in changes) {
+    let action = changes[filePath];
+    if (action) {
+      batch.push({
+        action: action,
+        path: filePath
+      });
+    }
+  }
+  return batch;
+};
+
+export {
+  buildSetUpChanges,
+  filterSourceChanges,
+  filterSourceFiles,
+  isRouteFile,
+  isComponentFile,
+  isAreaFile
+};

--- a/src/lib/file-hash-generator.js
+++ b/src/lib/file-hash-generator.js
@@ -1,0 +1,329 @@
+import path from 'path';
+import fs from 'fs';
+import Q from 'q';
+import crypto from 'crypto';
+import request from 'request';
+import merge from 'deepmerge'
+
+let ChangeAction = {
+  Save: 'save',
+  Remove: 'remove'
+};
+
+let generateFilesHash = (files) => {
+  let root = process.cwd();
+  let readAndHash = (filePath) => {
+    return Q.nfcall(fs.readFile, path.resolve(root, filePath)).then((content) => {
+      let hashedContent = crypto.createHash('md5').update(content, 'binary').digest('hex');
+      return {
+        path: filePath,
+        hash: hashedContent
+      };
+    });
+  };
+
+  let filesPromise = [];
+  files.forEach((file) => {
+    filesPromise.push(readAndHash(file));
+  });
+
+  return Q.all(filesPromise).then(mapFilesHash);
+};
+
+let mapFilesHash = (filesArr) => {
+  let filesAndHash = {};
+  filesArr.forEach((file) => {
+    filesAndHash[file.path] = {
+      hash: file.hash
+    };
+  });
+  return filesAndHash;
+};
+
+let passToChanges = (filesToLoop, filesToCompare) => {
+  let changes = {};
+  let filesToCompareExists = filesToCompare !== void 0;
+
+  for (let file in filesToLoop) {
+    if (!filesToCompareExists) {
+      changes[file] = ChangeAction.Save;
+    } else {
+      if (filesToCompare[file] == null) {
+        changes[file] = ChangeAction.Remove;
+      } else {
+        let hashCompare = filesToCompare[file].hash !== filesToLoop[file].hash;
+        delete filesToCompare[file];
+        if (hashCompare) {
+          changes[file] = ChangeAction.Save;
+        }
+      }
+    }
+  }
+
+  let compareKeys;
+  if (!!filesToCompareExists) {
+    compareKeys = Object.keys(filesToCompare).length;
+  }
+
+  if (compareKeys > 0) {
+    for (let file in filesToCompare) {
+      changes[file] = ChangeAction.Save;
+    }
+  }
+  return changes;
+};
+
+let getSandboxFiles = ({ endpoint, vendor, sandbox, app, acceptHeader, token }) => {
+  let options = {
+    url: endpoint + '/' + vendor + '/sandboxes/' + sandbox + '/' + app + '/files',
+    method: 'GET',
+    headers: {
+      Authorization: 'token ' + token,
+      Accept: acceptHeader,
+      'Content-Type': 'application/json',
+      'x-vtex-accept-snapshot': false
+    }
+  };
+
+  return Q.nfcall(request, options).then((data) => {
+    let response = data[0];
+    if (response.statusCode === 200) {
+      return JSON.parse(response.body);
+    } else if (response.statusCode === 404) {
+      return void 0;
+    }
+    return console.error('Status:', response.statusCode);
+  });
+};
+
+let filterCommonFiles = (files) => {
+  let commonFiles = files.filter((item) => isCommonFile(item));
+  return commonFiles.map((item) => path.basename(item)).filter((file) =>
+    path.extname(file) != '.map');
+};
+
+let generateComponentFilesHash = (assetFiles) => {
+  return Q.all([getComponentsAssets(assetFiles), getComponentsAreas(assetFiles)])
+    .spread((assets, areas) => {
+        try {
+          let hashes = [];
+          let merged = merge(assets, areas);
+
+          Object.keys(merged).forEach((componentName) => {
+            let componentPath = `storefront/component/${componentName}.json`;
+            let componentHash = getHashContent(componentPath, merged[componentName]);
+            hashes.push(componentHash);
+          });
+          let fileHashes = mapFilesHash(hashes);
+          return { fileHashes, merged };
+        } catch (error) { console.log(error); }
+    });
+};
+
+let findId = (propsArr) => {
+  let isId = (str) => {
+    return str.substring(0, "id".length) === "id";
+  };
+
+  for (var i = 0; i < propsArr.length; i++) {
+    if(isId(propsArr[i])) {
+      return { id: propsArr[i].replace(/\"|\'|id:/g, '') };
+    }
+  }
+};
+
+let findIntention = (propsArr) => {
+  let isIntention = (str) => {
+    return str.substring(0, "intention".length) === "intention";
+  };
+
+  for (var i = 0; i < propsArr.length; i++) {
+    if(isIntention(propsArr[i])) {
+      return { intention: propsArr[i].replace(/\"|\'|intention:/g, '') };
+    }
+  }
+};
+
+let getComponentsAreas = (assetFiles) => {
+  let assets = assetFiles.filter((item) => path.extname(item) === '.js');
+  let regex = /(id|intention):\s*((\'\/(?:[^\']*)\'|\'\~(?:[^\']*)\')|(\"\/(?:[^\"]*)\"|\"\~(?:[^\"]*)\"))/g
+
+  let mapAreaFiles = (filesArr) => {
+    let files = {};
+    filesArr.forEach((item) => {
+      files[item.path] = {
+        areas: item.areas
+      }
+    });
+    return files;
+  };
+
+  let readFile = (filePath) => {
+    return Q.nfcall(fs.readFile, path.resolve(process.cwd(), 'storefront/assets', filePath), 'utf8')
+      .catch((error) => { return ''; })
+      .then((content) => {
+        let match = content.match(regex);
+        let areas = [];
+        if (match != null) {
+          for (let i = 0; i < match.length; i=i+2) {
+              let id = findId([match[i], match[i+1]]);
+              let intention = findIntention([match[i], match[i+1]]);
+              let area = merge(id, intention);
+              areas.push(JSON.parse(JSON.stringify(area)));
+          }
+        }
+        let componentName = filePath.substring(0, filePath.indexOf('/'));
+        return { path: componentName, areas };
+      });
+  };
+
+  let filesPromise = [];
+  assets.forEach((file) => { filesPromise.push(readFile(file)); });
+
+  return Q.all(filesPromise).then(mapAreaFiles);
+};
+
+let generateRouteFilesHash = (routePath) => {
+  let root = process.cwd();
+  let createRoutes = (data, filePath) => {
+    try {
+      let fileHashes = [];
+      if (!data) return { fileHashes, allRoutes: {} };
+
+      let json = JSON.parse(data);
+      Object.keys(json).forEach((routeName) => {
+        let routePath = `storefront/routes/${routeName}.json`;
+        let routeHash = getHashContent(routePath, json[routeName]);
+        fileHashes.push(routeHash);
+      });
+      return { fileHashes, allRoutes: json };
+    } catch (error) { console.log(`${error} in ${filePath} file`); }
+  };
+
+  let readAndHash = (filePath) => {
+    return Q.nfcall(fs.readFile, path.resolve(root, filePath), 'utf8')
+      .catch((error) => { return null; })
+      .then((data) => { return createRoutes(data, filePath); });
+  };
+
+  let filesPromise = [];
+  filesPromise.push(readAndHash(routePath));
+  return Q.all(filesPromise).spread((routes) => {
+    routes.fileHashes = mapFilesHash(routes.fileHashes);
+    return routes;
+  });
+};
+
+let generateAreaFilesHash = (areaPath, componentAreas) => {
+  let root = process.cwd();
+  let hashAreas = (area, routeName, content) => {
+    let areaName = area === '/' ? routeName : `${routeName}${area}`;
+    let changePath = `storefront/areas/${areaName}.json`;
+    return getHashContent(changePath, content);
+  };
+
+  let isIntention = (filePath) => {
+   let input = "~";
+   return filePath.substring(0, input.length) === input;
+  };
+
+  let getRouteAreas = (routeAreas, routeName) => {
+    let hashes = [];
+    Object.keys(routeAreas).forEach((area) => {
+      if (isIntention(area)) {
+        let areasForIntentions = getAreasForIntentions(area, componentAreas);
+        areasForIntentions.forEach((areaId) => {
+          let areaHashedContent = hashAreas(areaId, routeName, routeAreas[area]);
+          hashes.push(areaHashedContent);
+        });
+      }
+      else {
+        let areaHashedContent = hashAreas(area, routeName, routeAreas[area]);
+        hashes.push(areaHashedContent);
+      }
+    });
+    return hashes;
+  };
+
+  let createAreas = (data, filePath) => {
+    try {
+      let hashes = [];
+      if (!data) return { fileHashes: [], allAreas: {} };
+
+      let json = JSON.parse(data);
+      Object.keys(json).forEach((routeName) => {
+        hashes.push(getRouteAreas(json[routeName], routeName));
+      });
+
+      let fileHashes = [];
+      hashes.forEach((fileHash) => { fileHash.forEach((item) => fileHashes.push(item)); });
+      return { fileHashes, allAreas: json };
+    } catch (error) { console.log(`${error} in ${filePath} file`); }
+  };
+
+  let readAndHashArea = (filePath) => {
+     return Q.nfcall(fs.readFile, path.resolve(root, filePath), 'utf8')
+        .catch((error) => { return null; })
+        .then((data) => { return createAreas(data, filePath); });
+  };
+
+  let filesPromise = [];
+  filesPromise.push(readAndHashArea(areaPath));
+  return Q.all(filesPromise).spread((areas) => {
+    areas.fileHashes = mapFilesHash(areas.fileHashes);
+    return areas;
+  });
+};
+
+let getHashContent = (filePath, content) => {
+  let hashedContent = crypto.createHash('md5').update(JSON.stringify(content)).digest('hex');
+  return { path: filePath, hash: hashedContent};
+};
+
+let getComponentsAssets = (assetFiles) => {
+  let commonFiles = filterCommonFiles(assetFiles);
+  let assets = assetFiles.filter((item) => path.extname(item) === '.js');
+
+  let componentes = {};
+  assets.forEach((item) => {
+    let componentName = item.substring(0, item.indexOf('/'));
+    if (componentName === 'common') return;
+
+    let asset = item.substring(componentName.length + 1);
+    if (componentName in componentes) {
+      let values = componentes[componentName].assets;
+      componentes[componentName].assets = values.concat(asset);
+    }
+    else {
+      componentes[componentName] = { assets: commonFiles.concat(asset) };
+    }
+  });
+  return componentes;
+};
+
+let getAreasForIntentions = (areaName, componentAreas) => {
+  let areasForIntentions = [];
+  Object.keys(componentAreas).forEach((component) => {
+    let areas = componentAreas[component].areas;
+    areas.forEach((area) => {
+      if (area.intention === areaName) {
+        areasForIntentions.push(area.id);
+      }
+    });
+  });
+  return areasForIntentions;
+};
+
+let isCommonFile = (filePath) => {
+  let input = 'common/';
+  return filePath.substring(0, input.length) === input;
+}
+
+export {
+  getSandboxFiles,
+  generateComponentFilesHash,
+  generateRouteFilesHash,
+  generateAreaFilesHash,
+  generateFilesHash,
+  passToChanges
+};

--- a/src/lib/webpack.js
+++ b/src/lib/webpack.js
@@ -25,7 +25,7 @@ class WebpackRunner {
 
     this.compiler = webpack(this.config);
     this.DELAY_TIME = 2000;
-  }
+  };
 
   startDevServer = () => {
     let port = 3000;
@@ -97,7 +97,7 @@ class WebpackRunner {
           }
         });
     }, this.DELAY_TIME);
-  }
+  };
 
   startWebpack = () => {
     setTimeout(() => {
@@ -114,7 +114,7 @@ class WebpackRunner {
         console.log(stats.toString(outputOptions) + '\n');
       });
     }, this.DELAY_TIME);
-  }
+  };
 }
 
 export default WebpackRunner;


### PR DESCRIPTION
#### Cria migrador de mudanças

Este migrador tem a resposabilidade de manter a compatibilidade da nova arquitetura
do Storefront.

#### Como funciona:
O migrador le os arquivos:

/src/components/HomePage.js
```js
...
<Area id="/banner" intention='~amoreira'/>
<Area id="/shelf" intention="~shelf"/>
...
```

/storefront/setup/areas.json
```json
"home": {
  "~amoreira": {
    "component": "Banner@vtex.storefront-theme",
    "settings": {}
  },
 "~shelf": {
    "component": "Shelf@vtex.storefront-theme",
    "settings": {}
 }
}
```

/storefront/setup/routes.json
```json
{
  "home" : {
    "path": "/"
  }
}
```



E gera os metadados durante o comando `watch`:
/storefront/routes/home.json
```json
{
  "path": "/"
}
```

/storefront/areas/home/banner.json
```json
{
  "component": "Banner@vtex.storefront-theme",
  "settings": {}
}
```


/storefront/areas/home/shelf.json
```json
{
 "component": "Shelf@vtex.storefront-theme",
  "settings": {}
}
```

PS: Para ativar o migrador de mudança é preciso setar a flag --changes ou -c