### PR TITLE
Stop npmignoring scripts/prompt.bash

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -20,4 +20,5 @@ tslint.json
 tsconfig.json
 coverage/
 scripts/
+!scripts/prompt.bash
 yarn.lock


### PR DESCRIPTION
`.npmignore` ignores the entire `scripts` folder.
As it stands, this doesn't work: https://github.com/vtex/toolbelt#customizing-your-prompt

This PR makes it work again, by opening an exception to `scripts/prompt.bash` on `.npmignore`.

#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
