### PR TITLE
Add loaders for install and uninstall commands

### DIFF
--- a/src/courier.js
+++ b/src/courier.js
@@ -5,9 +5,9 @@ import {timeStop} from './time'
 import endpoint from './endpoint'
 import stripAnsi from 'strip-ansi'
 import {manifest} from './manifest'
+import {clearAbove} from './terminal'
 import EventSource from 'eventsource'
 import {consumeChangeLog} from './apps'
-import {clearLine, cursorTo} from 'readline'
 import {locatorByMajor} from './locator'
 import {__, any, contains, map} from 'ramda'
 import {setSpinnerText, stopSpinner, isSpinnerActive} from './spinner'
@@ -22,11 +22,6 @@ const levelFormat = {
 }
 
 let timeoutId
-
-const clearAbove = () => {
-  clearLine(process.stdout, 0)
-  cursorTo(process.stdout, 0)
-}
 
 const stopAndLog = (log) => {
   const timeEnd = timeStop()

--- a/src/courier.js
+++ b/src/courier.js
@@ -8,6 +8,8 @@ import {manifest} from './manifest'
 import EventSource from 'eventsource'
 import {consumeChangeLog} from './apps'
 import {clearLine, cursorTo} from 'readline'
+import {locatorByMajor} from './locator'
+import {__, any, contains, map} from 'ramda'
 import {setSpinnerText, stopSpinner, isSpinnerActive} from './spinner'
 
 const courierHost = endpoint('courier')
@@ -18,6 +20,8 @@ const levelFormat = {
   warning: log.warn,
   error: log.error,
 }
+
+let timeoutId
 
 const clearAbove = () => {
   clearLine(process.stdout, 0)
@@ -44,9 +48,9 @@ const stopAndLog = (log) => {
   console.log(timedLog)
 }
 
-const logToConsole = (level, origin, message) => {
+const logToConsole = (level, origin, message, timeout, action) => {
   const isLogLevelInfo = log.level === 'info'
-  const {message: text, timeout} = typeof message === 'string'
+  const {message: text, timeout: msgTimeout} = typeof message === 'string'
     ? {message} : message
   if (isLogLevelInfo && isSpinnerActive()) {
     if (level === 'error') {
@@ -54,7 +58,12 @@ const logToConsole = (level, origin, message) => {
       clearAbove()
       return console.log(`\n${text}\n`)
     }
-    setSpinnerText(text, timeout)
+
+    if (timeout) {
+      timeoutId = setTimeout(action, msgTimeout || timeout)
+    }
+
+    setSpinnerText(text, msgTimeout || timeout)
     return
   }
 
@@ -63,38 +72,60 @@ const logToConsole = (level, origin, message) => {
   levelFormat[level](`[${time}] ${text}`)
 }
 
-const originMatch = (origin) => {
-  const {vendor, name, version} = manifest
-  const local = `${vendor}.${name}@${version.substring(0, 0)}`
-  return local === origin.substring(0, origin.indexOf('@') + 1)
+const getOriginByManifest = () => {
+  const {name, vendor, version} = manifest
+  return `${vendor}.${name}@${version}`
 }
 
-const listen = (account, workspace, authToken) => {
-  let es = new EventSource(`${courierHost}/${account}/${workspace}/app-events?level=${log.level}`, {
+const originMatch = (msgOrigin, origin = []) => {
+  if (origin.length === 0) {
+    origin.push(getOriginByManifest())
+  }
+  return any(contains(__, locatorByMajor(msgOrigin)), map(locatorByMajor, origin))
+}
+
+const listen = (account, workspace, authToken, {timeout: {duration, action}, origin, callback}) => {
+  const es = new EventSource(`${courierHost}/${account}/${workspace}/app-events?level=${log.level}`, {
     'Authorization': `token ${authToken}`,
   })
-  es.onopen = () => log.debug(`courier: connected with level ${log.level}`)
-  es.addEventListener('system', async (msg) => {
-    let {message, origin} = JSON.parse(msg.data)
-    if (!originMatch(origin)) {
+
+  es.onopen = () => {
+    log.debug(`courier: connected with level ${log.level}`)
+    timeoutId = setTimeout(action, duration)
+  }
+
+  es.addEventListener('system', (msg) => {
+    clearTimeout(timeoutId)
+    const {message, origin: msgOrigin} = JSON.parse(msg.data)
+    if (!originMatch(msgOrigin, origin)) {
       return
     }
 
     if (message === 'workspace:changed') {
       stopAndLog(consumeChangeLog())
+      if (callback) {
+        callback()
+      }
     }
+
+    timeoutId = setTimeout(action, duration)
   })
+
   es.addEventListener('message', (msg) => {
-    let {level, origin, message} = JSON.parse(msg.data)
-    if (!originMatch(origin)) {
+    clearTimeout(timeoutId)
+    const {level, origin: msgOrigin, message} = JSON.parse(msg.data)
+    if (!originMatch(msgOrigin, origin)) {
       return
     }
 
     clearAbove()
-    logToConsole(level, origin, message)
+    logToConsole(level, origin, message, duration, action)
   })
+
   es.onerror = (err) => {
+    clearTimeout(timeoutId)
     log.error(`Connection to courier server has failed with status ${err.status}`)
+    timeoutId = setTimeout(action, duration)
   }
 }
 

--- a/src/locator.js
+++ b/src/locator.js
@@ -1,0 +1,5 @@
+export function locatorByMajor (locator) {
+  const versionIndex = locator.indexOf('@')
+  return versionIndex > -1
+    ? locator.substring(0, versionIndex + 2) : locator
+}

--- a/src/modules/workspace/reset.js
+++ b/src/modules/workspace/reset.js
@@ -9,7 +9,7 @@ export default {
   handler: function (name) {
     log.debug('Resetting workspace', name)
     const workspace = name || getWorkspace()
-    return deleteCmd.handler(workspace, {yes: true, force: true})
+    return deleteCmd.handler(workspace, {_: [], yes: true, force: true})
     .delay(3000)
     .then(() => createCmd.handler(workspace))
     .catch(err => {

--- a/src/spinner.js
+++ b/src/spinner.js
@@ -50,3 +50,12 @@ export function stopSpinner () {
 export function isSpinnerActive () {
   return counter > 0
 }
+
+export function stopSpinnerForced () {
+  if (counter === 0) {
+    return
+  }
+  counter = 0
+  clearSpinnerTimeout()
+  spinner.stop()
+}

--- a/src/terminal.js
+++ b/src/terminal.js
@@ -1,0 +1,6 @@
+import {clearLine, cursorTo} from 'readline'
+
+export function clearAbove () {
+  clearLine(process.stdout, 0)
+  cursorTo(process.stdout, 0)
+}


### PR DESCRIPTION
#### What is the purpose of this pull request?
When you install or uninstall an app the VTEX Apps response is just a part of what actually happens on the background.

If you install a render app, for example, after the VTEX Apps response the render service still have to pick up the installed app and build a bundle with it.

If you install and switch directly to the page, you won't see what you wanted because render is still working it's magic.

This PR aims to fix that by adding loaders and connecting with the courier service to receive the messages that other systems may pass when working with the install or uninstall of an app.

#### What problem is this solving?
install/uninstall commands being too simple on it's success.

#### How should this be manually tested?
Just try to install or uninstall any app on your workspace :smiley: 

#### Screenshots or example usage
n/a

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
