### PR TITLE
Check app status to start it on link

### DIFF
--- a/src/modules/apps/utils.ts
+++ b/src/modules/apps/utils.ts
@@ -103,3 +103,7 @@ export const appsLastVersion = (app: string): Bluebird<string | never> => {
     .then(pickLatestVersion)
     .catch(handleError(app))
 }
+
+export const hasServiceOnBuilders = (manifest: Manifest): boolean => {
+  return manifest.builders["service-js"]
+}


### PR DESCRIPTION
#### What is the purpose of this pull request?
Colossus-server doesn't perform the whoami anymore when the app has a service.json declaring routes and events. So the toolbelt must wake up the app's pod when the developer link an app.

#### What problem is this solving?
Toolbelt must wake up the app's pod when the developer link an app.

#### How should this be manually tested?
1 - install this version of toolbelt
2 - link the masterdata-graphql. Check if it starts to running.
3 - link the extension-store. Check if it starts to running.

#### Screenshots or example usage

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
