### PR TITLE
Implemented feature to install apps from other registries, and to pub…

### DIFF
--- a/src/clients.ts
+++ b/src/clients.ts
@@ -21,6 +21,11 @@ const interceptor = (client) => new Proxy({}, {
   },
 })
 
+export const accountRegistry = (acc: string): Registry => {
+  if (!acc) acc = getAccount();
+  return Registry({...options, account: acc, endpoint: endpoint('registry')})
+}
+
 const [apps, router, registry, workspaces] = getToken()
   ? [
     Apps({...options, endpoint: endpoint('apps')}),

--- a/src/clients.ts
+++ b/src/clients.ts
@@ -21,28 +21,25 @@ const interceptor = (client) => new Proxy({}, {
   },
 })
 
-export const accountRegistry = (acc: string): Registry => {
-  if (!acc) acc = getAccount();
-  return Registry({...options, account: acc, endpoint: endpoint('registry')})
+const accountRegistry = (account: string = 'smartcheckout'): Registry => {
+  return Registry({...options, account, endpoint: endpoint('registry')})
 }
 
-const [apps, router, registry, workspaces] = getToken()
+const [apps, router, workspaces] = getToken()
   ? [
     Apps({...options, endpoint: endpoint('apps')}),
     Router({...options, endpoint: endpoint('router')}),
-    Registry({...options, endpoint: endpoint('registry')}),
     Workspaces({...options, endpoint: endpoint('workspaces')}),
   ]
   : [
     interceptor('apps'),
     interceptor('router') ,
-    interceptor('registry'),
     interceptor('workspaces'),
   ]
 
 export {
   apps,
   router,
-  registry,
+  accountRegistry,
   workspaces
 }

--- a/src/modules/apps/add.ts
+++ b/src/modules/apps/add.ts
@@ -6,7 +6,7 @@ import * as latestVersion from 'latest-version'
 import {head, tail, last, reduce, prop, split, compose, concat, __} from 'ramda'
 
 import log from '../../logger'
-import {registry} from '../../clients'
+import {accountRegistry} from '../../clients'
 import {
   namePattern,
   manifestPath,
@@ -46,7 +46,7 @@ const pickLatestVersion = (versions: VersionByApp[]): string => {
 }
 
 const appsLatestVersion = (app: string): Bluebird<string | never> => {
-  return registry.listVersionsByApp(app)
+  return accountRegistry().listVersionsByApp(app)
     .then(prop('data'))
     .then(pickLatestVersion)
     .then(wildVersionByMajor)

--- a/src/modules/apps/install.ts
+++ b/src/modules/apps/install.ts
@@ -72,6 +72,6 @@ export default {
     const app = optionalApp || `${manifest.vendor}.${manifest.name}@${manifest.version}`
     const apps = [app, ...options._.slice(ARGS_START_INDEX)].map(arg => arg.toString())
     log.debug('Installing app(s)', apps)
-    return installApps(apps, options.r || options.registry)
+    return installApps(apps, options.r || options.registry || 'smartcheckout')
   },
 }

--- a/src/modules/apps/publish.ts
+++ b/src/modules/apps/publish.ts
@@ -6,7 +6,6 @@ import {readFileSync} from 'fs-promise'
 
 import log from '../../logger'
 import {accountRegistry} from '../../clients'
-import {Registry} from '@vtex/api'
 import {id, mapFileObject} from './utils'
 import {listLocalFiles} from '../../file'
 
@@ -16,30 +15,36 @@ const root = process.cwd()
 const automaticTag = (version: string): string =>
   version.indexOf('-') > 0 ? null : 'latest'
 
-const publishApp = (path: string, tag: string, reg: Registry, manifest: Manifest): Bluebird<LoggerInstance | never> => {
-  const spinner = ora('Publishing app...').start()
-  return listLocalFiles(path)
-    .tap(files => log.debug('Sending files:', '\n' + files.join('\n')))
-    .then(files => mapFileObject(files, path))
-    .then(files => reg.publishApp(files, tag))
-    .finally(() => spinner.stop())
-    .then(() => log.info(`Published app ${id(manifest)} successfully`))
-    .catch(e => {
-      if (e.response && /already published/.test(e.response.data.message)) {
-        log.error(e.response.data.message.split('The').join(' -'))
-        return Promise.resolve()
-      }
-      throw e
-    })
-}
+const publisher = (account: string) => {
+  const reg = accountRegistry(account)
 
-const publishApps = (paths: string[], tag: string, reg: Registry, accessor = 0): Bluebird<void | never> => {
-  const path = resolve(paths[accessor])
-  const manifest = JSON.parse(readFileSync(resolve(path, 'manifest.json'), 'utf8'))
-  const next = () => accessor < paths.length - 1
-    ? publishApps(paths, tag, reg, accessor + 1)
-    : Promise.resolve()
-  return publishApp(path, tag || automaticTag(manifest.version), reg, manifest).then(next)
+  const publishApp = (path: string, tag: string, manifest: Manifest): Bluebird<LoggerInstance | never> => {
+    const spinner = ora('Publishing app...').start()
+    return listLocalFiles(path)
+      .tap(files => log.debug('Sending files:', '\n' + files.join('\n')))
+      .then(files => mapFileObject(files, path))
+      .then(files => reg.publishApp(files, tag))
+      .finally(() => spinner.stop())
+      .then(() => log.info(`Published app ${id(manifest)} successfully at ${account}`))
+      .catch(e => {
+        if (e.response && /already published/.test(e.response.data.message)) {
+          log.error(e.response.data.message.split('The').join(' -'))
+          return Promise.resolve()
+        }
+        throw e
+      })
+  }
+
+  const publishApps = (paths: string[], tag: string, accessor = 0): Bluebird<void | never> => {
+    const path = resolve(paths[accessor])
+    const manifest = JSON.parse(readFileSync(resolve(path, 'manifest.json'), 'utf8'))
+    const next = () => accessor < paths.length - 1
+      ? publishApps(paths, tag, accessor + 1)
+      : Promise.resolve()
+    return publishApp(path, tag || automaticTag(manifest.version), manifest).then(next)
+  }
+
+  return {publishApp, publishApps}
 }
 
 export default {
@@ -62,7 +67,7 @@ export default {
   handler: (path: string, options) => {
     log.debug('Starting to publish app')
     const paths = [path || root, ...options._.slice(ARGS_START_INDEX)].map(arg => arg.toString())
-    const reg = accountRegistry(options.r || options.registry)
-    return publishApps(paths, options.tag, reg)
+    const {publishApps} = publisher(options.r || options.registry)
+    return publishApps(paths, options.tag)
   },
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
To allow users to install apps  from other registries and to publish apps to other registries.

#### What problem is this solving?
Users can install apps from different registries and publish to different registries.

#### How should this be manually tested?
commandline

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
