### PR TITLE
Fix update-notifier lag

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "pad": "^1.0.0",
     "ramda": "^0.22.0",
     "strip-ansi": "^3.0.1",
-    "update-notifier": "^0.7.0",
+    "update-notifier": "^1.0.3",
     "validator": "^6.0.0",
     "winston": "^2.2.0"
   },

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "ora": "^0.2.3",
     "pad": "^1.0.0",
     "ramda": "^0.22.0",
+    "semver-diff": "^2.1.0",
     "strip-ansi": "^3.0.1",
     "update-notifier": "^1.0.3",
     "validator": "^6.0.0",

--- a/src/update.js
+++ b/src/update.js
@@ -1,7 +1,20 @@
-import updateNotifier from 'update-notifier'
 import pkg from '../package.json'
+import semverDiff from 'semver-diff'
+import updateNotifier from 'update-notifier'
+
+function updateCallback (err, update) {
+  if (err) {
+    throw Error(err)
+  }
+
+  if (!semverDiff(update.current, update.latest)) {
+    return
+  }
+
+  this.update = update
+  this.notify()
+}
 
 export default function notify () {
-  updateNotifier({pkg, updateCheckInterval: 0})
-  .notify({defer: false})
+  updateNotifier({pkg, callback: updateCallback})
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -59,7 +59,7 @@ amdefine@>=0.0.4:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
 
-ansi-align@^1.0.0:
+ansi-align@^1.0.0, ansi-align@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/ansi-align/-/ansi-align-1.1.0.tgz#2f0c1658829739add5ebb15e6b0c6e3423f016ba"
   dependencies:
@@ -970,6 +970,20 @@ boxen@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/boxen/-/boxen-0.5.1.tgz#5b73d8840eb7f3c8a155cbf69ed3ed68d4720014"
   dependencies:
+    camelcase "^2.1.0"
+    chalk "^1.1.1"
+    cli-boxes "^1.0.0"
+    filled-array "^1.0.0"
+    object-assign "^4.0.1"
+    repeating "^2.0.0"
+    string-width "^1.0.1"
+    widest-line "^1.0.0"
+
+boxen@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/boxen/-/boxen-0.6.0.tgz#8364d4248ac34ff0ef1b2f2bf49a6c60ce0d81b6"
+  dependencies:
+    ansi-align "^1.1.0"
     camelcase "^2.1.0"
     chalk "^1.1.1"
     cli-boxes "^1.0.0"
@@ -2588,6 +2602,10 @@ lazy-cache@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/lazy-cache/-/lazy-cache-1.0.4.tgz#a1d78fc3a50474cb80845d3b3b6e1da49a446e8e"
 
+lazy-req@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/lazy-req/-/lazy-req-1.1.0.tgz#bdaebead30f8d824039ce0ce149d4daa07ba1fac"
+
 lcid@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/lcid/-/lcid-1.0.0.tgz#308accafa0bc483a3867b4b6f2b9506251d1b835"
@@ -4085,6 +4103,19 @@ update-notifier@^0.7.0:
     configstore "^2.0.0"
     is-npm "^1.0.0"
     latest-version "^2.0.0"
+    semver-diff "^2.0.0"
+    xdg-basedir "^2.0.0"
+
+update-notifier@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/update-notifier/-/update-notifier-1.0.3.tgz#8f92c515482bd6831b7c93013e70f87552c7cf5a"
+  dependencies:
+    boxen "^0.6.0"
+    chalk "^1.0.0"
+    configstore "^2.0.0"
+    is-npm "^1.0.0"
+    latest-version "^2.0.0"
+    lazy-req "^1.1.0"
     semver-diff "^2.0.0"
     xdg-basedir "^2.0.0"
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix the behavior of the `update-notifier` package.
Now the messages won't lag behind and they're displayed when you exit the CLI.

#### What problem is this solving?
Fix the behavior of the `update-notifier` package that kind of  "lagged" the version checks.

#### How should this be manually tested?
Link this branch and play with the `package.json` version and run any `vtex` command.

#### Screenshots or example usage
n/a

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
