### PR TITLE
Login favours workspace master

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -9,8 +9,10 @@ export class CommandError extends ExtendableError {
 }
 
 export class SSEConnectionError extends ExtendableError {
-  constructor (message: string) {
+  statusCode: number
+  constructor (message: string, statusCode: number) {
     super(message)
+    this.statusCode = statusCode
   }
 }
 

--- a/src/modules/workspace/use.ts
+++ b/src/modules/workspace/use.ts
@@ -28,7 +28,7 @@ export default (name: string) => {
           .then(confirm => {
             if (!confirm) {
               log.error(`Could not use workspace ${chalk.green(name)}`)
-              return Promise.reject(null)
+              return Promise.reject(new Error ('User cancelled'))
             }
             return createCmd(name)
           })

--- a/src/sse.ts
+++ b/src/sse.ts
@@ -88,7 +88,7 @@ export const onAuth = (account: string, workspace: string, state: string): Promi
 
     es.onerror = (event) => {
       es.close()
-      reject(new SSEConnectionError(`Connection to login server has failed with status ${event.status}`))
+      reject(new SSEConnectionError(`Connection to login server has failed with status ${event.status}`, event.status))
     }
   })
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
If no workspace is specified, login will be in workspace `master`

#### What problem is this solving?
No more automatic logging in into a broken workspace

#### How should this be manually tested?
`vtex login -w workspace1`, `vtex login -a account -w workspace2`

#### Screenshots or example usage#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
