### PR TITLE
Fix keys query string to subscribe to events

### DIFF
--- a/src/sse.ts
+++ b/src/sse.ts
@@ -43,7 +43,7 @@ const createEventSource = (source: string) =>
 const parseKeyToQueryParameter = (keys: string[]): string => {
   let urlQueryParameters = ''
   forEach(key => {
-    urlQueryParameters += `&keys[]=${key}`
+    urlQueryParameters += `&keys=${key}`
   }, keys)
   return urlQueryParameters
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Use the correct colossus API.

#### What problem is this solving?
Our infra can not authorize the access to /events using `keys[]`.

#### How should this be manually tested?
Linking an app and checking the logs.

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
