### PR TITLE
Changed nomenclature from acc to registry

### DIFF
--- a/src/modules/apps/deprecate.ts
+++ b/src/modules/apps/deprecate.ts
@@ -24,8 +24,8 @@ const deprecateApps = async (appsList: string[], registry): Promise<void> => {
 }
 
 export default async (optionalApp: string, options) => {
-  const optionAccount = options ? (options.a || options.account) : null
-  const context = {account: optionAccount || getAccount(), workspace: 'master'}
+  const optionRegistry = options ? (options.r || options.registry) : null
+  const context = {account: optionRegistry || getAccount(), workspace: 'master'}
   const {registry} = createClients(context)
   const appsList = prepend(optionalApp || toAppLocator(await getManifest()), parseArgs(options._))
   log.debug('Deprecating app' + (appsList.length > 1 ? 's' : '') + `: ${appsList.join(', ')}`)

--- a/src/modules/tree.ts
+++ b/src/modules/tree.ts
@@ -65,9 +65,9 @@ export default {
     description: 'Deprecate app(s)',
     options: [
       {
-        short: 'a',
-        long: 'account',
-        description: 'Specify app(s) account',
+        short: 'r',
+        long: 'registry',
+        description: 'Specify the registry for the app(s)',
         type: 'string',
       },
     ],


### PR DESCRIPTION
#### What is the purpose of this pull request?
Small change from `-a` `--account` to `-r` `--registry`, to better align with the other API's