### PR TITLE
Improve the workspace reset command

### DIFF
--- a/src/modules/workspace.js
+++ b/src/modules/workspace.js
@@ -161,13 +161,14 @@ export default {
       },
     },
     reset: {
-      requiredArgs: 'name',
+      optionalArgs: 'name',
       description: 'Delete and create a workspace',
       handler: function (name) {
         log.debug('Resetting workspace', name)
-        return this.workspace.delete.handler(name, {yes: true, force: true})
+        const workspace = typeof name !== 'string' ? getWorkspace() : name
+        return this.workspace.delete.handler(workspace, {yes: true, force: true})
         .delay(3000)
-        .then(() => this.workspace.create.handler(name))
+        .then(() => this.workspace.create.handler(workspace))
       },
     },
   },

--- a/src/modules/workspace.js
+++ b/src/modules/workspace.js
@@ -169,6 +169,12 @@ export default {
         return this.workspace.delete.handler(workspace, {yes: true, force: true})
         .delay(3000)
         .then(() => this.workspace.create.handler(workspace))
+        .catch(err => {
+          if (err.error && err.error.code === 'WorkspaceAlreadyExists') {
+            return setTimeout(() => this.workspace.create.handler(workspace), 3000)
+          }
+          return Promise.reject(err)
+        })
       },
     },
   },


### PR DESCRIPTION
#### What is the purpose of this pull request?
Make `vtex workspace reset` argument optional and add a retry for slow workspace deletion.

#### What problem is this solving?
Usage of the reset command.

#### How should this be manually tested?
Using `vtex workspace reset` with and without an argument and ensuring everything works.

#### Screenshots or example usage
n/a

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
