### PR TITLE
Fixed 'vtex uninstall' with no args

### DIFF
--- a/src/modules/apps/uninstall.ts
+++ b/src/modules/apps/uninstall.ts
@@ -8,7 +8,7 @@ import {getManifest, validateApp} from '../../manifest'
 import {toAppLocator} from './../../locator'
 
 const {uninstallApp} = apps
-const ARGS_START_INDEX = 2
+const ARGS_START_INDEX = 1
 
 const promptAppUninstall = (apps: string[]): Promise<void> =>
   inquirer.prompt({
@@ -26,15 +26,15 @@ const uninstallApps = async (apps: string[]): Promise<void> => {
   if (apps.length === 0) {
     return
   }
-  const app = validateApp(head(apps), true)
+  const app = validateApp(head(apps).split('@')[0], true)
   try {
     log.debug('Starting to uninstall app', app)
     await uninstallApp(app)
+    log.info(`Uninstalled app ${app} successfully`)
   } catch (e) {
-    log.warn(`The following apps were not uninstalled: ${apps.join(', ')}`)
-    throw e
+    log.warn(`The following app was not uninstalled: ${app}`)
+    log.error(`${e.response.status}: ${e.response.statusText}. ${e.response.data.message}`)
   }
-  log.info(`Uninstalled app ${app} successfully`)
   await uninstallApps(tail(apps))
 }
 
@@ -48,6 +48,6 @@ export default async (optionalApp: string, options) => {
     await promptAppUninstall(apps)
   }
 
-  log.debug('Uninstalling app(s)', apps)
+  log.debug(`Uninstalling app(s): ${apps.join(', ')}`)
   return uninstallApps(apps)
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
- Fixed `vtex uninstall` when no argument was provided.
- Add support for multiple app uninstalls

#### What problem is this solving?
- An app format error would be thrown even when in correct app folder
- Added support for multiple app inputs. Uninstall of other apps doesn't stop when an error occurs.
- Cleaner error report

#### How should this be manually tested?
`vtex uninstall`, or
`vtex uninstall vtex.render-builder vtex.visa-checkout@0.13.5`

#### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
