### PR TITLE
Add switch command for switching between accounts

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -10,6 +10,7 @@ import {Promise} from 'bluebird'
 import 'any-promise/register/bluebird'
 import loginCmd from './modules/auth/login'
 import logoutCmd from './modules/auth/logout'
+import switchCmd from './modules/auth/switch'
 import {find, run as unboundRun, MissingRequiredArgsError} from 'findhelp'
 
 global.Promise = Promise
@@ -37,7 +38,7 @@ const checkCommandExists = found => {
 }
 
 const checkLogin = found => {
-  const whitelist = [tree, loginCmd, logoutCmd]
+  const whitelist = [tree, loginCmd, logoutCmd, switchCmd]
   if (!getToken() && whitelist.indexOf(found.command) === -1) {
     log.debug('Requesting login before command:', process.argv.slice(2).join(' '))
     return run({command: loginCmd})

--- a/src/modules/auth/index.js
+++ b/src/modules/auth/index.js
@@ -7,4 +7,7 @@ export default {
   logout: {
     module: dirnameJoin('modules/auth/logout'),
   },
+  switch: {
+    module: dirnameJoin('modules/auth/switch'),
+  },
 }

--- a/src/modules/auth/switch.js
+++ b/src/modules/auth/switch.js
@@ -1,0 +1,42 @@
+import chalk from 'chalk'
+import log from '../../logger'
+import loginCmd from './login'
+import inquirer from 'inquirer'
+import {Promise} from 'bluebird'
+import {getAccount, saveAccount} from '../../conf'
+
+function promptLogin () {
+  return Promise.try(() =>
+    inquirer.prompt({
+      type: 'confirm',
+      name: 'confirm',
+      message: 'Log in?',
+    })
+  )
+  .then(({confirm}) => confirm)
+}
+
+export default {
+  requiredArgs: 'account',
+  description: 'Switch to another VTEX account',
+  handler: (account) => {
+    const isValidAccount = /^\s*[\w-]+\s*$/.test(account)
+    if (!isValidAccount) {
+      return Promise.resolve(log.error('Invalid account format'))
+    }
+
+    const previousAccount = getAccount()
+    if (!previousAccount) {
+      log.error('You\'re not logged in right now')
+      return promptLogin()
+      .then(confirm => confirm ? loginCmd.handler() : log.error('User cancelled'))
+    } else if (previousAccount === account) {
+      return Promise.resolve(log.warn(`You're already using the account ${chalk.blue(account)}`))
+    }
+
+    return Promise.resolve(saveAccount(account))
+    .tap(() =>
+      log.info(`Switched from ${chalk.blue(previousAccount)} to ${chalk.blue(account)}`)
+    )
+  },
+}


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add a `switch` command to change between accounts.

#### What problem is this solving?
Boring process of logging again every time a user wants to change the current account. 

#### How should this be manually tested?
Use `vtex switch <account>`

#### Screenshots or example usage
n/a

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.