### PR TITLE
Check debugger websocket state before sending data

### DIFF
--- a/src/modules/apps/debugger.ts
+++ b/src/modules/apps/debugger.ts
@@ -69,8 +69,12 @@ function webSocketTunnelHandler (host, path: string, server: net.Server): (socke
 
     ws.on('open', () => {
       socket.on('data', data => {
+        if (ws.readyState !== ws.OPEN) {
+          log.debug(`Tried to write to debugger websocket but it is not opened`)
+          return
+        }
         ws.send(data, err => {
-          if (err && err.message !== 'not opened') {
+          if (err) {
             log.error(`Error writing to debugger websocket: ${err.name}: ${err.message}`)
           }
         })


### PR DESCRIPTION
#### What is the purpose of this pull request?
Check debugger websocket connection state before passing on data from local socket.
Toolbelt was ignoring this check and omitting the error message for this case.

#### What problem is this solving?
Unhelpful error messages polluting console.
```error:    Error: WebSocket is not open: readyState 2 (CLOSING)```

#### How should this be manually tested?
Link an app and attach debugger.

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
