### PR TITLE
Add 'vtex unlink --all' command

### DIFF
--- a/src/modules/tree.ts
+++ b/src/modules/tree.ts
@@ -20,6 +20,14 @@ export default {
   unlink: {
     optionalArgs: 'app',
     description: 'Unlink an app on the current directory or a specified one',
+    options: [
+      {
+        short: 'a',
+        long: 'all',
+        description: 'Unlink all apps',
+        type: 'boolean',
+      },
+    ],
     handler: './apps/unlink',
   },
   add: {


### PR DESCRIPTION
#### What is the purpose of this pull request?
Added the command `vtex unlink --all` that unlinks all linked apps in the current workspace. 

#### What problem is this solving?
It is now possible to unlink multiple apps - or all of them at once - without uninstalling them. No need to `workspace reset` to unlink all apps with the side effect of also uninstalling them.

#### How should this be manually tested?
`vtex unlink vtex.render-server@2.0.5 vtex.render-builder@2.x`, or
`vtex unlink --all`
Use `-a` for short.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.