### PR TITLE
Add toggle check before publish an app

### DIFF
--- a/src/modules/apps/publish.ts
+++ b/src/modules/apps/publish.ts
@@ -90,7 +90,7 @@ const publisher = (workspace: string = 'master') => {
   const checkActiveToggle = async (): Promise<any> => {
     const http = axios.create({
       baseURL: `https://vtex.myvtex.com`,
-      timeout: 15000,
+      timeout: 10000,
     })
     try {
       const res = await http.get('/_v/private/builder/0/toggle')
@@ -109,7 +109,7 @@ const publisher = (workspace: string = 'master') => {
 
     const activeToggle = await checkActiveToggle()
     if (activeToggle.isActive) {
-      const confirmPublishingMsg = `We need a confirmation to continue. Reason: ${activeToggle.cause}.\nEnter the name of the app to continue (ex: vtex.getting-started):`
+      const confirmPublishingMsg = `Are you absolutely sure? ${activeToggle.message ? activeToggle.message : ""}\nPlease type in the name of the app to confirm (ex: vtex.getting-started):`
       const appNameInput = await promptConfirmPublishing(confirmPublishingMsg)
       const appToBePublished = `${manifest.vendor}.${manifest.name}`
       if (appNameInput != appToBePublished) {


### PR DESCRIPTION
#### What is the purpose of this pull request?
Publish an app is a sensitive operation, once housekeeping will update all accounts which are using it. We want to add one more confirmation when some events are happening. If the user really needs to publish a new version of an app, he/she should enter with the app name which is been published.

The check to verify if this confirmation is really necessary can be done with a request to a builder-hub public path at `vtex` account. The path can also return a message with the reason of this confirmation.

#### What problem is this solving?
Make sure the user really wants to publish a new app version and update the accounts which are using it. This is important for events like Black Week, when the publishing process become still more sensitive.

#### How should this be manually tested?
- Install a beta `builder-hub` with the new path at `vtex` account and set the toggle of this account;
- Run toolbelt locally and try to publish an app.

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
