### PR TITLE
Trigger build after publishing app

### DIFF
--- a/src/clients.ts
+++ b/src/clients.ts
@@ -23,8 +23,11 @@ const interceptor = (client) => new Proxy({}, {
   },
 })
 
-const accountRegistry = (account: string = 'smartcheckout'): Registry => {
-  return Registry({...options, account, endpoint: endpoint('registry')})
+const createClients = (customOptions) => {
+  return {
+    registry: Registry({...options, ...customOptions, endpoint: endpoint('registry')}),
+    colossus: Colossus({...options, ...customOptions}),
+  }
 }
 
 const [apps, router, workspaces, colossus] = getToken()
@@ -44,7 +47,7 @@ const [apps, router, workspaces, colossus] = getToken()
 export {
   apps,
   router,
-  accountRegistry,
   workspaces,
   colossus,
+  createClients,
 }

--- a/src/modules/apps/add.ts
+++ b/src/modules/apps/add.ts
@@ -19,7 +19,7 @@ import {
 } from 'ramda'
 
 import log from '../../logger'
-import {accountRegistry, router} from '../../clients'
+import {createClients, router} from '../../clients'
 import {
   namePattern,
   manifestPath,
@@ -65,7 +65,8 @@ const handleError = curry((app: string, err: any) => {
 })
 
 const appsLatestVersion = (app: string): Bluebird<string | never> => {
-  return accountRegistry().listVersionsByApp(app)
+  return createClients({account: 'smartcheckout'}).registry
+    .listVersionsByApp(app)
     .then(prop('data'))
     .then(map(extractVersionFromId))
     .then(pickLatestVersion)

--- a/src/modules/apps/install.ts
+++ b/src/modules/apps/install.ts
@@ -2,7 +2,8 @@ import {head, tail} from 'ramda'
 
 import log from '../../logger'
 import {apps} from '../../clients'
-import {listenUntilBuildSuccess, validateAppAction} from './utils'
+import {validateAppAction} from './utils'
+import {listenBuild} from '../utils'
 import {manifest, validateApp} from '../../manifest'
 
 const {installApp} = apps
@@ -41,12 +42,12 @@ export default {
     const app = optionalApp || `${manifest.vendor}.${manifest.name}@${manifest.version}`
     const apps = [app, ...options._.slice(ARGS_START_INDEX)].map(arg => arg.toString())
 
-    // Only listen for feedback if there's only one app
-    if (apps.length === 1) {
-      listenUntilBuildSuccess(app)
-    }
-
+    const doInstall = () => installApps(apps, options.r || options.registry || 'smartcheckout')
     log.debug('Installing app(s)', apps)
-    return installApps(apps, options.r || options.registry || 'smartcheckout')
+
+    // Only listen for feedback if there's only one app
+    return apps.length === 1
+      ? listenBuild(app, doInstall)
+      : doInstall()
   },
 }

--- a/src/modules/apps/uninstall.ts
+++ b/src/modules/apps/uninstall.ts
@@ -3,7 +3,8 @@ import {head, tail} from 'ramda'
 
 import log from '../../logger'
 import {apps} from '../../clients'
-import {listenUntilBuildSuccess, validateAppAction} from './utils'
+import {validateAppAction} from './utils'
+import {listenBuild} from '../utils'
 import {manifest, validateApp} from '../../manifest'
 
 const {uninstallApp} = apps
@@ -58,12 +59,11 @@ export default {
       await promptAppUninstall(apps)
     }
 
-    // Only listen for feedback if there's only one app
-    if (apps.length === 1) {
-      listenUntilBuildSuccess(app)
-    }
-
+    const doUninstall = () => uninstallApps(apps)
     log.debug('Uninstalling app(s)', apps)
-    return uninstallApps(apps)
+    // Only listen for feedback if there's only one app
+    return apps.length === 1
+      ? listenBuild(app, doUninstall)
+      : doUninstall()
   },
 }

--- a/src/modules/apps/unlink.ts
+++ b/src/modules/apps/unlink.ts
@@ -2,7 +2,8 @@ import {head, tail} from 'ramda'
 
 import log from '../../logger'
 import {apps} from '../../clients'
-import {listenUntilBuildSuccess, validateAppAction} from './utils'
+import {validateAppAction} from './utils'
+import {listenBuild} from '../utils'
 import {manifest, validateApp} from '../../manifest'
 
 const {unlink} = apps
@@ -36,12 +37,11 @@ export default {
     const app = optionalApp || `${manifest.vendor}.${manifest.name}@${manifest.version}`
     const apps = [app, ...options._.slice(ARGS_START_INDEX)].map(arg => arg.toString())
 
-    // Only listen for feedback if there's only one app
-    if (apps.length === 1) {
-      listenUntilBuildSuccess(app)
-    }
-
+    const doUnlink = () => unlinkApps(apps)
     log.debug('Unlinking app(s)', apps)
-    return unlinkApps(apps)
+    // Only listen for feedback if there's only one app
+    return apps.length === 1
+      ? listenBuild(app, doUnlink)
+      : doUnlink()
   },
 }

