### PR TITLE
Feature/vtex token

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ Adding commands to the Toolbelt is very easy.
 All commands are implemented by JavaScript files in the `src/modules/` directory.  
 These files `export` a JavaScript object containing one `command` for each key.  
 The `key` in this object will be the command name, and the value is an object containing, at least, a `handler` function.  
-Hander functions **should return a Promise**.
+Handler functions **should return a Promise**.
 You can either add a command to an existing file, or create a new one.  
 Here's an example for a very simple command:
 

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "chokidar": "^1.6.1",
     "clear-module": "^2.1.0",
     "cli-table": "^0.3.1",
+    "clipboardy": "^1.1.4",
     "configstore": "^3.0.0",
     "debounce": "^1.0.0",
     "diff": "^3.2.0",

--- a/src/modules/local/token.ts
+++ b/src/modules/local/token.ts
@@ -1,0 +1,8 @@
+import {getToken} from '../../conf'
+import * as clipboardy from 'clipboardy'
+
+export default () => {
+  const token = getToken()
+  clipboardy.writeSync(token)
+  return console.log(token)
+}

--- a/src/modules/tree.ts
+++ b/src/modules/tree.ts
@@ -233,6 +233,10 @@ export default {
       description: 'Run a Colossus function locally',
       handler: './local/debug',
     },
+    token: {
+      description: 'Show user\'s auth token and copy it to clipboard',
+      handler: './local/token',
+    },
   },
   init: {
     description: 'Create basic files and folders for your VTEX app',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1115,6 +1115,12 @@ cli-width@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.1.0.tgz#b234ca209b29ef66fc518d9b98d5847b00edf00a"
 
+clipboardy@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/clipboardy/-/clipboardy-1.1.4.tgz#51b17574fc682588e2dd295cfa6e6aa109eab5ee"
+  dependencies:
+    execa "^0.6.0"
+
 cliui@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-2.1.0.tgz#4b475760ff80264c762c3a1719032e91c7fea0d1"
@@ -1770,6 +1776,18 @@ execa@^0.5.0:
   dependencies:
     cross-spawn "^4.0.0"
     get-stream "^2.2.0"
+    is-stream "^1.1.0"
+    npm-run-path "^2.0.0"
+    p-finally "^1.0.0"
+    signal-exit "^3.0.0"
+    strip-eof "^1.0.0"
+
+execa@^0.6.0:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-0.6.3.tgz#57b69a594f081759c69e5370f0d17b9cb11658fe"
+  dependencies:
+    cross-spawn "^5.0.1"
+    get-stream "^3.0.0"
     is-stream "^1.1.0"
     npm-run-path "^2.0.0"
     p-finally "^1.0.0"


### PR DESCRIPTION
#### What is the purpose of this pull request?
- Added the command `vtex local token` to print a user's auth token and copy it to clipboard. To copy to clipboard, the _clipboardy_ npm module was used.

- Fixed a small typo in CONTRIBUTING.md

#### What problem is this solving?
This is a simpler way to find the user's auth token. The command avoids the hassle of opening a local file, extracting the token and copying it to clipboard, all manually.

#### How should this be manually tested?
`vtex local token`

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
