### PR TITLE
Simplify update-notifier usage

### DIFF
--- a/src/update.ts
+++ b/src/update.ts
@@ -1,25 +1,7 @@
-import {curry} from 'ramda'
-import * as Bluebird from 'bluebird'
-import * as semverDiff from 'semver-diff'
 import * as updateNotifier from 'update-notifier'
 
 import * as pkg from '../package.json'
 
-const updateCallback = curry(
-  function (resolve: Function, reject: Function, err, update): void {
-    if (err) {
-      reject(err)
-    }
-    if (!semverDiff(update.current, update.latest)) {
-      return resolve()
-    }
-    this.update = update
-    resolve(this.notify())
-  },
-)
-
-export default function notify (): Bluebird<void> {
-  return new Promise<void>((resolve, reject) =>
-    updateNotifier({pkg, callback: updateCallback(resolve, reject)}),
-  )
+export default function notify () {
+  updateNotifier({pkg}).notify()
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Simplify `update-notifier` usage so it will only look for updates and possibly show update message at most once per day, according to [documentation](https://github.com/yeoman/update-notifier#how).

#### What problem is this solving?
When an update is available, an update message will be shown for every command.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