--- a/src/modules/apps/utils.ts
+++ b/src/modules/apps/utils.ts
@@ -7,7 +7,6 @@ import log from '../../logger'
 import {getWorkspace} from '../../conf'
 import {CommandError} from '../../errors'
 import {isManifestReadable} from '../../manifest'
-import {listenBuildSuccess} from '../utils'
 
 export const id = (manifest: Manifest): string =>
   `${manifest.vendor}.${manifest.name}@${manifest.version}`
@@ -17,15 +16,6 @@ export const mapFileObject = (files: string[], root = process.cwd()): BatchStrea
 
 export const workspaceMasterMessage =
   `Workspace ${chalk.green('master')} is ${chalk.red('read-only')}, please use another workspace.`
-
-export const listenUntilBuildSuccess = (appOrKey) => {
-  listenBuildSuccess(appOrKey, (err) => {
-    if (err) {
-      log.error('Build failed')
-    }
-    process.exit(err ? 1 : 0)
-  })
-}
 
 export const validateAppAction = async (app?) => {
   if (getWorkspace() === 'master') {

--- a/src/modules/utils.ts
+++ b/src/modules/utils.ts
@@ -1,28 +1,71 @@
+import {pathOr} from 'ramda'
+
 import {logAll, onEvent} from '../sse'
 import log from '../logger'
 
-export const listenBuildSuccess = (appOrKey, callback) => {
-  const timeout = setTimeout(() => {
-    unlistenStart()
-    unlistenSuccess()
-    unlistenFail()
-    callback()
-  }, 5000)
+type BuildEvent = 'start' | 'success' | 'fail' | 'timeout' | 'logs'
+
+const allEvents: BuildEvent[] = ['start', 'success', 'fail', 'timeout', 'logs']
+
+const flowEvents: BuildEvent[] = ['start', 'success', 'fail']
+
+const onBuildEvent = (appOrKey: string, callback: (type: BuildEvent, message?: Message) => void) => {
   const unlistenLogs = logAll(log.level, appOrKey.split('@')[0])
-  const unlistenStart = onEvent('vtex.render-builder', 'build.start', () => {
-    clearTimeout(timeout)
-    unlistenStart()
-  })
-  const unlistenSuccess = onEvent('vtex.render-builder', 'build.success', () => {
-    unlistenLogs()
-    unlistenSuccess()
-    unlistenFail()
-    callback()
-  })
-  const unlistenFail = onEvent('vtex.render-builder', 'build.fail', () => {
-    unlistenLogs()
-    unlistenSuccess()
-    unlistenFail()
-    callback(true)
+  const [unlistenStart, unlistenSuccess, unlistenFail] = flowEvents.map((type) => onEvent('vtex.render-builder', `build.${type}`, (message) => callback(type, message)))
+  const timeout = setTimeout(() => callback('timeout'), 5000)
+
+  return (...types: BuildEvent[]) => {
+    types.forEach(type => {
+      switch (type) {
+        case 'start':
+          unlistenStart()
+          break
+        case 'success':
+          unlistenSuccess()
+          break
+        case 'fail':
+          unlistenFail()
+          break
+        case 'timeout':
+          clearTimeout(timeout)
+          break
+        case 'logs':
+          unlistenLogs()
+          break
+      }
+    })
+  }
+}
+
+export const listenBuild = (appOrKey: string, triggerBuild: () => Promise<any>) => {
+  return new Promise((resolve, reject) => {
+    let triggerResponse
+
+    const unlisten = onBuildEvent(appOrKey, (eventType, message) => {
+      switch (eventType) {
+        case 'start':
+          unlisten('start', 'timeout')
+          break
+        case 'success':
+        case 'timeout':
+          unlisten(...allEvents)
+          resolve(triggerResponse)
+          break
+        case 'fail':
+          const errorMsg = pathOr('Build fail', ['body', 'message'], message)
+          unlisten(...allEvents)
+          reject(new Error(errorMsg))
+          break
+      }
+    })
+
+    triggerBuild()
+      .then(response => {
+        triggerResponse = response
+      })
+      .catch(e => {
+        unlisten(...allEvents)
+        reject(e)
+      })
   })
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Enable build of apps on publish.

#### What problem is this solving?
Builder 2 must be called when an app is published. Later, that event will be triggered by *apps* itself.

#### How should this be manually tested?
Builder 2 is not ready, so you must link vtex.render-builder 2.x in some workspace of smartcheckout account. Then change workspace master to your workspace [here](https://github.com/vtex/toolbelt/blob/feature/publish-event/src/modules/apps/publish.ts#L21) and publish some app.

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
