### PR TITLE
Support registry with unified workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "url": "https://github.com/vtex/toolbelt/issues"
   },
   "dependencies": {
-    "@vtex/api": "^0.11.5",
+    "@vtex/api": "^0.12.0",
     "any-promise": "^1.3.0",
     "babel-eslint": "^7.0.0",
     "bluebird": "^3.4.0",

--- a/src/locator.js
+++ b/src/locator.js
@@ -1,5 +1,9 @@
 export function locatorByMajor (locator) {
   const versionIndex = locator.indexOf('@')
-  return versionIndex > -1
-    ? locator.substring(0, versionIndex + 2) : locator
+  const majorIndex = versionIndex + 2
+  const hasVersion = /\d/.test(locator[majorIndex])
+  if (versionIndex > -1 && hasVersion) {
+    return locator.substring(0, majorIndex)
+  }
+  return locator
 }

--- a/src/manifest.js
+++ b/src/manifest.js
@@ -9,8 +9,6 @@ export const namePattern = '[\\w_-]+'
 
 export const versionPattern = '\\d+\\.\\d+\\.\\d+(-.*)?'
 
-export const wildVersionPattern = '\\d+\\.((\\d+\\.\\d+)|(\\d+\\.x)|x)(-.*)?'
-
 export const manifestPath = path.resolve(process.cwd(), 'manifest.json')
 
 const R_OK = fs.constants ? fs.constants.R_OK : fs.R_OK // Node v6 breaking change

--- a/src/manifest.test.js
+++ b/src/manifest.test.js
@@ -3,7 +3,6 @@ import {
   vendorPattern,
   namePattern,
   versionPattern,
-  wildVersionPattern,
   validateAppManifest,
 } from './manifest'
 
@@ -29,15 +28,6 @@ test('validates an app version', t => {
   t.false(versionRegex.test('0.1.0_beta'))
   t.true(versionRegex.test('0.1.0'))
   t.true(versionRegex.test('0.1.0-beta'))
-})
-
-test('validates an app version with a wildcard', t => {
-  const wildVersionRegex = new RegExp(`^${wildVersionPattern}$`)
-  t.false(wildVersionRegex.test('x.1.0'))
-  t.false(wildVersionRegex.test('0.1.x_beta'))
-  t.true(wildVersionRegex.test('0.x'))
-  t.true(wildVersionRegex.test('0.1.x'))
-  t.true(wildVersionRegex.test('0.1.x-beta'))
 })
 
 test('validates an app manifest', t => {

--- a/src/modules/apps/publish.js
+++ b/src/modules/apps/publish.js
@@ -1,22 +1,15 @@
 import log from '../../logger'
 import {Promise} from 'bluebird'
 import {manifest} from '../../manifest'
-import {getWorkspace} from '../../conf'
 import {listLocalFiles} from '../../file'
 import {startSpinner, setSpinnerText, stopSpinner} from '../../spinner'
-import {workspaceMasterMessage, id, publishApp, mapFileObject} from './utils'
+import {id, publishApp, mapFileObject} from './utils'
 
 const root = process.cwd()
 
 export default {
   description: 'Publish this app',
   handler: () => {
-    const workspace = getWorkspace()
-    if (workspace === 'master') {
-      log.error(workspaceMasterMessage)
-      return Promise.resolve()
-    }
-
     log.debug('Starting to publish app')
     setSpinnerText('Publishing app...')
     startSpinner()

--- a/src/modules/apps/publish.js
+++ b/src/modules/apps/publish.js
@@ -7,9 +7,21 @@ import {id, publishApp, mapFileObject} from './utils'
 
 const root = process.cwd()
 
+function automaticTag (version) {
+  return version.indexOf('-') > 0 ? undefined : 'latest'
+}
+
 export default {
   description: 'Publish this app',
-  handler: () => {
+  options: [
+    {
+      short: 't',
+      long: 'tag',
+      description: 'Apply a tag to the release',
+      type: 'string',
+    },
+  ],
+  handler: (options) => {
     log.debug('Starting to publish app')
     setSpinnerText('Publishing app...')
     startSpinner()
@@ -17,7 +29,7 @@ export default {
     return listLocalFiles(root)
     .tap(files => log.debug('Sending files:', '\n' + files.join('\n')))
     .then(mapFileObject)
-    .then(publishApp)
+    .then(files => publishApp(files, options.tag || automaticTag(manifest.version)))
     .finally(() => stopSpinner())
     .then(() => log.info(`Published app ${id} successfully`))
     .catch(err =>

--- a/src/modules/apps/utils.js
+++ b/src/modules/apps/utils.js
@@ -24,12 +24,11 @@ export const installApp = (id) => {
   )
 }
 
-export const publishApp = (files, isDevelopment = false) => {
+export const publishApp = (files, tag = undefined) => {
   return registryClient().publishApp(
     getAccount(),
-    getWorkspace(),
     files,
-    isDevelopment
+    tag
   )
 }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
To adapt the toolbelt to a breaking change in the apps server related to publishing and installing apps.

#### What problem is this solving?
The apps server has unified the registry so that it is no longer separated by workspace. This required a change to the way watched apps are updated. Now, instead of saying `isDevelopment`, a special tag is passed, in the format `dev.<workspace-name>`. Oh yes, versiontags are now supported, in the lines of NPM's `dist-tag`s :)

#### How should this be manually tested?

1. Prepare to use the beta environment
    * point the apps endpoint to beta
    * link the `@vtex/api` package to use `feature/install-prototype` branch, which has a PR open (vtex/node-vtex-api#13)
2. Run `vtex watch` and see if everything works as expected
3. Publish an app with `vtex publish --tag foo`
4. Install the app with `vtex install my.app@foo`, and verify that it installed the new version you just published

#### Screenshots or example usage

##### Publishing
* Given the manifest for `vtex.foo@1.0.0`, publishing with `vtex publish` automatically tags the release with `latest`
* Given the manifest for `vtex.foo@1.0.0-somelabel`, publishing with `vtex publish` will not apply any tag because of the pre-release label
* Given any manifest, publishing with `vtex publish --tag foo` will apply the tag `foo`

##### Installing
* `vtex install my.app` is the same as `vtex install my.app@latest`
* `vtex install my.app@some-tag` installs the version tagged as `some-tag`

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

**Important**: although this feature is a non-breaking change in terms of the toolbelt, it **does break** compatibility with the apps server.

**Important (2)**: before merging this PR, I still have to update the `@vtex/api` dependency to the not yet released `0.12.0` version.
