### PR TITLE
Treat GraphQL errors as an array of error messages

### DIFF
--- a/src/modules/apps/install.ts
+++ b/src/modules/apps/install.ts
@@ -78,15 +78,20 @@ export const prepareInstall = async (appsList: string[], reg: string): Promise<v
       } else {
         log.error(e.response.data.error)
       }
-    } else if (e instanceof Array) {
-      e.forEach(err => log.error(err.message ? err.message : err))
     } else {
-      log.error(e)
+      logGraphQLErrorMessage(e)
     }
     log.warn(`The following app was not installed: ${app}`)
   }
 
   await prepareInstall(tail(appsList), reg)
+}
+
+const logGraphQLErrorMessage = (e) => {
+  const errorMessage = e instanceof Array
+  ? e.forEach(err => log.error(err.message ? err.message : err))
+  : e
+  log.error(errorMessage)
 }
 
 export default async (optionalApp: string, options) => {


### PR DESCRIPTION
#### What is the purpose of this pull request?
Clear error pollution when treating installation errors via `vtex.billing`

#### What problem is this solving?
Errors from GraphQL often are in the form of an array. Printing them on the screen would always bring message pollution, because all fields of all elements were printed. This small addition prints only the messages of the errors array.

Example of previous message sequence:
```shell
MacBook-Pro-4:visa-checkout-app arturpimentel$ vtex install --verbose
14:26:49.283 - debug:   Toolbelt version: 2.23.0
14:26:49.306 - info:    Logged into extensions as artur.oliveira@vtex.com.br at workspace artur in environment prod
14:26:49.662 - debug:   Installing app: vtex.visa-checkout@1.0.13
14:26:49.662 - debug:   Starting to install app vtex.visa-checkout@1.0.13
14:26:55.820 - error:    message=Failed to find app to install: App vtex.visa-checkout@1.0.13 not found in registries [smartcheckout vtex extensions], locations=[line=2, column=7], path=[install], message=Failed to find app to install: App vtex.visa-checkout@1.0.13 not found in registries [smartcheckout vtex extensions], name=GraphQLError, stack=Error: Failed to find app to install: App vtex.visa-checkout@1.0.13 not found in registries [smartcheckout vtex extensions]
    at /usr/local/app/service/webpack:/node/graphql/index.ts:34:13
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:188:7)
14:26:55.821 - warn:    The following app was not installed: vtex.visa-checkout@1.0.13
```

#### How should this be manually tested?
1. Clone/Pull this repo/branch
2. In the `toolbelt` folder, run `yarn watch`
3. Once compilation is complete, try, for example, to install a not published app, e.g.`vtex install vtex.visa-checkout@1.0.13 --verbose`
4. Now, the toolbelt should display the message like
```shell
MacBook-Pro-4:visa-checkout-app arturpimentel$ vtex install vtex.visa-checkout@1.0.13 --verbose
14:35:08.589 - debug:   Toolbelt version: 2.23.0
14:35:08.616 - info:    Logged into extensions as artur.oliveira@vtex.com.br at workspace artur in environment prod
14:35:08.968 - debug:   Installing app: vtex.visa-checkout@1.0.13
14:35:08.969 - debug:   Starting to install app vtex.visa-checkout@1.0.13
14:35:09.921 - error:   Failed to find app to install: App vtex.visa-checkout@1.0.13 not found in registries [smartcheckout vtex extensions]
14:35:09.921 - warn:    The following app was not installed: vtex.visa-checkout@1.0.13
```

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
