### PR TITLE
fix/publish: Changed default registry to currentAcc and added --public

### DIFF
--- a/src/modules/apps/publish.ts
+++ b/src/modules/apps/publish.ts
@@ -11,13 +11,14 @@ import {id, mapFileObject, parseArgs} from './utils'
 import {listLocalFiles} from './file'
 import {listenBuild} from '../utils'
 import {BuildFailError} from '../../errors'
+import {getAccount} from '../../conf'
 
 const root = process.cwd()
 
 const automaticTag = (version: string): string =>
   version.indexOf('-') > 0 ? null : 'latest'
 
-const publisher = (account: string = 'smartcheckout', workspace: string = 'master') => {
+const publisher = (account: string, workspace: string = 'master') => {
   const context = {account, workspace}
 
   const prePublish = async (files, tag, unlistenBuild) => {
@@ -74,6 +75,8 @@ export default (path: string, options) => {
   const paths = prepend(path || root, parseArgs(options._))
   const registry = options.r || options.registry
   const workspace = options.w || options.workspace
-  const {publishApps} = publisher(registry, workspace)
+  const optionPublic = options.p || options.public
+  const account = optionPublic ? 'smartcheckout' : registry ? registry : getAccount()
+  const {publishApps} = publisher(account, workspace)
   return publishApps(paths, options.tag)
 }

--- a/src/modules/tree.ts
+++ b/src/modules/tree.ts
@@ -57,6 +57,12 @@ export default {
         description: 'Specify the workspace for the app registry',
         type: 'string',
       },
+      {
+        short: 'p',
+        long: 'public',
+        description: 'Use the public registry (smartcheckout)',
+        type: 'boolean',
+      },
     ],
     handler: './apps/publish',
   },


### PR DESCRIPTION
#### What is the purpose of this pull request?
Default registry is now the current account. Use `-p` `--public` to use the public registry (`smartcheckout`). `-p` has priority over `-r`

#### What problem is this solving?
Default registry is no longer `smartcheckout`

#### How should this be manually tested?
`vtex publish -r example_acc`
`vtex publish -p` 