### PR TITLE
Filter empty files on watch

### DIFF
--- a/src/file.js
+++ b/src/file.js
@@ -19,8 +19,9 @@ export function listLocalFiles (root) {
   })
   .then(files =>
     Promise.all(
-      files.map(file => bbStat(path.join(root, file))
-      .then(stats => ({file, stats})))
+      files.map(file =>
+        bbStat(path.join(root, file)).then(stats => ({file, stats}))
+      )
     )
   )
   .then(filesStats =>

--- a/src/file.js
+++ b/src/file.js
@@ -26,7 +26,10 @@ export function listLocalFiles (root) {
   )
   .then(filesStats =>
     filesStats.reduce((acc, {file, stats}) => {
-      return stats.size > 0 ? [...acc, file] : acc
+      if (stats.size > 0) {
+        acc.push(file)
+      }
+      return acc
     }, [])
   )
 }

--- a/src/file.js
+++ b/src/file.js
@@ -87,9 +87,13 @@ export function watch (root, sendChanges) {
   })
   return new Promise((resolve, reject) => {
     watcher
-    .on('add', f => sendSaveChanges(root, f, sendChanges))
-    .on('change', f => sendSaveChanges(root, f, sendChanges))
-    .on('unlink', f => sendRemoveChanges(root, f, sendChanges))
+    .on('add', (file, {size}) => size > 0 ? sendSaveChanges(root, file, sendChanges) : null)
+    .on('change', (file, {size}) => {
+      return size > 0
+        ? sendSaveChanges(root, file, sendChanges)
+        : sendRemoveChanges(root, file, sendChanges)
+    })
+    .on('unlink', file => sendRemoveChanges(root, file, sendChanges))
     .on('error', reject)
     .on('ready', resolve)
   })


### PR DESCRIPTION
#### What is the purpose of this pull request?
Prevent empty files from being sent to apps/vbase.

#### What problem is this solving?
Resource not found when trying to get an empty file on vbase.

#### How should this be manually tested?
Trying to send any empty files during the watch startup or via changes.

#### Screenshots or example usage
n/a

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
