### PR TITLE
Adds new exception message destructuring

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -58,9 +58,10 @@ const onError = e => {
     }
     if (statusCode >= 400) {
       try {
-        const {code, exception} = e.error
-        const {message, stackTrace} = exception
+        const {code, message, exception} = e.error
+        const {source, stackTrace} = exception
         log.error('API:', message, {statusCode, code})
+	log.debug(source)
         log.debug(stackTrace)
         return
       } catch (e) {}


### PR DESCRIPTION
It was decided among some vtex backend devs (@rdumont and @alanprot), that the new exception payload should be outputted like the following:

https://vtex.slack.com/archives/vtex-io/p1474575913000164

This pull request was created in order for the toolbelt to destructure this new exception format accordingly.