### PR TITLE
Add command to update all installed apps to latest version

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,6 +1,8 @@
 import ExtendableError from 'es6-error/lib/index.ts.js'
 
 export class CommandError extends ExtendableError {
+  public message
+
   constructor (message = '') {
     super(message)
   }

--- a/src/modules/apps/install.ts
+++ b/src/modules/apps/install.ts
@@ -8,7 +8,7 @@ import {toAppLocator} from './../../locator'
 
 const {installApp} = apps
 
-const installApps = async (appsList: string[], reg: string): Promise<void> => {
+export const installApps = async (appsList: string[], reg: string): Promise<void> => {
   if (appsList.length === 0) {
     return
   }

--- a/src/modules/apps/update.ts
+++ b/src/modules/apps/update.ts
@@ -1,0 +1,62 @@
+import * as ora from 'ora'
+import * as Table from 'cli-table'
+import * as inquirer from 'inquirer'
+import * as Bluebird from 'bluebird'
+import {map, prop, pipe, reject, isEmpty} from 'ramda'
+
+import log from '../../logger'
+import {apps} from '../../clients'
+import {installApps} from './install'
+import {appsLastVersion} from './utils'
+import {diffVersions} from '../infra/utils'
+import {parseLocator, toAppLocator} from '../../locator'
+
+const {listApps} = apps
+
+const promptUpdate = (): Bluebird<boolean> =>
+  Promise.resolve(
+    inquirer.prompt({
+      type: 'confirm',
+      name: 'confirm',
+      message: 'Apply version updates?',
+    })
+    .then<boolean>(prop('confirm')),
+  )
+
+const sameVersion = ({version, latest}: Manifest) => version === latest
+const updateVersion = (app) => {
+  app.version = app.latest
+  return app
+}
+
+export default async () => {
+  const spinner = ora('Getting available updates').start()
+  const {data} = await listApps()
+  const installedApps = map(pipe(prop('app'), parseLocator), data)
+  const withLatest = await Bluebird.all(map(async (app) => {
+    app.latest = await appsLastVersion(`${app.vendor}.${app.name}`)
+    return app
+  }, installedApps))
+  const updateableApps = reject(sameVersion, withLatest)
+
+  const table = new Table({head: ['Vendor', 'Name', 'Current', 'Latest']})
+  updateableApps.forEach(({vendor, name, version, latest}) => {
+    const [fromVersion, toVersion] = diffVersions(version, latest)
+    table.push([vendor, name, fromVersion, toVersion])
+  })
+  spinner.stop()
+
+  if (isEmpty(updateableApps)) {
+    return log.info('No updates available for installed apps.')
+  }
+
+  console.log(`${table.toString()}\n`)
+
+  const confirm = await promptUpdate()
+  if (!confirm) {
+    return
+  }
+
+  const appsList = map(pipe(updateVersion, toAppLocator), updateableApps)
+  await installApps(appsList, 'smartcheckout')
+}

--- a/src/modules/apps/utils.ts
+++ b/src/modules/apps/utils.ts
@@ -1,12 +1,30 @@
 import {join} from 'path'
 import * as chalk from 'chalk'
+import * as Bluebird from 'bluebird'
 import * as inquirer from 'inquirer'
 import {createReadStream} from 'fs-extra'
+import * as semverDiff from 'semver-diff'
 import {splitAt, flatten, values} from 'ramda'
+import {RegistryAppVersionsListItem} from '@vtex/api'
+
+import {
+  __,
+  map,
+  head,
+  tail,
+  last,
+  prop,
+  curry,
+  split,
+  reduce,
+  concat,
+  compose,
+} from 'ramda'
 
 import log from '../../logger'
 import {getWorkspace} from '../../conf'
 import {CommandError} from '../../errors'
+import {createClients} from '../../clients'
 import {isManifestReadable} from '../../manifest'
 
 export const id = (manifest: Manifest): string =>
@@ -46,4 +64,42 @@ export const validateAppAction = async (app?) => {
   if (!app && !isReadable) {
     throw new CommandError(`No app was found, please fix your manifest.json${app ? ' or use <vendor>.<name>[@<version>]' : ''}`)
   }
+}
+
+export const wildVersionByMajor = compose<string, string[], string, string>(concat(__, '.x'), head, split('.'))
+
+export const extractVersionFromId =
+  compose<VersionByApp, string, string[], string>(last, split('@'), prop('versionIdentifier'))
+
+export const pickLatestVersion = (versions: string[]): string => {
+  const start = head(versions)
+  return reduce((acc: string, version: string) => {
+    return semverDiff(acc, version) ? version : acc
+  }, start, tail(versions))
+}
+
+export const handleError = curry((app: string, err: any) => {
+  if (err.response && err.response.status === 404) {
+    return Promise.reject(new CommandError(`App ${chalk.green(app)} not found`))
+  }
+  return Promise.reject(err)
+})
+
+export const appsLatestVersion = (app: string): Bluebird<string | never> => {
+  return createClients({account: 'smartcheckout'}).registry
+    .listVersionsByApp(app)
+    .then<RegistryAppVersionsListItem[]>(prop('data'))
+    .then(map(extractVersionFromId))
+    .then(pickLatestVersion)
+    .then(wildVersionByMajor)
+    .catch(handleError(app))
+}
+
+export const appsLastVersion = (app: string): Bluebird<string | never> => {
+  return createClients({account: 'smartcheckout'}).registry
+    .listVersionsByApp(app)
+    .then<RegistryAppVersionsListItem[]>(prop('data'))
+    .then(map(extractVersionFromId))
+    .then(pickLatestVersion)
+    .catch(handleError(app))
 }

--- a/src/modules/tree.ts
+++ b/src/modules/tree.ts
@@ -86,6 +86,10 @@ export default {
     description: 'List your installed VTEX apps',
     handler: './apps/list',
   },
+  update: {
+    description: 'Update all installed apps to the latest version',
+    handler: './apps/update',
+  },
   settings: {
     description: 'Get app settings',
     requiredArgs: 'app',

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -25,6 +25,7 @@ interface Manifest {
   categories?: string[],
   registries?: string[],
   mustUpdateAt?: string,
+  latest?: string,
 }
 
 interface InstalledApp {


### PR DESCRIPTION
#### What is the purpose of this pull request?
No more updating accounts manually! Just `switch`, `infra update` and now: `update`.

#### What problem is this solving?
Old accounts are boring to manually update.

#### How should this be manually tested?
Install some old apps and call `vtex update`.

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/1633518/30391926-8c6a9628-9891-11e7-83c4-bb2172190f41.png)

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
