### PR TITLE
Allow workspace option on publish command

### DIFF
--- a/src/modules/apps/publish.ts
+++ b/src/modules/apps/publish.ts
@@ -17,8 +17,8 @@ const root = process.cwd()
 const automaticTag = (version: string): string =>
   version.indexOf('-') > 0 ? null : 'latest'
 
-const publisher = (account: string = 'smartcheckout') => {
-  const context = {account, workspace: 'master'}
+const publisher = (account: string = 'smartcheckout', workspace: string = 'master') => {
+  const context = {account, workspace}
 
   const prePublish = async (files, tag, unlistenBuild) => {
     const {builder} = createClients(context)
@@ -72,6 +72,8 @@ const publisher = (account: string = 'smartcheckout') => {
 export default (path: string, options) => {
   log.debug('Starting to publish app')
   const paths = prepend(path || root, parseArgs(options._))
-  const {publishApps} = publisher(options.r || options.registry)
+  const registry = options.r || options.registry
+  const workspace = options.w || options.workspace
+  const {publishApps} = publisher(registry, workspace)
   return publishApps(paths, options.tag)
 }

--- a/src/modules/tree.ts
+++ b/src/modules/tree.ts
@@ -48,7 +48,13 @@ export default {
       {
         short: 'r',
         long: 'registry',
-        description: 'Specify the registry for the app registry',
+        description: 'Specify the account for the app registry',
+        type: 'string',
+      },
+      {
+        short: 'w',
+        long: 'workspace',
+        description: 'Specify the workspace for the app registry',
         type: 'string',
       },
     ],


### PR DESCRIPTION
#### What is the purpose of this pull request?
Allow the user to publish to a specific workspace to allow for better testing of the builder.

#### What problem is this solving?
Right now you need to hack your way around publishing to a specific account/workspace.

#### How should this be manually tested?
`vtex publish -r basedevmkp -w guilherme`

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
