### PR TITLE
Add debug log with toolbet version

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -57,7 +57,7 @@ const checkLogin = args => {
 const main = async () => {
   const args = process.argv.slice(2)
 
-  await logToolbeltVersion()
+  logToolbeltVersion()
 
   await checkLogin(args)
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add a debug log including the toolbelt version to reduce the number of times information has to go back and forth when a user says something bad is happening.

#### What problem is this solving?
We are never sure if people are using the correct version of toolbelt and it is often something we need to ask people. With this log, any run with `--verbose` will automatically include this info.

#### How should this be manually tested?
Run commands with `--verbose`.

#### Screenshots or example usage
```
$ vtex ls --verbose
15:41:13.232 - debug:   Toolbelt version: 2.17.15
15:41:13.457 - debug:   Starting to list apps
...
```

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
