### PR TITLE
Use request wrapper with retry capability

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "ora": "^0.2.1",
     "prompt": "~1.0.0",
     "q": "^1.4.1",
-    "request": "^2.64.0",
+    "requestretry": "^1.8.0",
     "semver": "^5.0.3",
     "shelljs": "^0.7.0",
     "supports-color": "^3.1.1",

--- a/src/lib/auth/credentials.js
+++ b/src/lib/auth/credentials.js
@@ -1,5 +1,5 @@
 import path from 'path';
-import request from 'request';
+import request from 'requestretry';
 import Q from 'q';
 import fs from 'fs';
 import { getErrorMessage } from './utils';

--- a/src/lib/auth/login.js
+++ b/src/lib/auth/login.js
@@ -1,5 +1,5 @@
 import path from 'path';
-import request from 'request';
+import request from 'requestretry';
 import Q from 'q';
 import fs from 'fs';
 import prompt from 'prompt';

--- a/src/lib/publish.js
+++ b/src/lib/publish.js
@@ -1,5 +1,5 @@
 import Q from 'q';
-import request from 'request';
+import request from 'requestretry';
 import fs from 'fs';
 import { compressFiles, getRequestConfig, getZipFilePath, removeZipFile } from './file-manager';
 import chalk from 'chalk';

--- a/src/lib/watch.js
+++ b/src/lib/watch.js
@@ -1,7 +1,7 @@
 import Q from 'q';
 import path from 'path';
 import fs from 'fs';
-import request from 'request';
+import request from 'requestretry';
 import chokidar from 'chokidar';
 import { listFiles } from './file-manager';
 import tinylr from 'tiny-lr';

--- a/src/lib/watch.js
+++ b/src/lib/watch.js
@@ -296,9 +296,7 @@ class Watcher {
       }
     };
 
-    return Q.nfcall(request, options).then((data) => {
-      let response = data[0];
-
+    return request(options).then((response) => {
       if (response.statusCode === 200) {
         return JSON.parse(response.body).data.reduce((acc, file) => {
           acc[file.path] = { hash: file.hash };


### PR DESCRIPTION
Fixes https://github.com/vtex/toolbelt/issues/90

@tamorim can you take this branch for a spin?

From https://github.com/FGRibreau/node-request-retry

> When the connection fails with one of ECONNRESET, ENOTFOUND, ESOCKETTIMEDOUT, ETIMEDOUT, ECONNREFUSED, EHOSTUNREACH, EPIPE, EAI_AGAIN or when an HTTP 5xx error occurrs, the request will automatically be re-attempted as these are often recoverable errors and will go away on retry.

```
  // The below parameters are specific to request-retry
  maxAttempts: 5,   // (default) try 5 times
  retryDelay: 5000,  // (default) wait for 5s before trying again
```