### PR TITLE
Appends sender to logged messages

### DIFF
--- a/src/courier.js
+++ b/src/courier.js
@@ -11,6 +11,7 @@ import {consumeChangeLog} from './apps'
 import {locatorByMajor} from './locator'
 import {__, any, contains, map} from 'ramda'
 import {setSpinnerText, stopSpinner, isSpinnerActive} from './spinner'
+import {} from './conf'
 
 const courierHost = endpoint('courier')
 const colossusHost = endpoint('colossus')
@@ -128,16 +129,17 @@ const listen = (account, workspace, authToken, {timeout: {duration, action}, ori
   }
 }
 
-const consumeAppLogs = (account, workspace, level) => {
+const consumeAppLogs = (account, workspace, level, id) => {
   const es = new EventSource(`${colossusHost}/${account}/${workspace}/logs?level=${level}`)
   es.onopen = () => {
     log.debug(`Connected to logs with level ${level}`)
   }
 
   es.addEventListener('message', (msg) => {
-    const {body: {message}, level, subject} = JSON.parse(msg.data)
+    const {body: {message}, level, subject, sender} = JSON.parse(msg.data)
     if (subject.startsWith(`${manifest.vendor}.${manifest.name}`) || subject.startsWith('-')) {
-      log.log(levelAdapter[level] || level, `${message.replace(/\n\s*$/, '')}`)
+      const suffix = id === sender ? '' : ' ' + chalk.gray(sender)
+      log.log(levelAdapter[level] || level, `${message.replace(/\n\s*$/, '')}${suffix}`)
     }
   })
 

--- a/src/modules/apps/link.js
+++ b/src/modules/apps/link.js
@@ -71,7 +71,7 @@ export default {
 
     const account = getAccount()
     log.info('Linking app', `${id(manifest)}`)
-    courier.log(account, workspace, log.level)
+    courier.log(account, workspace, log.level, `${manifest.vendor}.${manifest.name}@${manifest.version}`)
     const majorLocator = toMajorLocator(manifest.vendor, manifest.name, manifest.version)
     const paths = await listLocalFiles(root)
     log.debug('Sending files:')


### PR DESCRIPTION
#### What is the purpose of this pull request?
To add the sender to logged messages. If the sender is the linked app itself, the sender is omitted.

#### What problem is this solving?
Sometimes, especially when using GraphQL calls, it is really hard to tell where logged messages are coming from. This makes it more explicit.

#### How should this be manually tested?
Run `vtex link`. You should see the sender for each message.

#### Screenshots or example usage
![image](https://cloud.githubusercontent.com/assets/430448/23519575/2e6b7558-ff56-11e6-957e-f09857b97454.png)

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
