### PR TITLE
Add `vtex add` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "glob": "^7.0.5",
     "inquirer": "^1.0.3",
     "jsonpath": "^0.2.6",
+    "latest-version": "^2.0.0",
     "minimist": "^1.2.0",
     "moment": "^2.13.0",
     "ora": "^0.2.3",

--- a/src/manifest.js
+++ b/src/manifest.js
@@ -15,7 +15,7 @@ export const manifestPath = path.resolve(process.cwd(), 'manifest.json')
 
 const R_OK = fs.constants ? fs.constants.R_OK : fs.R_OK // Node v6 breaking change
 
-const isManifestReadable = () => {
+export const isManifestReadable = () => {
   try {
     fs.accessSync(manifestPath, R_OK) // Throws if check fails
     return true

--- a/src/modules/apps/add.js
+++ b/src/modules/apps/add.js
@@ -1,0 +1,132 @@
+import chalk from 'chalk'
+import log from '../../logger'
+import semverDiff from 'semver-diff'
+import {readFile, writeFile} from 'fs'
+import {registryClient} from './utils'
+import latestVersion from 'latest-version'
+import {Promise, promisify} from 'bluebird'
+import {getAccount, getWorkspace} from '../../conf'
+import {head, tail, last, reduce, prop, split, compose, concat, __} from 'ramda'
+import {
+  namePattern,
+  manifestPath,
+  vendorPattern,
+  isManifestReadable,
+  wildVersionPattern,
+  validateAppManifest,
+} from '../../manifest'
+
+const ARGS_START_INDEX = 2
+const bbReadFile = promisify(readFile)
+const bbWriteFile = promisify(writeFile)
+const npmName = compose(last, split(':'))
+const wildVersionByMajor = compose(concat(__, '.x'), head, split('.'))
+const invalidAppMessage = 'Invalid app format, please use <vendor>.<name>, <vendor>.<name>@<version>, npm:<name> or npm:<name>@<version>'
+
+class InterruptionException extends Error {}
+
+function readManifest () {
+  const isReadable = isManifestReadable()
+  if (!isReadable) {
+    return Promise.reject(new InterruptionException('Couldn\'t read manifest file'))
+  }
+  return bbReadFile(manifestPath)
+  .then(JSON.parse)
+  .then(validateAppManifest)
+}
+
+function pickLatestVersion (versions) {
+  const start = prop('version', head(versions))
+  return reduce((acc, {version}) => {
+    return semverDiff(acc, version) ? version : acc
+  }, start, tail(versions))
+}
+
+function appsLatestVersion (app) {
+  const [vendor, name] = app.split('.')
+  return registryClient()
+  .listVersionsByApp(getAccount(), getWorkspace(), vendor, name)
+  .then(pickLatestVersion)
+  .then(wildVersionByMajor)
+  .catch(err => {
+    if (err.response && err.response.status === 404) {
+      return Promise.reject(new InterruptionException(`App ${chalk.green(app)} not found`))
+    }
+    return Promise.reject(err)
+  })
+}
+
+function npmLatestVersion (app) {
+  return latestVersion(app)
+  .then(concat('^'))
+  .catch(err => Promise.reject(new InterruptionException(err.message)))
+}
+
+function updateManifestDependencies (app, version) {
+  return readManifest()
+  .then(manifest => {
+    return {
+      ...manifest,
+      dependencies: {
+        ...manifest.dependencies,
+        [app]: version,
+      },
+    }
+  })
+  .then(newManifest => JSON.stringify(newManifest, null, 2) + '\n')
+  .then(manifestJson => bbWriteFile(manifestPath, manifestJson))
+}
+
+function addApp (app) {
+  const hasVersion = app.indexOf('@') > -1
+  if (hasVersion) {
+    const [appId, version] = app.split('@')
+    return updateManifestDependencies(appId, version)
+  }
+
+  const isNpm = app.startsWith('npm:')
+  const appName = isNpm ? npmName(app) : app
+  const versionRequest = isNpm
+    ? npmLatestVersion(appName)
+    : appsLatestVersion(appName)
+  return versionRequest
+  .then(version => updateManifestDependencies(app, version))
+}
+
+function addApps (apps) {
+  const app = head(apps)
+  const decApps = tail(apps)
+  log.debug('Starting to add app', app)
+  const appRegex = new RegExp(`^(${vendorPattern}\\.|npm:)${namePattern}(@${wildVersionPattern})?$`)
+  const appPromise = appRegex.test(app)
+    ? addApp(app)
+    : Promise.reject(new InterruptionException(invalidAppMessage))
+
+  return appPromise
+  .then(() => decApps.length > 0 ? addApps(decApps) : Promise.resolve())
+  .catch(err => {
+    if (apps.length > 0 && !err.toolbeltWarning) {
+      log.warn(`The following app(s) were not added: ${apps.join(', ')}`)
+      err.toolbeltWarning = true
+    }
+    return Promise.reject(err)
+  })
+}
+
+export default {
+  requiredArgs: 'app',
+  description: 'Add an app to the manifest dependencies',
+  handler: (app, options) => {
+    const apps = [app, ...options._.slice(ARGS_START_INDEX)]
+    log.debug('Adding app(s)', apps)
+    return addApps(apps)
+    .then(() => log.info('App(s) added succesfully!'))
+    .catch(err => {
+      if (err instanceof InterruptionException) {
+        log.error(err.message)
+        return Promise.resolve()
+      }
+      return Promise.reject(err)
+    })
+  },
+}

--- a/src/modules/apps/index.js
+++ b/src/modules/apps/index.js
@@ -1,6 +1,9 @@
 import {dirnameJoin} from '../../file'
 
 export default {
+  add: {
+    module: dirnameJoin('modules/apps/add'),
+  },
   watch: {
     module: dirnameJoin('modules/apps/watch'),
   },


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add the `vtex add` command.
It adds the desired VTEX app or npm package as a dependency to your `manifest.json` file.
If you use without providing a version, then the latest version for that app/package will be fetched and added with a fixed major version (so you get minors and patches automatically, a la npm default). 

#### What problem is this solving?
Boring and cumbersome addition of dependencies on your app.

#### How should this be manually tested?
Use `vtex add` with any app or npm package inside a app directory containing a `manifest.json` file.
Hint: It supports multiple arguments!

#### Screenshots or example usage
n/a

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
