### PR TITLE
Fix getting environment from process env

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -1,8 +1,13 @@
 import {Environment, getEnvironment} from './conf'
 
-const env = process.env.VTEX_ENV === 'beta' ?
-    Environment.Staging :
-    (getEnvironment() || Environment.Production)
+const env = fromProcessEnv() || getEnvironment() || Environment.Production
+
+function fromProcessEnv (): Environment {
+  if (!process.env.VTEX_ENV) {
+    return null
+  }
+  return process.env.VTEX_ENV === 'beta' ? Environment.Staging : Environment.Production
+}
 
 export function endpoint (api = 'api'): string {
   switch (api.toLowerCase()) {


### PR DESCRIPTION
To be less confusing, allow the process env also
to set the env to production, by only ignoring it
if it is actually unset.

The other way around, if the user had a configuration
for the staging environment and an env var VTEX_ENV=prod
(or anything different than 'beta'), it'd keep using the
configuration instead of deriving the non-beta environment
from the env var.

This now only falls back to the configuration if the env
var is really not set.