### PR TITLE
Fix prompt.bash PS1

### DIFF
--- a/plugins/bash/prompt.bash
+++ b/plugins/bash/prompt.bash
@@ -1,11 +1,13 @@
 toolbeltify_prompt() {
     if [ -z "$PS1_BAK" ]; then
     	PS1_BAK=$PS1
-	export PS1_BAK
+      export PS1_BAK
     fi
 
-    local suffix=${PS1_BAK:(-2)}
-    PS1="${PS1_BAK::-2}$(__vtex_ps1)$suffix"
+    local len=${#PS1_BAK}
+    local prefix="${PS1_BAK:0:($len - 3)}"
+    local suffix="${PS1_BAK: -3}"
+    PS1="$prefix $(__vtex_ps1)$suffix"
     export PS1
 }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
Previously, it was sending an error message on getting a substring of the previous PS1 prompt message on certain versions of `bash`. This fixes that issue.

#### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
