### PR TITLE
Fix registry reference on publish success message

### DIFF
--- a/src/clients.ts
+++ b/src/clients.ts
@@ -21,7 +21,7 @@ const interceptor = (client) => new Proxy({}, {
   },
 })
 
-const accountRegistry = (account: string = 'smartcheckout'): Registry => {
+const accountRegistry = (account: string): Registry => {
   return Registry({...options, account, endpoint: endpoint('registry')})
 }
 
@@ -44,5 +44,5 @@ export {
   router,
   accountRegistry,
   workspaces,
-  colossus
+  colossus,
 }

--- a/src/modules/apps/publish.ts
+++ b/src/modules/apps/publish.ts
@@ -15,7 +15,7 @@ const root = process.cwd()
 const automaticTag = (version: string): string =>
   version.indexOf('-') > 0 ? null : 'latest'
 
-const publisher = (account: string) => {
+const publisher = (account: string = 'smartcheckout') => {
   const reg = accountRegistry(account)
 
   const publishApp = (path: string, tag: string, manifest: Manifest): Bluebird<LoggerInstance | never> => {


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix the `undefined` at the end of the success message of the `vtex publish` command.

#### What problem is this solving?
Move the default parameter for the `registry` one level up on the function stack so that the message can print the output correctly. 
Fix #302 

#### How should this be manually tested?
Running the `vtex publish` command and confirming that the output doesn't contain `undefined`.

#### Screenshots or example usage
n/a

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
