### PR TITLE
Multiple arguments support fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "nyc": "^10.1.2",
     "rimraf": "^2.6.1",
     "tslint": "^5.2.0",
-    "tslint-config-vtex": "^1.3.1",
+    "tslint-config-vtex": "^1.3.2",
     "tslint-eslint-rules": "^4.0.0",
     "typescript": "^2.4.2"
   },

--- a/src/modules/apps/add.ts
+++ b/src/modules/apps/add.ts
@@ -16,6 +16,7 @@ import {
   reduce,
   concat,
   compose,
+  prepend,
 } from 'ramda'
 
 import log from '../../logger'
@@ -28,9 +29,9 @@ import {
   wildVersionPattern,
 } from '../../manifest'
 
+import {parseArgs} from './utils'
 import {RegistryAppVersionsListItem} from '@vtex/api'
 
-const ARGS_START_INDEX = 2
 const unprefixName = compose<string, string[], string>(last, split(':'))
 const wildVersionByMajor = compose<string, string[], string, string>(concat(__, '.x'), head, split('.'))
 const invalidAppMessage =
@@ -122,7 +123,7 @@ const addApps = (apps: string[]): Bluebird<void | never> => {
     .catch(err => {
       // A warn message will display the workspaces not deleted.
       if (!err.toolbeltWarning) {
-        log.warn(`The following app(s) were not added: ${apps.join(', ')}`)
+        log.warn(`The following app` + (apps.length > 1 ? 's were' : ' was') + ` not added: ${apps.join(', ')}`)
         // the warn message is only displayed the first time the err occurs.
         err.toolbeltWarning = true
       }
@@ -131,10 +132,10 @@ const addApps = (apps: string[]): Bluebird<void | never> => {
 }
 
 export default (app: string, options) => {
-  const apps = [app, ...options._.slice(ARGS_START_INDEX)].map(arg => arg.toString())
-  log.debug('Adding app(s)', apps)
+  const apps = prepend(app, parseArgs(options._))
+  log.debug('Adding app' + (apps.length > 1 ? 's' : '') + `: ${apps.join(', ')}`)
   return addApps(apps)
-    .then(() => log.info('App(s) added succesfully!'))
+    .then(() => log.info('App' + (apps.length > 1 ? 's' : '') + ' added succesfully!'))
     .catch(err => {
       if (err instanceof InterruptionException) {
         log.error(err.message)

--- a/src/modules/apps/install.ts
+++ b/src/modules/apps/install.ts
@@ -1,36 +1,34 @@
-import {head, tail} from 'ramda'
+import {head, tail, prepend} from 'ramda'
 
 import log from '../../logger'
 import {apps} from '../../clients'
-import {validateAppAction} from './utils'
+import {validateAppAction, parseArgs} from './utils'
 import {getManifest, validateApp} from '../../manifest'
 import {toAppLocator} from './../../locator'
 
 const {installApp} = apps
-const ARGS_START_INDEX = 2
 
-const installApps = async (apps: string[], reg: string): Promise<void> => {
-  if (apps.length === 0) {
+const installApps = async (appsList: string[], reg: string): Promise<void> => {
+  if (appsList.length === 0) {
     return
   }
-  const app = validateApp(head(apps))
+  const app = validateApp(head(appsList))
 
   try {
     log.debug('Starting to install app', app)
     await installApp(app, reg)
+    log.info(`Installed app ${app} successfully`)
   } catch (e) {
-    log.warn(`The following apps were not installed: ${apps.join(', ')}`)
-    throw e
+    log.warn(`The following app was not installed: ${app}`)
+    log.error(`Error ${e.response.status}: ${e.response.statusText}. ${e.response.data.message}`)
   }
-  log.info(`Installed app ${app} successfully`)
-  await installApps(tail(apps), reg)
+  await installApps(tail(appsList), reg)
 }
 
 export default async (optionalApp: string, options) => {
   await validateAppAction(optionalApp)
   const app = optionalApp || toAppLocator(await getManifest())
-  const apps = [app, ...options._.slice(ARGS_START_INDEX)].map(arg => arg.toString())
-
-  log.debug('Installing app(s)', apps)
-  return installApps(apps, options.r || options.registry || 'smartcheckout')
+  const appsList = prepend(app, parseArgs(options._))
+  log.debug('Installing app' + (appsList.length > 1 ? 's' : '') + `: ${appsList.join(', ')}`)
+  return installApps(appsList, options.r || options.registry || 'smartcheckout')
 }

--- a/src/modules/apps/publish.ts
+++ b/src/modules/apps/publish.ts
@@ -3,15 +3,15 @@ import {resolve} from 'path'
 import * as Bluebird from 'bluebird'
 import {LoggerInstance} from 'winston'
 import {readFileSync} from 'fs-extra'
+import {prepend} from 'ramda'
 
 import log from '../../logger'
 import {createClients} from '../../clients'
-import {id, mapFileObject} from './utils'
+import {id, mapFileObject, parseArgs} from './utils'
 import {listLocalFiles} from './file'
 import {listenBuild} from '../utils'
 import {BuildFailError} from '../../errors'
 
-const ARGS_START_INDEX = 2
 const root = process.cwd()
 
 const automaticTag = (version: string): string =>
@@ -71,7 +71,7 @@ const publisher = (account: string = 'smartcheckout') => {
 
 export default (path: string, options) => {
   log.debug('Starting to publish app')
-  const paths = [path || root, ...options._.slice(ARGS_START_INDEX)].map(arg => arg.toString())
+  const paths = prepend(path || root, parseArgs(options._))
   const {publishApps} = publisher(options.r || options.registry)
   return publishApps(paths, options.tag)
 }

--- a/src/modules/apps/settings/set.ts
+++ b/src/modules/apps/settings/set.ts
@@ -1,5 +1,6 @@
-import {splitAt, flatten, merge, zipObj, values, __} from 'ramda'
+import {merge, zipObj, __} from 'ramda'
 import {apps} from '../../../clients'
+import {parseArgs} from '../utils'
 
 const {getAppSettings, saveAppSettings} = apps
 
@@ -29,8 +30,7 @@ const transformCommandsToObj = (commandSettings) => {
 }
 
 export default (app: string, _field, _value, options) => {
-  const [, commands] = splitAt(1, flatten(values(options)))
-  const commandSettings = transformCommandsToObj(commands)
+  const commandSettings = transformCommandsToObj(parseArgs(options))
   return getAppSettings(app)
     .then(merge(__, commandSettings))
     .then(newSettings => JSON.stringify(newSettings, null, 2))

--- a/src/modules/apps/utils.ts
+++ b/src/modules/apps/utils.ts
@@ -2,6 +2,7 @@ import {join} from 'path'
 import * as chalk from 'chalk'
 import * as inquirer from 'inquirer'
 import {createReadStream} from 'fs-extra'
+import {splitAt, flatten, values} from 'ramda'
 
 import log from '../../logger'
 import {getWorkspace} from '../../conf'
@@ -16,6 +17,11 @@ export const mapFileObject = (files: string[], root = process.cwd()): BatchStrea
 
 export const workspaceMasterMessage =
   `Workspace ${chalk.green('master')} is ${chalk.red('read-only')}, please use another workspace.`
+
+export const parseArgs = (args: string[]) => {
+  const [, commands] = splitAt(1, flatten(values(args)))
+  return commands
+}
 
 export const validateAppAction = async (app?) => {
   if (getWorkspace() === 'master') {

--- a/src/modules/tree.ts
+++ b/src/modules/tree.ts
@@ -32,7 +32,7 @@ export default {
   },
   add: {
     requiredArgs: 'app',
-    description: 'Add an app to the manifest dependencies',
+    description: 'Add app(s) to the manifest dependencies',
     handler: './apps/add',
   },
   publish: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4277,9 +4277,9 @@ tslib@^1.0.0, tslib@^1.6.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.7.0.tgz#6e8366695f72961252b35167b0dd4fbeeafba491"
 
-tslint-config-vtex@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/tslint-config-vtex/-/tslint-config-vtex-1.3.1.tgz#ec628d663464ad187ef71c646196d4a93cea3cf2"
+tslint-config-vtex@^1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/tslint-config-vtex/-/tslint-config-vtex-1.3.2.tgz#b40f9dd621173c4f7137c426479d1a661adcd356"
 
 tslint-eslint-rules@^4.0.0:
   version "4.1.1"


### PR DESCRIPTION
#### What is the purpose of this pull request?
Small rework of toolbelt functions in order for them to properly receive multiple input arguments.

#### What problem is this solving?
Eliminated the need to set `const ARGS_START_INDEX` in every toolbelt function that supported (or should support) multiple arguments. Improved error handling in some functions.

#### How should this be manually tested?
`vtex install vtex.render-server vtex.visa-checkout@0.x vtex.render-builder@3.1.0`
`vtex add vtex.render-server vtex.render-builder`
`vtex delete workspace1 workspace2`

#### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
