### PR TITLE
Add support for builder-hub messages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: node_js
 node_js:
-- 6
+- 8
 cache:
   directories:
   - node_modules

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.33.0",
+  "version": "2.34.0",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/modules/apps/link.ts
+++ b/src/modules/apps/link.ts
@@ -5,7 +5,7 @@ import * as debounce from 'debounce'
 import { readFileSync } from 'fs'
 import * as moment from 'moment'
 import { join, resolve as resolvePath, sep} from 'path'
-import { concat, map, pipe, toPairs } from 'ramda'
+import { concat, isEmpty, map, pipe, toPairs } from 'ramda'
 import { createInterface } from 'readline'
 import lint from './lint'
 
@@ -21,7 +21,7 @@ import { formatNano } from '../utils'
 import startDebuggerTunnel from './debugger'
 import { createLinkConfig, getIgnoredPaths, getLinkedDepsDirs, getLinkedFiles, listLocalFiles } from './file'
 import legacyLink from './legacyLink'
-import { pathToFileObject, validateAppAction } from './utils'
+import { checkBuilderHubMessage, pathToFileObject, showBuilderHubMessage, validateAppAction } from './utils'
 
 const root = process.cwd()
 const DELETE_SIGN = chalk.red('D')
@@ -160,6 +160,10 @@ const performInitialLink = async (appId: string, builder: Builder, extraData : {
 export default async (options) => {
   await validateAppAction('link')
   const manifest = await getManifest()
+  const builderHubMessage = await checkBuilderHubMessage('link')
+  if (!isEmpty(builderHubMessage)) {
+    await showBuilderHubMessage(builderHubMessage.message, builderHubMessage.prompt, manifest)
+  }
 
   if (manifest.builders.render
     || manifest.builders['functions-ts']

--- a/src/modules/apps/utils.ts
+++ b/src/modules/apps/utils.ts
@@ -148,7 +148,7 @@ export function optionsFormatter(billingOptions: BillingOptions) {
 
 export async function checkBuilderHubMessage(cliRoute: string): Promise<any> {
   const http = axios.create({
-    baseURL: `https://calasans--basedevmkp.myvtexdev.com`,
+    baseURL: `https://vtex.myvtex.com`,
     timeout: 10000,
   })
   try {
@@ -177,7 +177,7 @@ export async function showBuilderHubMessage(message: string, showPrompt: boolean
         throw new CommandError(`${appNameInput} doesn't match with the app name.`)
       }
     } else {
-      console.log(message)
+      log.info(message)
     }
   }
 }

--- a/src/modules/apps/utils.ts
+++ b/src/modules/apps/utils.ts
@@ -1,3 +1,4 @@
+import axios from 'axios'
 import chalk from 'chalk'
 import * as Table from 'cli-table2'
 import { createReadStream } from 'fs-extra'
@@ -143,4 +144,40 @@ export function optionsFormatter(billingOptions: BillingOptions) {
   }
   table.push([{ content: chalk.bold('Terms of use:'), hAlign: 'center' }, { content: billingOptions.termsURL, hAlign: 'center' }])
   return table.toString()
+}
+
+export async function checkBuilderHubMessage(cliRoute: string): Promise<any> {
+  const http = axios.create({
+    baseURL: `https://calasans--basedevmkp.myvtexdev.com`,
+    timeout: 10000,
+  })
+  try {
+    const res = await http.get(`/_v/private/builder/0/getmessage/${cliRoute}`)
+    return res.data
+  } catch (e) {
+    return {}
+  }
+}
+
+const promptConfirm = (msg: string): Promise<string> =>
+  inquirer.prompt({
+    message: msg,
+    name: 'appName',
+    type: 'input',
+  })
+    .then<string>(prop('appName'))
+
+export async function showBuilderHubMessage(message: string, showPrompt: boolean, manifest: Manifest) {
+  if(message) {
+    if (showPrompt) {
+      const confirmMsg = `Are you absolutely sure?\n${message ? message : ''}\nPlease type in the name of the app to confirm (ex: vtex.getting-started):`
+      const appNameInput = await promptConfirm(confirmMsg)
+      const AppName = `${manifest.vendor}.${manifest.name}`
+      if (appNameInput !== AppName) {
+        throw new CommandError(`${appNameInput} doesn't match with the app name.`)
+      }
+    } else {
+      console.log(message)
+    }
+  }
 }

--- a/src/modules/apps/utils.ts
+++ b/src/modules/apps/utils.ts
@@ -23,6 +23,9 @@ const workspaceMasterAllowedOperations = [
   'uninstall',
 ]
 
+const builderHubMessagesLinkTimeout = 2000  // 2 seconds
+const builderHubMessagesPublishTimeout = 10000  // 10 seconds
+
 export const workspaceMasterMessage =
   `This action is ${chalk.red('not allowed')} in workspace ${chalk.green('master')}, please use another workspace.
 You can run "${chalk.blue(`vtex use ${workspaceExampleName} -r`)}" to use a workspace named "${chalk.green(workspaceExampleName)}"`
@@ -149,7 +152,7 @@ export function optionsFormatter(billingOptions: BillingOptions) {
 export async function checkBuilderHubMessage(cliRoute: string): Promise<any> {
   const http = axios.create({
     baseURL: `https://vtex.myvtex.com`,
-    timeout: 10000,
+    timeout: (cliRoute === 'link') ? builderHubMessagesLinkTimeout : builderHubMessagesPublishTimeout,
   })
   try {
     const res = await http.get(`/_v/private/builder/0/getmessage/${cliRoute}`)


### PR DESCRIPTION
This commit adds support for VTEX/builder-hub messages, replacing
the `toggle` routes.

Check https://github.com/vtex/builder-hub/pull/280 for more information.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
