### PR TITLE
fix/cli.ts: Bash now stops running when error occurs

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -129,7 +129,7 @@ const onError = e => {
     }
   }
 
-  process.exit()
+  process.exit(1)
 }
 
 try {


### PR DESCRIPTION
#### What is the purpose of this pull request?
`onError` now exits with `process.exit(1)` instead of `process.exit()`
Motivation: `vtex install && vtex uninstall` would run `uninstall` even when installation failed.


#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
