### PR TITLE
Allow batch install and uninstall (and uninstall without args)

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "eslint-plugin-react": "^5.0.1",
     "eventsource": "^0.2.1",
     "fast-async": "^6.0.34",
-    "findhelp": "^0.2.0",
+    "findhelp": "^0.3.0",
     "glob": "^7.0.5",
     "inquirer": "^1.0.3",
     "jsonpath": "^0.2.6",

--- a/src/modules/apps/install.js
+++ b/src/modules/apps/install.js
@@ -8,33 +8,44 @@ import {
   wildVersionPattern,
 } from '../../manifest'
 
+const ARGS_START_INDEX = 2
+
+function installApps (apps) {
+  const app = apps.shift() || `${manifest.vendor}.${manifest.name}@${manifest.version}`
+  log.debug('Starting to install app', app)
+  const appRegex = new RegExp(`^${vendorPattern}.${namePattern}@${wildVersionPattern}$`)
+  if (!appRegex.test(app)) {
+    log.error('Invalid app format, please use <vendor>.<name>@<version>')
+    return Promise.resolve()
+  }
+
+  return installApp(app)
+  .then(() => log.info(`Installed app ${app} successfully`))
+  .then(() =>
+    apps.length > 0
+      ? installApps(apps)
+      : Promise.resolve()
+  )
+  .catch(err => {
+    if (err.statusCode === 409) {
+      return log.error(`App ${app} already installed`)
+    }
+    return Promise.reject(err)
+  })
+}
+
 export default {
   optionalArgs: 'app',
   description: 'Install an app on the current directory or a specified one',
-  handler: (optionalApp) => {
+  handler: (optionalApp, options) => {
     const workspace = getWorkspace()
     if (workspace === 'master') {
       log.error(workspaceMasterMessage)
       return Promise.resolve()
     }
 
-    const app = typeof optionalApp === 'string'
-      ? optionalApp
-      : `${manifest.vendor}.${manifest.name}@${manifest.version}`
-    log.debug('Starting to install app', app)
-    const appRegex = new RegExp(`^${vendorPattern}.${namePattern}@${wildVersionPattern}$`)
-    if (!appRegex.test(app)) {
-      log.error('Invalid app format, please use <vendor>.<name>@<version>')
-      return Promise.resolve()
-    }
-
-    return installApp(app)
-    .then(() => log.info(`Installed app ${app} successfully`))
-    .catch(err => {
-      if (err.statusCode === 409) {
-        return log.error(`App ${app} already installed`)
-      }
-      return Promise.reject(err)
-    })
+    const apps = options._ ? [optionalApp, ...options._.slice(ARGS_START_INDEX)] : [optionalApp]
+    log.debug('Installing app(s)', apps)
+    return installApps(apps)
   },
 }

--- a/src/modules/apps/install.js
+++ b/src/modules/apps/install.js
@@ -10,7 +10,7 @@ import {
 
 const ARGS_START_INDEX = 2
 
-function installApps (apps) {
+function installApps (apps = []) {
   const app = apps.shift() || `${manifest.vendor}.${manifest.name}@${manifest.version}`
   log.debug('Starting to install app', app)
   const appRegex = new RegExp(`^${vendorPattern}.${namePattern}@${wildVersionPattern}$`)

--- a/src/modules/apps/install.js
+++ b/src/modules/apps/install.js
@@ -30,6 +30,7 @@ function installApps (apps = []) {
     if (err.statusCode === 409) {
       return log.error(`App ${app} already installed`)
     }
+    log.warn(`The following apps were not installed: ${[app, ...apps].join(', ')}`)
     return Promise.reject(err)
   })
 }

--- a/src/modules/apps/install.js
+++ b/src/modules/apps/install.js
@@ -44,7 +44,7 @@ export default {
       return Promise.resolve()
     }
 
-    const apps = options._ ? [optionalApp, ...options._.slice(ARGS_START_INDEX)] : [optionalApp]
+    const apps = [optionalApp, ...options._.slice(ARGS_START_INDEX)]
     log.debug('Installing app(s)', apps)
     return installApps(apps)
   },

--- a/src/modules/apps/list.js
+++ b/src/modules/apps/list.js
@@ -4,7 +4,6 @@ import {appsClient} from './utils'
 import {getAccount, getWorkspace} from '../../conf'
 
 export default {
-  optionalArgs: 'query',
   description: 'List your installed VTEX apps',
   handler: () => {
     log.debug('Starting to list apps')

--- a/src/modules/apps/settings/index.js
+++ b/src/modules/apps/settings/index.js
@@ -10,7 +10,7 @@ export default {
   handler: async (app, field) => {
     const response = await appsClient().getAppSettings(
       getAccount(), getWorkspace(), app)
-    if (typeof field === 'object') {
+    if (field === null) {
       console.log(response)
     } else {
       console.log(jp.value(response, '$.' + field))

--- a/src/modules/apps/uninstall.js
+++ b/src/modules/apps/uninstall.js
@@ -1,9 +1,10 @@
 import log from '../../logger'
 import inquirer from 'inquirer'
 import {getWorkspace, getAccount} from '../../conf'
-import {vendorPattern, namePattern} from '../../manifest'
 import {workspaceMasterMessage, appsClient} from './utils'
+import {manifest, vendorPattern, namePattern} from '../../manifest'
 
+const ARGS_START_INDEX = 2
 const promptAppUninstall = (app) => {
   return inquirer.prompt({
     type: 'confirm',
@@ -13,9 +14,41 @@ const promptAppUninstall = (app) => {
   .then(({confirm}) => confirm)
 }
 
+function uninstallApps (apps, preConfirm) {
+  const app = apps.shift() || `${manifest.vendor}.${manifest.name}`
+  log.debug('Starting to uninstall app', app)
+  const appRegex = new RegExp(`^${vendorPattern}.${namePattern}$`)
+  if (!appRegex.test(app)) {
+    log.error('Invalid app format, please use <vendor>.<name>')
+    return Promise.resolve()
+  }
+
+  return Promise.try(() => preConfirm || promptAppUninstall(app))
+  .then(confirm => confirm || Promise.reject('User cancelled'))
+  .then(() =>
+    appsClient().uninstallApp(
+      getAccount(),
+      getWorkspace(),
+      app
+    )
+  )
+  .then(() => log.info(`Uninstalled app ${app} successfully`))
+  .then(() =>
+    apps.length > 0
+      ? uninstallApps(apps, preConfirm)
+      : Promise.resolve()
+  )
+  .catch(err => {
+    if (err.statusCode === 409) {
+      return log.error(`App ${app} not installed`)
+    }
+    return Promise.reject(err)
+  })
+}
+
 export default {
-  requiredArgs: 'app',
-  description: 'Uninstall the specified app',
+  optionalArgs: 'app',
+  description: 'Uninstall an app on the current directory or a specified one',
   options: [
     {
       short: 'y',
@@ -24,36 +57,16 @@ export default {
       type: 'boolean',
     },
   ],
-  handler: (app, options) => {
+  handler: (optionalApp, options) => {
     const workspace = getWorkspace()
     if (workspace === 'master') {
       log.error(workspaceMasterMessage)
       return Promise.resolve()
     }
 
-    log.debug('Starting to uninstall app', app)
-    const appRegex = new RegExp(`^${vendorPattern}.${namePattern}$`)
-    if (!appRegex.test(app)) {
-      log.error('Invalid app format, please use <vendor>.<name>')
-      return Promise.resolve()
-    }
-
+    const apps = options._ ? [optionalApp, ...options._.slice(ARGS_START_INDEX)] : [optionalApp]
     const preConfirm = options.y || options.yes
-    return Promise.try(() => preConfirm || promptAppUninstall(app))
-    .then(confirm => confirm || Promise.reject('User cancelled'))
-    .then(() =>
-      appsClient().uninstallApp(
-        getAccount(),
-        getWorkspace(),
-        app
-      )
-    )
-    .then(() => log.info(`Uninstalled app ${app} successfully`))
-    .catch(err => {
-      if (err.statusCode === 409) {
-        return log.error(`App ${app} not installed`)
-      }
-      return Promise.reject(err)
-    })
+    log.debug('Uninstalling app(s)', apps)
+    return uninstallApps(apps, preConfirm)
   },
 }

--- a/src/modules/apps/uninstall.js
+++ b/src/modules/apps/uninstall.js
@@ -14,7 +14,7 @@ const promptAppUninstall = (app) => {
   .then(({confirm}) => confirm)
 }
 
-function uninstallApps (apps, preConfirm) {
+function uninstallApps (apps = [], preConfirm) {
   const app = apps.shift() || `${manifest.vendor}.${manifest.name}`
   log.debug('Starting to uninstall app', app)
   const appRegex = new RegExp(`^${vendorPattern}.${namePattern}$`)

--- a/src/modules/apps/uninstall.js
+++ b/src/modules/apps/uninstall.js
@@ -42,6 +42,7 @@ function uninstallApps (apps = [], preConfirm) {
     if (err.statusCode === 409) {
       return log.error(`App ${app} not installed`)
     }
+    log.warn(`The following apps were not uninstalled: ${[app, ...apps].join(', ')}`)
     return Promise.reject(err)
   })
 }

--- a/src/modules/apps/uninstall.js
+++ b/src/modules/apps/uninstall.js
@@ -64,7 +64,7 @@ export default {
       return Promise.resolve()
     }
 
-    const apps = options._ ? [optionalApp, ...options._.slice(ARGS_START_INDEX)] : [optionalApp]
+    const apps = [optionalApp, ...options._.slice(ARGS_START_INDEX)]
     const preConfirm = options.y || options.yes
     log.debug('Uninstalling app(s)', apps)
     return uninstallApps(apps, preConfirm)

--- a/src/modules/workspace/delete.js
+++ b/src/modules/workspace/delete.js
@@ -35,6 +35,10 @@ function deleteWorkspaces (names = [], preConfirm, force) {
       ? deleteWorkspaces(names, preConfirm, force)
       : Promise.resolve()
   )
+  .catch(err => {
+    log.warn(`The following workspaces were not deleted: ${[name, ...names].join(', ')}`)
+    return Promise.reject(err)
+  })
 }
 
 export default {

--- a/src/modules/workspace/delete.js
+++ b/src/modules/workspace/delete.js
@@ -55,7 +55,7 @@ export default {
     },
   ],
   handler: function (name, options) {
-    const names = options._ ? [name, ...options._.slice(ARGS_START_INDEX)] : [name]
+    const names = [name, ...options._.slice(ARGS_START_INDEX)]
     const preConfirm = options.y || options.yes
     const force = options.f || options.force
     log.debug('Deleting workspace(s)', names)

--- a/src/modules/workspace/delete.js
+++ b/src/modules/workspace/delete.js
@@ -16,7 +16,7 @@ function promptWorkspaceDeletion (name) {
   .then(({confirm}) => confirm)
 }
 
-function deleteWorkspaces (names, preConfirm, force) {
+function deleteWorkspaces (names = [], preConfirm, force) {
   const name = names.shift()
   log.debug('Starting to delete workspace', name)
   if (!force && name === getWorkspace()) {

--- a/src/modules/workspace/reset.js
+++ b/src/modules/workspace/reset.js
@@ -8,7 +8,7 @@ export default {
   description: 'Delete and create a workspace',
   handler: function (name) {
     log.debug('Resetting workspace', name)
-    const workspace = typeof name !== 'string' ? getWorkspace() : name
+    const workspace = name || getWorkspace()
     return deleteCmd.handler(workspace, {yes: true, force: true})
     .delay(3000)
     .then(() => createCmd.handler(workspace))


### PR DESCRIPTION
#### What is the purpose of this pull request?
To allow `install` and `uninstall` with multiple apps and make `uninstall` require an optional argument!
If you run `vtex uninstall` it will uninstall the app on the current folder.

#### What problem is this solving?
Not having to type a lot to install or uninstall stuff :smile:  

#### How should this be manually tested?
Try to install and uninstall more than one app.

#### Screenshots or example usage
`vtex install vtex.shelf@0.5.3 vtex.react-slick@0.15.3`
`vtex uninstall vtex.shelf vtex.react-slick`

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
