### PR TITLE
Improve unresolved regex to only match packages

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -19,7 +19,7 @@
       {
         "commonjs": true,
         "amd": true,
-        "ignore": ["^[a-zA-Z\\.@-]+$"]
+        "ignore": ["^([a-zA-Z@]+[-\\.]?)+"]
       }
     ]
   },


### PR DESCRIPTION
#### What is the purpose of this pull request?
Prevent misleading eslint warning about external imports.

#### What problem is this solving?
Eslint warning for stuff like:
```javascript
import React from 'react'
```
or
```javascript
import Link from 'vtex.render-runtime/components/Link'
```

#### How should this be manually tested?
Run `vtex setup eslint` on an app folder and try one of the imports mentioned before.
Check your editor warnings or run the eslint bin to check for the project.

#### Screenshots or example usage
n/a

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
