### PR TITLE
fix/Wks list prints Weight and Production

### DIFF
--- a/src/modules/workspace/list.ts
+++ b/src/modules/workspace/list.ts
@@ -9,13 +9,15 @@ const [account, currentWorkspace] = [getAccount(), getWorkspace()]
 
 export default () => {
   log.debug('Listing workspaces')
-  const table = new Table({head: ['Name', 'Last Modified', 'State']})
+  const table = new Table({head: ['Name', 'Weight', 'Production']})
   return workspaces.list(account)
     .then((workspaces: WorkspaceResponse[]) =>
       workspaces.forEach(workspace => {
         const name = workspace.name === currentWorkspace
           ? chalk.green(`* ${workspace.name}`) : workspace.name
-        table.push([name, '?', '?'])
+        const weight = workspace.weight
+        const production = workspace.production
+        table.push([name, weight, production])
       }),
     )
     .then(() => console.log(table.toString()))

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -99,6 +99,8 @@ interface MessageJSON {
 
 interface WorkspaceResponse {
   name: string,
+  weight: number,
+  production: boolean,
 }
 
 interface VersionByApp {


### PR DESCRIPTION
#### What is the purpose of this pull request?
`vtex workspace list` now shows all available workspace parameters: Weight (number) and Production (boolean). Next step would be to print out other parameters such as Creation Date, Last Modified, etc., which would require some adjustments in the router.

#### What problem is this solving?
`vtex workspace list` used to print out question-marks for columns ```Last Modified``` and ```Status```.

#### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
