### PR TITLE
Adds basic account and workspace labels to bash prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,24 @@ On an app directory, run `vtex watch` and click on or copy the provided URL into
 
 The `vtex` command will now monitor your files for changes and sync them automatically.
 
+## Customizing your prompt
+
+If you are a _bash_ user and wish to have information regarding the account and the workspace 
+you are logged in visible at your command prompt it is achievable by running the following 
+command:
+
+```sh
+echo "source $(npm get prefix)/node_modules/vtex/scripts/prompt.bash" >> .bashrc
+```
+
+Or, similarly, if you are a _zsh_ user:
+
+```sh
+echo "source $(npm get prefix)/node_modules/vtex/scripts/prompt.bash" >> .zshrc
+```
+
+Disclaimer: _fish_ is not yet supported.
+
 ---
 
 # Frequently Asked Questions
@@ -116,6 +134,11 @@ If no `.vtexignore` is found, your [.gitignore](http://git-scm.com/docs/gitignor
 ## How do I publish my App to the VTEX App Store?
 
 To publish your VTEX app to VTEX App Store, use the `vtex publish` command. The app will be published under the vendor name.
+
+
+## I don't like the default toolbelt prompt customization. It's ugly or it messes with some of my other configurations, but I still want to be able to see the account and workspace I'm logged into. What do I do?
+
+You can do so by adding the `vtex_get_account` and `vtex_get_workspace` commands to your PS1 environment variable the way it pleases you.
 
 ---
 

--- a/scripts/prompt.bash
+++ b/scripts/prompt.bash
@@ -1,0 +1,75 @@
+
+
+###############################################################################
+#                                   GLOBALS                                   #
+###############################################################################
+
+export TOOLBELT_PROMPT_ACTIVE=true
+export TOOLBELT_PROMPT_COLOR=colorful
+TOOLBELT_CFG_FILE="$HOME/.config/configstore/vtex.json"
+
+
+###############################################################################
+#                                   HELPERS                                   #
+###############################################################################
+
+parse_vtex_json() {
+    cat "$TOOLBELT_CFG_FILE" | grep $1 | sed -n "s/^.*\"$1\": \"\(.*\)\".*$/\1/p"
+}
+
+get_vtex_account() {
+    parse_vtex_json "account"
+}
+
+get_vtex_workspace() {
+    parse_vtex_json "workspace"
+}
+
+
+###############################################################################
+#                                     CORE                                    #
+###############################################################################
+
+__vtex_ps1() {
+    local account=$(get_vtex_account)
+    local workspace=$(get_vtex_workspace)
+    
+    local white="\[\e[37m\]"
+    local blue="\[\e[34m\]"
+    local darkred="\[\e[1;31m\]"
+    local default="\[\e[39m\]"
+
+    if [ "$TOOLBELT_PROMPT_COLOR" == "light" ]; then
+        local parenthesis=$white
+        local vtex=$white
+        local dynamic=$white
+        local symbols=$white
+    elif [ "$TOOLBELT_PROMPT_COLOR" == "dark" ]; then
+        local parenthesis=$blue
+        local vtex=$blue
+        local dynamic=$blue
+        local symbols=$blue
+    else     
+        local parenthesis=$darkred
+        local vtex=$darkred
+        local dynamic=$white
+        local symbols=$darkred
+    fi
+
+    if [ -n "$account" ] || [ -n "$workspace" ]; then
+    	echo -e "${parenthesis}(${vtex}vtex${symbols}: ${dynamic}$account${symbols}@${dynamic}$workspace${parenthesis})${default} "
+    fi
+}
+
+toolbeltify_prompt() {
+    if [ -z "$PS1_BAK" ]; then
+    	PS1_BAK=$PS1
+	export PS1_BAK
+    fi
+    
+    local suffix=${PS1_BAK:(-2)}
+    PS1="${PS1_BAK::-2}$(__vtex_ps1)$suffix"
+    export PS1
+}
+
+PROMPT_COMMAND=toolbeltify_prompt


### PR DESCRIPTION
#### What is the purpose of this pull request?
Adds account and workspace labels to bash prompt

#### How should this be manually tested?
You must source the file `scripts/prompt.bash`

#### Screenshots or example usage
![image](https://cloud.githubusercontent.com/assets/1023238/18448796/d398cec0-7902-11e6-8a1a-2f19bda3f896.png)


