### PR TITLE
Fix vtex workspace link

### DIFF
--- a/src/workspace.js
+++ b/src/workspace.js
@@ -1,3 +1,3 @@
 export function getWorkspaceURL (account, workspace) {
-  return `http://${account}.beta.myvtex.com/?workspace=${workspace}`
+  return `http://${account}.alpha.myvtex.com/?vtex_workspace=${workspace}`
 }

--- a/src/workspace.test.js
+++ b/src/workspace.test.js
@@ -4,7 +4,7 @@ import {getWorkspaceURL} from './workspace'
 test('makes a development workspace from the login email', t => {
   const account = 'dreamstore'
   const workspace = 'test'
-  const expected = `http://${account}.beta.myvtex.com/?workspace=${workspace}`
+  const expected = `http://${account}.alpha.myvtex.com/?vtex_workspace=${workspace}`
   const actual = getWorkspaceURL(account, workspace)
   t.is(actual, expected)
 })


### PR DESCRIPTION
#### What is the purpose of this pull request?
Update the link shown to the user during the watch command.

#### What problem is this solving?
The query string key changed to `vtex_workspace` to match the cookie name. Also, we're publishing the new render only in `alpha` right now.

#### How should this be manually tested?
`vtex watch`, see the new link is issued.

#### Screenshots or example usage
![image](https://cloud.githubusercontent.com/assets/1633518/17305108/452ff784-5829-11e6-9c78-64e52359062e.png)

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

