### PR TITLE
fix/deprecateApp: Changed default registry and 404 behavior

### DIFF
--- a/src/modules/apps/deprecate.ts
+++ b/src/modules/apps/deprecate.ts
@@ -1,4 +1,5 @@
 import {head, tail, prepend} from 'ramda'
+import * as chalk from 'chalk'
 
 import log from '../../logger'
 import {parseArgs} from './utils'
@@ -7,7 +8,7 @@ import {toAppLocator, parseLocator} from './../../locator'
 import {createClients} from '../../clients'
 import {getAccount} from '../../conf'
 
-const deprecateApps = async (appsList: string[], registry): Promise<void> => {
+const deprecateApps = async (appsList: string[], optionAccount: string, registry: any): Promise<void> => {
   if (appsList.length === 0) {
     return
   }
@@ -18,16 +19,23 @@ const deprecateApps = async (appsList: string[], registry): Promise<void> => {
     await registry.deprecateApp(`${vendor}.${name}`, version)
     log.info('Successfully deprecated', app)
   } catch (e) {
-    log.error(`Error deprecating ${app}. ${e.message}. ${e.response.statusText}`)
+    if (e.response.status === 404) {
+      log.error(`Error deprecating ${app}. App not found in registry ${chalk.green(optionAccount)}`)
+      log.info('Please use --public to use the public registry or --registry to specify one')
+    } else {
+      log.error(`Error deprecating ${app}. ${e.message}. ${e.response.statusText}`)
+    }
   }
-  await deprecateApps(tail(appsList), registry)
+  await deprecateApps(tail(appsList), optionAccount, registry)
 }
 
 export default async (optionalApp: string, options) => {
-  const optionRegistry = options ? (options.r || options.registry) : null
-  const context = {account: optionRegistry || getAccount(), workspace: 'master'}
+  const optionRegistry = options.r || options.registry
+  const optionPublic = options.p || options.public
+  const optionAccount = optionPublic ? 'smartcheckout' : optionRegistry ? optionRegistry : getAccount()
+  const context = {account: optionAccount, workspace: 'master'}
   const {registry} = createClients(context)
   const appsList = prepend(optionalApp || toAppLocator(await getManifest()), parseArgs(options._))
   log.debug('Deprecating app' + (appsList.length > 1 ? 's' : '') + `: ${appsList.join(', ')}`)
-  return deprecateApps(appsList, registry)
+  return deprecateApps(appsList, optionAccount, registry)
 }

--- a/src/modules/tree.ts
+++ b/src/modules/tree.ts
@@ -76,6 +76,12 @@ export default {
         description: 'Specify the registry for the app(s)',
         type: 'string',
       },
+      {
+        short: 'p',
+        long: 'public',
+        description: 'Use the public registry (smartcheckout)',
+        type: 'boolean',
+      },
     ],
     handler: './apps/deprecate',
   },


### PR DESCRIPTION
The registry used now works as follows:
- `--public -p` means `account = smartcheckout`
- `--registry -r` means `account = optionalAcc`
- `null` means `account = currentAcc`
- public > registry > null

#### What problem is this solving?
Avoid using the wrong/undesired registry by sending better error messages

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
