### PR TITLE
Added workspace use --reset

### DIFF
--- a/src/modules/tree.ts
+++ b/src/modules/tree.ts
@@ -206,6 +206,14 @@ export default {
     use: {
       requiredArgs: 'name',
       description: 'Use a workspace to perform operations',
+      options: [
+        {
+          short: 'r',
+          long: 'reset',
+          description: 'Resets workspace before using it',
+          type: 'boolean',
+        },
+      ],
       handler: './workspace/use',
     },
     reset: {

--- a/src/modules/workspace/create.ts
+++ b/src/modules/workspace/create.ts
@@ -13,7 +13,7 @@ export default (name: string) => {
   }
   log.debug('Creating workspace', name)
   return workspaces.create(getAccount(), name)
-    .then(() => log.info(`Workspace ${chalk.green(name)} created successfully`))
+    .then(() => log.info(`Workspace ${chalk.green(name)} created ${chalk.green('successfully')}`))
     .catch(err =>
       err.response && err.response.data.code === 'WorkspaceAlreadyExists'
         ? log.error(err.response.data.message)

--- a/src/modules/workspace/delete.ts
+++ b/src/modules/workspace/delete.ts
@@ -1,7 +1,7 @@
 import * as chalk from 'chalk'
 import * as inquirer from 'inquirer'
 import * as Bluebird from 'bluebird'
-import {prop, head, tail, prepend} from 'ramda'
+import {prop, head, tail, prepend, contains, flatten} from 'ramda'
 
 import log from '../../logger'
 import {workspaces} from '../../clients'
@@ -11,66 +11,53 @@ import workspaceUse from './use'
 
 const account = getAccount()
 const workspace = getWorkspace()
-const delSuccessList = []
-const delFailList = []
 
-const promptWorkspaceDeletion = (name: string): Bluebird<boolean> =>
-  Promise.resolve(
-    inquirer.prompt({
-      type: 'confirm',
-      name: 'confirm',
-      message: `Are you sure you want to delete workspace ${chalk.green(name)}?`,
-    }),
-  )
-    .then<boolean>(prop('confirm'))
+const promptWorkspaceDeletion = (names: string[]): Bluebird<boolean> =>
+  inquirer.prompt({
+    type: 'confirm',
+    name: 'confirm',
+    message: `Are you sure you want to delete workspace` + (names.length > 1 ? 's' : '') + ` ${chalk.green(names.join(', '))}?`,
+  })
+  .then<boolean>(prop('confirm'))
 
-const deleteWorkspaces = async (names = [], preConfirm: boolean, force: boolean): Promise<void | never> => {
+export const deleteWorkspaces = async (names = []): Promise<string[]> => {
   const name = head(names)
   const decNames = tail(names)
 
+  if (names.length === 0) {
+    return []
+  }
+
   log.debug('Starting to delete workspace', name)
-  if (!force && name === workspace) {
-    delFailList.push(name)
-    log.error(`You are currently using the workspace ${chalk.green(name)}, please change your workspace before deleting`)
-  } else {
-    try {
-      if (!preConfirm && !await promptWorkspaceDeletion(name)) {
-        throw new Error('User cancelled')
-      }
-      await workspaces.delete(account, name)
-      delSuccessList.push(name)
-      log.info(`Workspace ${chalk.green(name)} deleted ${chalk.green(`successfully`)}`)
-    } catch (err) {
-      delFailList.push(name)
-      log.warn(`Workspace ${chalk.green(name)} was ${chalk.red(`not`)} deleted`)
-      if (err.message === 'User cancelled') {
-        log.error(err.message)
-      } else {
-        log.error(`Error ${err.response.status}: ${err.response.statusText}. ${err.response.data.message}`)
-      }
-    }
-  }
+  try {
+    await workspaces.delete(account, name)
+    log.info(`Workspace ${chalk.green(name)} deleted ${chalk.green('successfully')}`)
 
-  if (decNames.length > 0) {
-    return deleteWorkspaces(decNames, preConfirm, force)
-  }
-  if (delSuccessList.length > 0) {
-    log.info(`The following workspace` + (delSuccessList.length > 1 ? 's were' : ' was') + ` ${chalk.green('successfully')} deleted: ${delSuccessList.join(', ')}`)
-  }
-  if (delFailList.length > 0) {
-    log.info(`The following workspace` + (delFailList.length > 1 ? 's were' : ' was') + ` ${chalk.red('not')} deleted: ${delFailList.join(', ')}`)
-  }
-
-  if (delSuccessList.indexOf(workspace) > -1) {
-    log.warn(`The workspace you were using was deleted`)
-    return workspaceUse('master')
+    return flatten([name, await deleteWorkspaces(decNames)])
+  } catch (err) {
+    log.warn(`Workspace ${chalk.green(name)} was ${chalk.red('not')} deleted`)
+    log.error(`Error ${err.response.status}: ${err.response.statusText}. ${err.response.data.message}`)
+    return deleteWorkspaces(decNames)
   }
 }
 
-export default (name: string, options) => {
+export default async (name: string, options) => {
   const names = prepend(name, parseArgs(options._))
   const preConfirm = options.y || options.yes
   const force = options.f || options.force
   log.debug('Deleting workspace' + (names.length > 1 ? 's' : '') + ':', names.join(', '))
-  return deleteWorkspaces(names, preConfirm, force)
+
+  if (!force && contains(workspace, names)) {
+    return log.error(`You are currently using the workspace ${chalk.green(workspace)}, please change your workspace before deleting`)
+  }
+
+  if (!preConfirm && !await promptWorkspaceDeletion(names)) {
+    throw new Error('User cancelled')
+  }
+
+  const deleted = await deleteWorkspaces(names)
+  if (contains(workspace, deleted)) {
+    log.warn(`The workspace you were using was deleted`)
+    return await workspaceUse('master')
+  }
 }

--- a/src/modules/workspace/reset.ts
+++ b/src/modules/workspace/reset.ts
@@ -1,19 +1,19 @@
 import log from '../../logger'
-import deleteCmd from './delete'
+import {deleteWorkspaces} from './delete'
 import createCmd from './create'
 import {getWorkspace} from '../../conf'
 
-export default (name: string) => {
+export default async (name: string) => {
   log.debug('Resetting workspace', name)
   const workspace = name || getWorkspace()
-  return deleteCmd(workspace, {_: [], yes: true, force: true})
-    .delay(3000)
-    .then(() => createCmd(workspace))
-    .catch(err => {
-      if (err.response && err.response.data.code === 'WorkspaceAlreadyExists') {
-        setTimeout(() => createCmd(workspace), 3000)
-        return
-      }
-      return Promise.reject(err)
-    })
+  try {
+    await deleteWorkspaces([workspace])
+    await createCmd(workspace)
+  } catch (err) {
+    if (err.response && err.response.data.code === 'WorkspaceAlreadyExists') {
+      setTimeout(() => createCmd(workspace), 3000)
+      return
+    }
+    throw err
+  }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Added --reset option to `vtex workspace use` command

#### What problem is this solving?
You can now reset the workspace before using it

#### How should this be manually tested?
`vtex workspace use workspace1 -r`
`vtex use workspace 2 --reset`

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
