### PR TITLE
Fix/build listening

### DIFF
--- a/src/modules/apps/publish.ts
+++ b/src/modules/apps/publish.ts
@@ -34,11 +34,12 @@ const publisher = (account: string = 'smartcheckout') => {
   const publishApp = (path: string, tag: string, manifest: Manifest): Bluebird<LoggerInstance | never> => {
     const spinner = ora('Publishing app...').start()
     const appId = id(manifest)
+    const options = {context, timeout: null}
 
     return listLocalFiles(path)
       .tap(files => log.debug('Sending files:', '\n' + files.join('\n')))
       .then(files => mapFileObject(files, path))
-      .then(files => listenBuild(appId, (unlistenBuild) => prePublish(files, tag, unlistenBuild), context))
+      .then(files => listenBuild(appId, (unlistenBuild) => prePublish(files, tag, unlistenBuild), options))
       .finally(() => spinner.stop())
       .then(() => log.info(`Published app ${appId} successfully at ${account}`))
       .catch(e => {

--- a/src/modules/utils.ts
+++ b/src/modules/utils.ts
@@ -3,16 +3,21 @@ import {currentContext} from '../conf'
 import log from '../logger'
 import {BuildFailError} from '../errors'
 
+type BuildListeningOptions = {
+  context?: Context,
+  timeout?: number,
+}
+
 type BuildEvent = 'start' | 'success' | 'fail' | 'timeout' | 'logs'
 
 const allEvents: BuildEvent[] = ['start', 'success', 'fail', 'timeout', 'logs']
 
 const flowEvents: BuildEvent[] = ['start', 'success', 'fail']
 
-const onBuildEvent = (ctx: Context, appOrKey: string, callback: (type: BuildEvent, message?: Message) => void) => {
+const onBuildEvent = (ctx: Context, timeout: number, appOrKey: string, callback: (type: BuildEvent, message?: Message) => void) => {
   const unlistenLogs = logAll(ctx, log.level, appOrKey.split('@')[0])
   const [unlistenStart, unlistenSuccess, unlistenFail] = flowEvents.map((type) => onEvent(ctx, 'vtex.render-builder', `build.${type}`, (message) => callback(type, message)))
-  const timer = setTimeout(() => callback('timeout'), 5000)
+  const timer = timeout && setTimeout(() => callback('timeout'), timeout)
 
   const unlistenMap: Record<BuildEvent, Function> = {
     start: unlistenStart,
@@ -27,11 +32,12 @@ const onBuildEvent = (ctx: Context, appOrKey: string, callback: (type: BuildEven
   }
 }
 
-export const listenBuild = (appOrKey: string, triggerBuild: (unlistenBuild?: (response) => void) => Promise<any>, ctx: Context = currentContext) => {
+export const listenBuild = (appOrKey: string, triggerBuild: (unlistenBuild?: (response) => void) => Promise<any>, options: BuildListeningOptions = {}) => {
   return new Promise((resolve, reject) => {
     let triggerResponse
 
-    const unlisten = onBuildEvent(ctx, appOrKey, (eventType, message) => {
+    const {context = currentContext, timeout = 5000} = options
+    const unlisten = onBuildEvent(context, timeout, appOrKey, (eventType, message) => {
       switch (eventType) {
         case 'start':
           unlisten('start', 'timeout')


### PR DESCRIPTION
#### What is the purpose of this pull request?
Adjust build listening to app publishing scenarios.

#### What problem is this solving?
- When publishing an app, after 5 seconds without builder response toolbelt logs a message of successful publication, even if it fails.
- When publishing an app that does not need a build process (a service app), builder will publish it immediately and toolbelt will wait 5 seconds to show a feedback

#### How should this be manually tested?
`vtex publish`

#### Screenshots or example usage

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
