### PR TITLE
Support watching any JSON file at root level

### DIFF
--- a/src/file.js
+++ b/src/file.js
@@ -10,7 +10,7 @@ const unlink = promisify(fs.unlink)
 const bbGlob = promisify(glob)
 
 export function listLocalFiles (root) {
-  return bbGlob('{*/**,manifest.json}', {
+  return bbGlob('{*/**,*.json}', {
     cwd: root,
     nodir: true,
     ignore: ['node_modules/**'],
@@ -74,7 +74,7 @@ export function createChanges (root, batch) {
 }
 
 export function watch (root, sendChanges) {
-  const watcher = chokidar.watch(['*/**', 'manifest.json'], {
+  const watcher = chokidar.watch(['*/**', '*.json'], {
     cwd: root,
     persistent: true,
     ignoreInitial: true,


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add support to watching any JSON file at root level.

#### What problem is this solving?
Only `manifest.json` was watched at root level. The router needs, for instance, `routes.json`.

#### How should this be manually tested?
* Add `bla.json` to root
* Start watch
* Change file
* Verify that the change has been applied

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

