### PR TITLE
Add deprecateApp Command

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "url": "https://github.com/vtex/toolbelt/issues"
   },
   "dependencies": {
-    "@vtex/api": "^0.31.0",
+    "@vtex/api": "^0.31.1",
     "any-promise": "^1.3.0",
     "babel-eslint": "^7.1.1",
     "bluebird": "^3.5.0",

--- a/src/modules/apps/deprecate.ts
+++ b/src/modules/apps/deprecate.ts
@@ -1,0 +1,33 @@
+import {head, tail, prepend} from 'ramda'
+
+import log from '../../logger'
+import {parseArgs} from './utils'
+import {getManifest, validateApp} from '../../manifest'
+import {toAppLocator, parseLocator} from './../../locator'
+import {createClients} from '../../clients'
+import {getAccount} from '../../conf'
+
+const deprecateApps = async (appsList: string[], registry): Promise<void> => {
+  if (appsList.length === 0) {
+    return
+  }
+  const app = await validateApp(head(appsList))
+  const {vendor, name, version} = parseLocator(app)
+  try {
+    log.debug('Starting to deprecate app:', app)
+    await registry.deprecateApp(`${vendor}.${name}`, version)
+    log.info('Successfully deprecated', app)
+  } catch (e) {
+    log.error(`Error deprecating ${app}. ${e.message}. ${e.response.statusText}`)
+  }
+  await deprecateApps(tail(appsList), registry)
+}
+
+export default async (optionalApp: string, options) => {
+  const optionAccount = options ? (options.a || options.account) : null
+  const context = {account: optionAccount || getAccount(), workspace: 'master'}
+  const {registry} = createClients(context)
+  const appsList = prepend(optionalApp || toAppLocator(await getManifest()), parseArgs(options._))
+  log.debug('Deprecating app' + (appsList.length > 1 ? 's' : '') + `: ${appsList.join(', ')}`)
+  return deprecateApps(appsList, registry)
+}

--- a/src/modules/tree.ts
+++ b/src/modules/tree.ts
@@ -60,6 +60,19 @@ export default {
     ],
     handler: './apps/publish',
   },
+  deprecate: {
+    optionalArgs: 'app',
+    description: 'Deprecate app(s)',
+    options: [
+      {
+        short: 'a',
+        long: 'account',
+        description: 'Specify app(s) account',
+        type: 'string',
+      },
+    ],
+    handler: './apps/deprecate',
+  },
   install: {
     alias: 'i',
     optionalArgs: 'app',

--- a/yarn.lock
+++ b/yarn.lock
@@ -196,9 +196,9 @@
   dependencies:
     "@types/node" "*"
 
-"@vtex/api@^0.31.0":
-  version "0.31.0"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-0.31.0.tgz#7a33747f267b7b95c61eb369487e38a037a9564b"
+"@vtex/api@^0.31.1":
+  version "0.31.1"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-0.31.1.tgz#51dffbd532e6dc44bb38b9e32c56c89090e9b311"
   dependencies:
     archiver "^1.3.0"
     axios "^0.16.0"


### PR DESCRIPTION
#### What is the purpose of this pull request?
New toolbelt command to deprecate app(s). Use `-a` to specify the account. Default account is the current one and workspace is always `master`.

#### What problem is this solving?
It is possible now to deprecate one or multiple apps using a toolbelt command. 

#### How should this be manually tested?
`vtex deprecate` will deprecate the current folder app
`vtex deprecate vtex.appone@0.1.0`
`vtex deprecate vtex.appone@0.1.0 vtex.apptwo@0.2.0 -a account`

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
