### PR TITLE
Fix logging of error with no message

### DIFF
--- a/src/courier.js
+++ b/src/courier.js
@@ -136,10 +136,10 @@ const consumeAppLogs = (account, workspace, level, id) => {
   }
 
   es.addEventListener('message', (msg) => {
-    const {body: {message}, level, subject, sender} = JSON.parse(msg.data)
+    const {body: {message, code}, level, subject, sender} = JSON.parse(msg.data)
     if (subject.startsWith(`${manifest.vendor}.${manifest.name}`) || subject.startsWith('-')) {
       const suffix = id === sender ? '' : ' ' + chalk.gray(sender)
-      log.log(levelAdapter[level] || level, `${message.replace(/\n\s*$/, '')}${suffix}`)
+      log.log(levelAdapter[level] || level, `${(message || code || '').replace(/\n\s*$/, '')}${suffix}`)
     }
   })
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix a bug that happens when an error with no message is logged.

#### What problem is this solving?
Today my app received an error with no message, and so toolbelt failed when trying to log it, saying: `TypeError: Cannot read property 'replace' of undefined`.

It's bad to have errors without messages, but I've added a check so that toolbelt at least won't fail when that happens, and we can ask for more error details in these cases as we detect them.

#### How should this be manually tested?
Send an error with no message and check that toolbelt doesn't fail.

#### Screenshots or example usage
n/a

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
