### PR TITLE
Create command to prepare workspace for production

### DIFF
--- a/src/clients.ts
+++ b/src/clients.ts
@@ -1,4 +1,4 @@
-import {Registry, Apps, Workspaces, Router} from '@vtex/api'
+import {Registry, Apps, Workspaces, Router, Colossus} from '@vtex/api'
 
 import endpoint from './endpoint'
 import envTimeout from './timeout'
@@ -25,21 +25,24 @@ const accountRegistry = (account: string = 'smartcheckout'): Registry => {
   return Registry({...options, account, endpoint: endpoint('registry')})
 }
 
-const [apps, router, workspaces] = getToken()
+const [apps, router, workspaces, colossus] = getToken()
   ? [
     Apps({...options, endpoint: endpoint('apps')}),
     Router({...options, endpoint: endpoint('router')}),
     Workspaces({...options, endpoint: endpoint('workspaces')}),
+    Colossus({...options}),
   ]
   : [
     interceptor('apps'),
     interceptor('router') ,
     interceptor('workspaces'),
+    interceptor('colossus'),
   ]
 
 export {
   apps,
   router,
   accountRegistry,
-  workspaces
+  workspaces,
+  colossus
 }

--- a/src/courier.ts
+++ b/src/courier.ts
@@ -3,13 +3,12 @@ import * as EventSource from 'eventsource'
 
 import log from './logger'
 import endpoint from './endpoint'
-import {manifest} from './manifest'
 
 let prevMsg = ''
 const levelAdapter = {warning: 'warn'}
 const colossusHost = endpoint('colossus')
 
-export const listen = (account: string, workspace: string, level: string, id: string): void => {
+export const listen = (account: string, workspace: string, level: string, id: string): SSEHandler => {
   const es = new EventSource(`${colossusHost}/${account}/${workspace}/logs?level=${level}`)
   es.onopen = () =>
     log.debug(`Connected to logs with level ${level}`)
@@ -21,9 +20,9 @@ export const listen = (account: string, workspace: string, level: string, id: st
       level: msgLevel,
       body: {message, code},
     }: Message = JSON.parse(msg.data)
-    if (subject.startsWith(`${manifest.vendor}.${manifest.name}`) || subject.startsWith('-')) {
+    if (subject.startsWith(id) || subject.startsWith('-')) {
       const logLevel = levelAdapter[msgLevel] || msgLevel
-      const suffix = id === sender ? '' : ' ' + chalk.gray(sender)
+      const suffix = sender.startsWith(id) ? '' : ' ' + chalk.gray(sender)
       const formattedMsg = (message || code || '').replace(/\n\s*$/, '')
       if (prevMsg === formattedMsg) {
         return
@@ -35,4 +34,28 @@ export const listen = (account: string, workspace: string, level: string, id: st
 
   es.onerror = (err) =>
     log.error(`Connection to log server has failed with status ${err.status}`)
+
+  return {
+    close: () => {
+      es.close()
+    },
+  }
+}
+
+export const onEvent = (account: string, workspace: string, sender: string, key: string, callback: (message: string) => void): SSEHandler => {
+  const es = new EventSource(`${colossusHost}/${account}/${workspace}/events/${sender}:-:${key}`)
+
+  es.addEventListener('message', (msg: MessageJSON) => {
+    const {body: {message}}: Message = JSON.parse(msg.data)
+    callback(message)
+  })
+
+  es.onerror = (err) =>
+    log.error(`Connection to log server has failed with status ${err.status}`)
+
+  return {
+    close: () => {
+      es.close()
+    },
+  }
 }

--- a/src/modules/apps/link.ts
+++ b/src/modules/apps/link.ts
@@ -60,7 +60,7 @@ export default {
     }
 
     log.info('Linking app', `${id(manifest)}`)
-    listen(account, workspace, log.level, `${manifest.vendor}.${manifest.name}@${manifest.version}`)
+    listen(account, workspace, log.level, `${manifest.vendor}.${manifest.name}`)
     const majorLocator = toMajorLocator(manifest.vendor, manifest.name, manifest.version)
     return listLocalFiles(root)
       .tap(() => log.debug('Sending files:'))

--- a/src/modules/workspace/index.ts
+++ b/src/modules/workspace/index.ts
@@ -21,5 +21,8 @@ export default {
     reset: {
       module: dirnameJoin('modules/workspace/reset'),
     },
+    prepare: {
+      module: dirnameJoin('modules/workspace/prepare'),
+    },
   },
 }

--- a/src/modules/workspace/prepare.ts
+++ b/src/modules/workspace/prepare.ts
@@ -1,0 +1,71 @@
+import * as chalk from 'chalk'
+import * as inquirer from 'inquirer'
+import * as Bluebird from 'bluebird'
+import {compose, flip, gt, length} from 'ramda'
+
+import log from '../../logger'
+import {apps, colossus} from '../../clients'
+import {listen, onEvent} from '../../courier'
+import {getAccount, getWorkspace} from '../../conf'
+
+const {listLinks} = apps
+const [account, currentWorkspace] = [getAccount(), getWorkspace()]
+
+const flippedGt = flip(gt)
+
+const hasLinks =
+  compose<any[], number, boolean>(flippedGt(0), length)
+
+const prepare = (): Bluebird<void> => {
+  return colossus.sendEvent('vtex.toolbelt', '-', 'buildProd')
+}
+
+const canGoLive = (): Bluebird<never | void> =>
+  listLinks()
+    .then(hasLinks)
+    .then(result => {
+      if (!result) {
+        return
+      }
+      const err = new Error()
+      err.name = 'InterruptionError'
+      log.error('You have links on your workspace, please unlink them before preparing for production')
+      throw err
+    })
+
+const promptConfirm = (workspace: string): Bluebird<never | void> =>
+  Promise.resolve(
+    inquirer.prompt({
+      type: 'confirm',
+      name: 'confirm',
+      message: `Are you sure you want to prepare workspace ${chalk.green(workspace)} to production?`,
+    }),
+  )
+  .then(({confirm}) => {
+    if (confirm) {
+      return
+    }
+    const err = new Error()
+    err.name = `InterruptionError`
+    throw err
+  })
+
+const waitCompletion = () => {
+  const logHandler = listen(account, currentWorkspace, log.level, 'production_requester')
+  const eventHandler = onEvent(account, currentWorkspace, 'vtex.prodman', 'production.ready', () => {
+    log.info(`Workspace ${chalk.green(currentWorkspace)} is now production ready`)
+    logHandler.close()
+    eventHandler.close()
+  })
+}
+
+export default {
+  description: 'Prepare this workspace to be production-ready',
+  handler: () => {
+    log.debug('Preparing workspace', currentWorkspace)
+    return canGoLive()
+      .then(() => promptConfirm(currentWorkspace))
+      .then(() => prepare())
+      .then(() => waitCompletion())
+  },
+}

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -25,6 +25,10 @@ interface Manifest {
   mustUpdateAt?: string,
 }
 
+interface SSEHandler {
+  close ()
+}
+
 interface InstalledApp {
   app: string,
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add a new command to prepare workspace for production

#### What problem is this solving?
Currently there is no way to trigger a production build on render-builder and set a workspace as "stable"

#### How should this be manually tested?
Use the `vtex workspace prepare` command while linking render-builder using the branch feature/production

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
