### PR TITLE
Make `vtex infra update` work for all services at once

### DIFF
--- a/src/modules/infra/update.ts
+++ b/src/modules/infra/update.ts
@@ -49,11 +49,9 @@ const createVersionMap = (availableRes: InfraAvailableResources, installedRes: I
       .filter(v => getTag(v) === tag)
       .sort(semver.rcompare)[0]
     if (currentVersion !== latestVersion) {
-      acc.update = {
-        [name]: {
-          latest: latestVersion,
-          current: currentVersion,
-        },
+      acc.update[name] = {
+        latest: latestVersion,
+        current: currentVersion,
       }
     } else {
       acc.latest[name] = currentVersion


### PR DESCRIPTION
#### What is the purpose of this pull request?
Make the call to `vtex infra update` update all services as it is intended to.

#### What problem is this solving?
Currently, only one service is updated at a time, which is a bug.

#### How should this be manually tested?
`vtex infra update` and see it work for all the apps.

#### Screenshots or example usage
```
~$ vtex infra update --verbose
colossus-js  0.1.3
vbase        v2.0.33
apps         0.10.2 -> 0.10.3
colossus     0.3.1 -> 0.3.5

? Apply version updates? Yes
14:00:48.696 - info:    All updates were installed
~$ vtex infra ls
info:    Services installed on basedevmkp/igor2
┌─────────────┬─────────┐
│ Name        │ Version │
├─────────────┼─────────┤
│ apps        │ 0.10.3  │
├─────────────┼─────────┤
│ colossus    │ 0.3.5   │
├─────────────┼─────────┤
│ colossus-js │ 0.1.3   │
├─────────────┼─────────┤
│ vbase       │ 2.0.33  │
└─────────────┴─────────┘
```

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
