### PR TITLE
Automatically add glob stars to folders in vtexignore

### DIFF
--- a/src/file.js
+++ b/src/file.js
@@ -89,7 +89,8 @@ function getIgnoredPaths (root) {
       .toString()
       .split('\n')
       .map(p => p.trim())
-      .filter(p => p !== '').concat(defaultIgnored)
+      .filter(p => p !== '')
+      .map(p => p.replace(/\/$/, '/**')).concat(defaultIgnored)
   } catch (e) {
     return defaultIgnored
   }

--- a/src/modules/apps.js
+++ b/src/modules/apps.js
@@ -198,6 +198,7 @@ export default {
       return createTempPath(id).then(t => { tempPath = t })
       .tap(() => log.debug('Listing local files...'))
       .then(() => listLocalFiles(root))
+      .tap(files => log.debug('Compressing files:', '\n' + files.join('\n')))
       .then(files => compressFiles(files, tempPath))
       .tap(() => log.debug('Publishing app...'))
       .then(({file}) => publishApp(file, true))
@@ -302,6 +303,7 @@ export default {
 
       return createTempPath(id).then(tempPath =>
         listLocalFiles(root)
+        .tap(files => log.debug('Compressing files:', '\n' + files.join('\n')))
         .then(files => compressFiles(files, tempPath))
         .then(({file}) => publishApp(file))
         .then(() => deleteTempFile(tempPath))


### PR DESCRIPTION
#### What is the purpose of this pull request?
Make our `.vtexignore` behave more similarly to `.gitignore`.

#### What problem is this solving?
Because the way `node-glob` works, if you list `src/` in your `.vtexignore` all files inside will still be matched. To ignore everything, you need to actually force `src/**`. This adds stars automatically.
This is not the optimal solution, as we should conform to the actual [spec](https://git-scm.com/docs/gitignore), or maybe use something like https://github.com/kaelzhang/node-ignore, but it improves the experience for now.

#### How should this be manually tested?
Ignore a folder using `/` at the end, watch things not get sent.

#### Screenshots or example usage
N/A

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

