### PR TITLE
Also send policies.json file to apps

### DIFF
--- a/src/modules/apps/file.ts
+++ b/src/modules/apps/file.ts
@@ -40,7 +40,7 @@ export const getIgnoredPaths = (root: string): string[] => {
 
 export const listLocalFiles = (root: string, folder?: string): Bluebird<string[]> =>
   Promise.resolve(
-    glob(`{manifest.json,${safeFolder(folder)}}`, {
+    glob(`{manifest.json,policies.json,${safeFolder(folder)}}`, {
       cwd: root,
       nodir: true,
       follow: true,

--- a/src/modules/apps/link.ts
+++ b/src/modules/apps/link.ts
@@ -53,7 +53,7 @@ const watchAndSendChanges = (appId, builder: Builder, performInitialLink) => {
     builder.relinkApp(appId, changeQueue.splice(0, changeQueue.length)).catch(initialLinkRequired)
   }, 50)
 
-  const watcher = chokidar.watch(['*/**', 'manifest.json'], {
+  const watcher = chokidar.watch(['*/**', 'manifest.json', 'policies.json'], {
     cwd: root,
     persistent: true,
     ignoreInitial: true,


### PR DESCRIPTION
#### What is the purpose of this pull request?
Include `policies.json` file when sending app files to IO.

#### What problem is this solving?
We need this file to allow apps to define access policies to their canonical endpoints.

#### How should this be manually tested?
Create a `policies.json` file in the app root folder and check that it is sent to the registry both on link and on publish.

#### Screenshots or example usage
`vtex link --verbose`

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
