### PR TITLE
Include dotfiles to link and publish

### DIFF
--- a/src/modules/apps/file.ts
+++ b/src/modules/apps/file.ts
@@ -45,6 +45,7 @@ export const listLocalFiles = (root: string, folder?: string): Bluebird<string[]
   Promise.resolve(
     glob(`{manifest.json,policies.json,${safeFolder(folder)}}`, {
       cwd: root,
+      dot: true,
       follow: true,
       ignore: getIgnoredPaths(root),
       nodir: true,


### PR DESCRIPTION
#### What is the purpose of this pull request?
It includes dotfiles when using `vtex link` and `vtex publish`
<!--- Describe your changes in detail. -->

#### What problem is this solving?
Dotfiles are being ignored
<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
