### PR TITLE
Allow forcing production IO env via process env

### DIFF
--- a/src/conf.ts
+++ b/src/conf.ts
@@ -36,6 +36,11 @@ export const getToken = (): string =>
 export const getWorkspace = (): string =>
   conf.get('workspace')
 
+const envFromProcessEnv = {
+  'beta': Environment.Staging,
+  'prod': Environment.Production,
+  'staging': Environment.Staging
+}
 let forcedEnv = null
 
 export const forceEnvironment = (env: Environment) => {
@@ -43,7 +48,7 @@ export const forceEnvironment = (env: Environment) => {
 }
 
 export const getEnvironment = (): Environment => {
-  const env = process.env.VTEX_ENV === 'beta' ? Environment.Staging : null
+  const env = envFromProcessEnv[process.env.VTEX_ENV]
   const persisted = conf.get('env') || Environment.Production
   return forcedEnv || env || persisted
 }


### PR DESCRIPTION
We were only considering the VTEX_ENV variable when it
was set to 'beta' to force toolbelt to use the staging env.

A more useful case tho is to force toolbelt to use
production tho, by considering when the env is set to
'prod' instead. This will allow for VTEX users to keep using
prod if they have some demand for it (case for developing
checkout extensions or GoCommerce apps).

#### What is the purpose of this pull request?
Add support to forcing prod env via process env.

#### What problem is this solving?
Not being able to always use production environment when there is need for it.

#### How should this be manually tested?
Alternate between config and env var to check it's working.

#### Screenshots or example usage
```
vtex config set env staging
VTEX_ENV=prod vtex config get env
"Production"
VTEX_ENV=pro vtex config get env
"Staging"
vtex config set env prod
VTEX_ENV=beta vtex config get env
"Staging"
VTEX_ENV=staging vtex config get env
"Staging"
VTEX_ENV=stag vtex config get env
"Production"
```

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
