### PR TITLE
Use YYYY-MM-DD HH:mm:ss.SSS date format on toolbelt verbose mode

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -32,7 +32,7 @@ const isVerbose = process.argv.indexOf(VERBOSE) >= 0
 if (isVerbose) {
   log.level = 'debug'
   log.default.transports.console['timestamp'] = () =>
-    chalk.grey(moment().format('HH:mm:ss.SSS'))
+    chalk.grey(moment().format('YYYY-MM-DD HH:mm:ss.SSS'))
 }
 
 if (process.env.NODE_ENV === 'development') {


### PR DESCRIPTION
#### What is the purpose of this pull request?
Use `YYYY-MM-DD HH:mm:ss.SSS` date format on toolbelt verbose mode.

#### What problem is this solving?
`vtex` toolbelt's verbose mode timestamp displays just the time of the log. This logs the whole datetime object instead.

#### How should this be manually tested?
`vtex link --verbose`

#### Screenshots or example usage
<img width="899" alt="screen shot 2018-09-24 at 14 08 54" src="https://user-images.githubusercontent.com/7853668/45967181-95797500-c003-11e8-80da-76b8f1467455.png">

