### PR TITLE
Fetch typings for react apps

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "babel-eslint": "^8.2.2",
     "bluebird": "^3.5.0",
     "chalk": "^2.3.2",
+    "child-process-es6-promise": "^1.2.0",
     "chokidar": "^2.0.4",
     "clear-module": "^3.0.0",
     "cli-table": "^0.3.1",
@@ -87,7 +88,8 @@
     "unzip-stream": "^0.3.0",
     "update-notifier": "^2.3.0",
     "winston": "^2.4.0",
-    "ws": "^6.0.0"
+    "ws": "^6.0.0",
+    "yarn": "^1.9.4"
   },
   "preferGlobal": true,
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.36.1",
+  "version": "2.37.0",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/modules/apps/link.ts
+++ b/src/modules/apps/link.ts
@@ -136,7 +136,7 @@ const warnAndLinkFromStart = (appId: string, builder: Builder, extraData: { link
   return null
 }
 
-const watchAndSendChanges = async (appId: string, builder: Builder, extraData : {linkConfig : LinkConfig}, manifest: Manifest, context: any): Promise<any> => {
+const watchAndSendChanges = async (appId: string, builder: Builder, extraData : {linkConfig : LinkConfig}): Promise<any> => {
   const changeQueue: Change[] = []
 
   const onInitialLinkRequired = e => {
@@ -201,7 +201,6 @@ const watchAndSendChanges = async (appId: string, builder: Builder, extraData : 
     watcher
       .on('add', (file, { size }) => size > 0 ? queueChange(file) : null)
       .on('change', (file, { size }) => {
-        if (!/package\.json$/.test(file)) { getTypings(manifest, context.account, context.workspace, context.environment) }
         return size > 0
           ? queueChange(file)
           : queueChange(file, true)
@@ -338,5 +337,5 @@ export default async (options) => {
       process.exit()
     })
 
-  await watchAndSendChanges(appId, builder, extraData, manifest, context)
+  await watchAndSendChanges(appId, builder, extraData)
 }

--- a/src/modules/apps/link.ts
+++ b/src/modules/apps/link.ts
@@ -278,7 +278,7 @@ export default async (options) => {
   try {
     const buildTrigger = performInitialLink.bind(this, appId, builder, extraData)
     const [subject] = appId.split('@')
-    const { unlisten } = await listenBuild(subject, buildTrigger, { waitCompletion: true, onBuild, onError })
+    const { unlisten } = await listenBuild(subject, buildTrigger, { waitCompletion: false, onBuild, onError })
     unlistenBuild = unlisten
   } catch (e) {
     if (e.response) {

--- a/src/modules/apps/link.ts
+++ b/src/modules/apps/link.ts
@@ -46,6 +46,7 @@ const typingsInfo = async (workspace: string, account: string, environment: stri
     const res = await http.get(`/_v/private/builder/0/typings`)
     return res.data.typingsInfo
   } catch (e) {
+    log.error('Unable to get typings info from vtex.builder-hub')
     return {}
   }
 }

--- a/src/modules/apps/link.ts
+++ b/src/modules/apps/link.ts
@@ -4,13 +4,13 @@ import chalk from 'chalk'
 import {execSync} from 'child-process-es6-promise'
 import * as chokidar from 'chokidar'
 import * as debounce from 'debounce'
-import { existsSync, readFileSync, writeFileSync } from 'fs'
+import { readFileSync } from 'fs'
+import { outputJson, pathExists, readJson } from 'fs-extra'
 import * as moment from 'moment'
 import { join, resolve as resolvePath, sep} from 'path'
-import { concat, has, isEmpty, map, merge, pipe, prop, toPairs } from 'ramda'
+import { concat, equals, has, isEmpty, isNil, map, mapObjIndexed, merge, path as ramdaPath, pipe, prop, reject as ramdaReject, toPairs, values } from 'ramda'
 import { createInterface } from 'readline'
 import { createClients } from '../../clients'
-import {apps} from '../../clients'
 import { getAccount, getEnvironment, getWorkspace } from '../../conf'
 import { CommandError } from '../../errors'
 import { getMostAvailableHost } from '../../host'
@@ -18,12 +18,12 @@ import { toAppLocator } from '../../locator'
 import log from '../../logger'
 import { getManifest } from '../../manifest'
 import { listenBuild } from '../build'
-import { formatNano} from '../utils'
+import { formatNano } from '../utils'
 import startDebuggerTunnel from './debugger'
 import { createLinkConfig, getIgnoredPaths, getLinkedDepsDirs, getLinkedFiles, listLocalFiles } from './file'
 import legacyLink from './legacyLink'
 import lint from './lint'
-import { checkBuilderHubMessage, pathToFileObject, showBuilderHubMessage, validateAppAction } from './utils'
+import { checkBuilderHubMessage, pathToFileObject, resolveAppId, showBuilderHubMessage, validateAppAction } from './utils'
 
 const root = process.cwd()
 const DELETE_SIGN = chalk.red('D')
@@ -36,17 +36,16 @@ const yarn = join(__dirname, '../../../node_modules/yarn/bin/yarn.js install --f
 
 const resolvePackageJsonPath = (builder: string) => resolvePath(process.cwd(), `${builder}/package.json`)
 
-const resolveAppId = async (appName: string, appVersion: string) => await apps.getApp(`${appName}@${appVersion}`).then(prop('id'))
 
-const injectedDependencies = async (builderName: string, builderVersion: string, workspace: string, account: string, environment: string) => {
+const typingsInfo = async (workspace: string, account: string, environment: string) => {
   const extension = (environment === 'prod') ? 'myvtex' : 'myvtexdev'  // Remove this
   const http = axios.create({
     baseURL: `https://${workspace}--${account}.${extension}.com`, // change this route!!!
     timeout: builderHubInjectedDepsTimeout,
   })
   try {
-    const res = await http.get(`/_v/private/builder/0/getdeps/${builderName}/${builderVersion}`)
-    return res.data
+    const res = await http.get(`/_v/private/builder/0/typings`)
+    return res.data.typingsInfo
   } catch (e) {
     return {}
   }
@@ -59,42 +58,74 @@ const appTypingsURL = async (account: string, workspace: string, environment: st
   return `https://${workspace}--${account}.${extension}.com/_v/private/typings/${typingsPath}/${appId}/${builder}` // change this route!!!!!!
 }
 
-const appsWithTypingsURLs = async (builder: string, account: string, workspace: string, environment: string, appDependencies: {[key: string]: string}) => {
-  const result: {[key: string]: string} = {}
+const appsWithTypingsURLs = async (builder: string, account: string, workspace: string, environment: string, appDependencies: Record<string, any>) => {
+  const result: Record<string, any> = {}
   for (const [appName, appVersion] of Object.entries(appDependencies)) {
     result[appName] = await appTypingsURL(account, workspace, environment, appName, appVersion, builder)
   }
   return result
 }
 
-const mergeDevDeps = (currentPackageJson: {[key: string]: any}, newDevDepsEntries: {[key: string]: string}) =>
-  merge(currentPackageJson.devDependencies, newDevDepsEntries)
-
-const runYarn = () => {
+const runYarn = (relativePath: string) => {
   log.info('Running yarn in ./react/')
-  process.chdir('./react')
+  process.chdir(`./${relativePath}`)
   execSync(yarn, {stdio: 'inherit'})
   process.chdir('../')
   log.info('Finished running yarn')
 }
 
-const getTypings = async (builder: string, manifest: Manifest, account: string, workspace: string, environment: string) => {
-  const packageJsonPath = resolvePackageJsonPath(builder)
-  if (existsSync(packageJsonPath)) {
-    if (has(builder, manifest.builders)) {
-      const declaredDependencies = manifest.dependencies
-      const implicitDependencies = await injectedDependencies(builder, manifest.builders[builder], workspace, account, environment)
-      const appDependencies = merge(declaredDependencies, implicitDependencies)
-      if (appDependencies) {
-        log.info('Exporting app dependencies to react/package.json')
-        const reactPackageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'))
-        const newDevDepsEntries = await appsWithTypingsURLs(builder, account, workspace, environment, appDependencies)
-        reactPackageJson.devDependencies = mergeDevDeps(reactPackageJson, newDevDepsEntries)
-        writeFileSync(packageJsonPath, JSON.stringify(reactPackageJson, null, 2))
-        runYarn()
+const getTypings = async (manifest: Manifest, account: string, workspace: string, environment: string) => {
+  const typingsData = await typingsInfo(workspace, account, environment)
+
+  const buildersWithInjectedDeps =
+    pipe(
+      prop('builders'),
+      mapObjIndexed(
+        (version: string, builder: string) => {
+          const builderTypingsData = prop(builder, typingsData)
+          if (builderTypingsData && has(version, builderTypingsData)) {
+            return ramdaPath([version, 'injectedDependencies'], builderTypingsData)
+          }
+          return null
+        }
+      ),
+      ramdaReject(isNil)
+    )(manifest)
+
+  const buildersWithAppDeps =
+    pipe(
+      mapObjIndexed(
+        (injectedDependencies) => merge(manifest.dependencies, injectedDependencies)
+      ),
+      ramdaReject(isEmpty)
+    )(buildersWithInjectedDeps as Record<string, any>)
+
+  const buildersToRunYarn = await pipe(
+    mapObjIndexed(
+      async (appDeps: Record<string, any>, builder: string) => {
+        const packageJsonPath = resolvePackageJsonPath(builder)
+        if (await pathExists(packageJsonPath)) {
+          const packageJson = await readJson(packageJsonPath)
+          const oldDevDeps = packageJson.devDependencies
+          const newDevDeps = await appsWithTypingsURLs(builder, account, workspace, environment, appDeps)
+          const mergedDevDeps = merge(oldDevDeps, newDevDeps)
+          if (!equals(oldDevDeps, mergedDevDeps)) {
+            await outputJson(
+              packageJsonPath,
+              { ...packageJson, ...{ 'devDependencies': mergedDevDeps } },
+              { spaces: '\t' }
+            )
+            return builder
+          }
+        }
+        return null
       }
-    }
-  }
+    ),
+    values,
+    Promise.all
+  )(buildersWithAppDeps as Record<string, any>)
+
+  map(runYarn)(ramdaReject(isNil, buildersToRunYarn))
 }
 
 const warnAndLinkFromStart = (appId: string, builder: Builder, extraData: { linkConfig: LinkConfig } = { linkConfig: null }) => {
@@ -103,7 +134,7 @@ const warnAndLinkFromStart = (appId: string, builder: Builder, extraData: { link
   return null
 }
 
-const watchAndSendChanges = async (appId: string, builder: Builder, extraData : {linkConfig : LinkConfig}): Promise<any> => {
+const watchAndSendChanges = async (appId: string, builder: Builder, extraData : {linkConfig : LinkConfig}, manifest: Manifest, context: any): Promise<any> => {
   const changeQueue: Change[] = []
 
   const onInitialLinkRequired = e => {
@@ -168,6 +199,7 @@ const watchAndSendChanges = async (appId: string, builder: Builder, extraData : 
     watcher
       .on('add', (file, { size }) => size > 0 ? queueChange(file) : null)
       .on('change', (file, { size }) => {
+        getTypings(manifest, context.account, context.workspace, context.environment)
         return size > 0
           ? queueChange(file)
           : queueChange(file, true)
@@ -245,7 +277,7 @@ export default async (options) => {
 
   const appId = toAppLocator(manifest)
   const context = { account: getAccount(), workspace: getWorkspace(), environment: getEnvironment() }
-  await getTypings('react', manifest, context.account, context.workspace, context.environment)  // remove the await?
+  await getTypings(manifest, context.account, context.workspace, context.environment)
   const { builder } = createClients(context, { timeout: 60000 })
 
   if (options.c || options.clean) {
@@ -304,5 +336,5 @@ export default async (options) => {
       process.exit()
     })
 
-  await watchAndSendChanges(appId, builder, extraData)
+  await watchAndSendChanges(appId, builder, extraData, manifest, context)
 }

--- a/src/modules/apps/link.ts
+++ b/src/modules/apps/link.ts
@@ -37,9 +37,9 @@ const resolvePackageJsonPath = (builder: string) => resolvePath(process.cwd(), `
 
 
 const typingsInfo = async (workspace: string, account: string, environment: string) => {
-  const extension = (environment === 'prod') ? 'myvtex' : 'myvtexdev'  // Remove this
+  const extension = (environment === 'prod') ? 'myvtex' : 'myvtexdev'
   const http = axios.create({
-    baseURL: `https://${workspace}--${account}.${extension}.com`, // change this route!!!
+    baseURL: `https://${workspace}--${account}.${extension}.com`,
     timeout: builderHubInjectedDepsTimeout,
   })
   try {
@@ -52,10 +52,10 @@ const typingsInfo = async (workspace: string, account: string, environment: stri
 }
 
 const appTypingsURL = async (account: string, workspace: string, environment: string, appName: string, appVersion: string, builder: string): Promise<string> => {
-  const extension = (environment === 'prod') ? 'myvtex' : 'myvtexdev'  // Remove this
+  const extension = (environment === 'prod') ? 'myvtex' : 'myvtexdev'
   const appId = await resolveAppId(appName, appVersion)
   const typingsPath = isLinked({'version': appId}) ? 'linked/v1' : 'v1'
-  return `https://${workspace}--${account}.${extension}.com/_v/private/typings/${typingsPath}/${appId}/${builder}` // change this route!!!!!!
+  return `https://${workspace}--${account}.${extension}.com/_v/private/typings/${typingsPath}/${appId}/${builder}`
 }
 
 const appsWithTypingsURLs = async (builder: string, account: string, workspace: string, environment: string, appDependencies: Record<string, any>) => {

--- a/src/modules/apps/link.ts
+++ b/src/modules/apps/link.ts
@@ -23,7 +23,7 @@ import startDebuggerTunnel from './debugger'
 import { createLinkConfig, getIgnoredPaths, getLinkedDepsDirs, getLinkedFiles, listLocalFiles } from './file'
 import legacyLink from './legacyLink'
 import lint from './lint'
-import { checkBuilderHubMessage, pathToFileObject, resolveAppId, showBuilderHubMessage, validateAppAction } from './utils'
+import { checkBuilderHubMessage, pathToFileObject, isLinked, resolveAppId, showBuilderHubMessage, validateAppAction } from './utils'
 
 const root = process.cwd()
 const DELETE_SIGN = chalk.red('D')
@@ -54,7 +54,7 @@ const typingsInfo = async (workspace: string, account: string, environment: stri
 const appTypingsURL = async (account: string, workspace: string, environment: string, appName: string, appVersion: string, builder: string): Promise<string> => {
   const extension = (environment === 'prod') ? 'myvtex' : 'myvtexdev'  // Remove this
   const appId = await resolveAppId(appName, appVersion)
-  const typingsPath = /\+build/.test(appId) ? 'linked/v1' : 'v1'
+  const typingsPath = isLinked(appId) ? 'linked/v1' : 'v1'
   return `https://${workspace}--${account}.${extension}.com/_v/private/typings/${typingsPath}/${appId}/${builder}` // change this route!!!!!!
 }
 

--- a/src/modules/apps/update.ts
+++ b/src/modules/apps/update.ts
@@ -2,14 +2,14 @@ import * as Bluebird from 'bluebird'
 import * as Table from 'cli-table'
 import * as inquirer from 'inquirer'
 import * as ora from 'ora'
-import { contains, isEmpty, map, pipe, prop, propSatisfies, reject } from 'ramda'
+import { isEmpty, map, pipe, prop, reject } from 'ramda'
 
 import { apps } from '../../clients'
 import { parseLocator, toAppLocator } from '../../locator'
 import log from '../../logger'
 import { diffVersions } from '../infra/utils'
 import { prepareInstall } from './install'
-import { appLatestVersion } from './utils'
+import { appLatestVersion, isLinked } from './utils'
 
 const { listApps } = apps
 
@@ -26,8 +26,6 @@ const promptUpdate = (): Bluebird<boolean> =>
 const sameVersion = ({ version, latest }: Manifest) => version === latest
 
 const extractAppLocator = pipe(prop('app'), parseLocator)
-
-const isLinked = propSatisfies<string, Manifest>(contains('+build'), 'version')
 
 const updateVersion = (app) => {
   app.version = app.latest

--- a/src/modules/apps/utils.ts
+++ b/src/modules/apps/utils.ts
@@ -4,7 +4,7 @@ import * as Table from 'cli-table2'
 import { createReadStream } from 'fs-extra'
 import * as inquirer from 'inquirer'
 import { join } from 'path'
-import { __, compose, concat, contains, curry, drop, head, last, prop, reduce, split, tail } from 'ramda'
+import { __, compose, concat, contains, curry, drop, head, last, prop, propSatisfies, reduce, split, tail } from 'ramda'
 import * as semverDiff from 'semver-diff'
 
 import { apps, createClients } from '../../clients'
@@ -190,3 +190,5 @@ export const switchAccountMessage = (previousAccount: string, currentAccount: st
 }
 
 export const resolveAppId = async (appName: string, appVersion: string) =>  await apps.getApp(`${appName}@${appVersion}`).then(prop('id'))
+
+export const isLinked = propSatisfies<string, Manifest>(contains('+build'), 'version')

--- a/src/modules/apps/utils.ts
+++ b/src/modules/apps/utils.ts
@@ -7,7 +7,7 @@ import { join } from 'path'
 import { __, compose, concat, contains, curry, drop, head, last, prop, reduce, split, tail } from 'ramda'
 import * as semverDiff from 'semver-diff'
 
-import { createClients } from '../../clients'
+import { apps, createClients } from '../../clients'
 import { getWorkspace } from '../../conf'
 import { CommandError, UserCancelledError } from '../../errors'
 import log from '../../logger'
@@ -188,3 +188,5 @@ export async function showBuilderHubMessage(message: string, showPrompt: boolean
 export const switchAccountMessage = (previousAccount: string, currentAccount: string): string => {
   return `Now you are logged in ${chalk.blue(currentAccount)}. Do you want to return to ${chalk.blue(previousAccount)} account?`
 }
+
+export const resolveAppId = async (appName: string, appVersion: string) =>  await apps.getApp(`${appName}@${appVersion}`).then(prop('id'))

--- a/src/modules/apps/utils.ts
+++ b/src/modules/apps/utils.ts
@@ -23,7 +23,7 @@ const workspaceMasterAllowedOperations = [
   'uninstall',
 ]
 
-export const builderHubMessagesLinkTimeout = 2000  // 2 seconds
+const builderHubMessagesLinkTimeout = 2000  // 2 seconds
 const builderHubMessagesPublishTimeout = 10000  // 10 seconds
 
 export const workspaceMasterMessage =

--- a/src/modules/apps/utils.ts
+++ b/src/modules/apps/utils.ts
@@ -23,7 +23,7 @@ const workspaceMasterAllowedOperations = [
   'uninstall',
 ]
 
-const builderHubMessagesLinkTimeout = 2000  // 2 seconds
+export const builderHubMessagesLinkTimeout = 2000  // 2 seconds
 const builderHubMessagesPublishTimeout = 10000  // 10 seconds
 
 export const workspaceMasterMessage =

--- a/src/modules/tree.ts
+++ b/src/modules/tree.ts
@@ -104,6 +104,12 @@ export default {
         short: 'c',
         type: 'boolean',
       },
+      {
+        description: 'Add app dependencies to package.json and run Yarn',
+        long: 'install',
+        short: 'i',
+        type: 'boolean',
+      },
     ],
   },
   list: {

--- a/src/typings/global.d.ts
+++ b/src/typings/global.d.ts
@@ -21,10 +21,8 @@ declare global {
     title?: string,
     vendor?: string,
     version: string,
-    dependencies?: {},
-    builders?: {
-      [builder: string]: string
-    },
+    dependencies?: Record<string, string>,
+    builders?: Record<string, string>,
     settingsSchema?: {},
     description?: string,
     categories?: string[],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1540,6 +1540,11 @@ chardet@^0.7.0:
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
 
+child-process-es6-promise@^1.2.0:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/child-process-es6-promise/-/child-process-es6-promise-1.2.1.tgz#3634950521b49d5cad9735cbcc8d69cf1e4d0cab"
+  integrity sha512-ekKf2tD+2B2AZvLBhrBb44oelJSjeBkG3dZHpF5oIC9xhePhI3cAMqxyAxLMmskpc81GfCodSRh29wshnsOd/g==
+
 chokidar@^1.4.2:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-1.7.0.tgz#798e689778151c8076b4b360e5edd28cda2bb468"
@@ -6423,6 +6428,11 @@ yargs@11.1.0:
     which-module "^2.0.0"
     y18n "^3.2.1"
     yargs-parser "^9.0.2"
+
+yarn@^1.9.4:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.13.0.tgz#affa9c956739548024068532a902cf18c9cb523f"
+  integrity sha512-Unfw2eefv8imt4ZMPhvFVP44WCz38huDxkHs+Yqrx4wBTK75Tr0mh3V4rh+2Nw5iQq0rcM/VafotCZo9qTb5DA==
 
 zip-stream@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
This commit affects the `vtex link` command in the following way:


- In the beginning of the linking process, checks for app dependencies in
  manifest.json. These dependencies are then added to react/package.json as
  `devDependencies`, pointing to endpoints in vtex.asset-server (https://github.com/vtex/asset-server/pull/12).
- Also asks vtex.builder-hub if it injects any dependencies in this app. vtex.builder-hub answer contains only dependencies that export components that the user is supposed to use in his app (only render-runtime, for the time being).
- `yarn --force` is run in the `react` folder, in order to fetch typings and
  install other dependencies.

The above procedures are carried out once for each `vtex link`.

#### Test it:

- Clone asset-server (vtex/asset-server#12). Link it with `vtex link`.
- Clone builder-hub (vtex/builder-hub#272). Link it with `vtex link`.
- Clone this repo and checkout this branch.
- `yarn install && yarn watch` in this branch.
- Extract these two apps: 
[testGenerateTypings.zip](https://github.com/vtex/toolbelt/files/2750090/testGenerateTypings.zip)
[testFetchTypings.zip](https://github.com/vtex/toolbelt/files/2750091/testFetchTypings.zip)
- link the `testGenerateTypings` app. builder-hub will generate its typings.
- `alias vtex=path_to_local_repo/lib/cli.js`
- link the `testFetchTypings` app. Toolbelt will fetch its typings from asset-server. If you look in `react/index.tsx`, there will be no tsc warnings. You can also access components exported by render-runtime because their typings are in the `node_modules` folder.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
