### PR TITLE
Remove missing / broken app examples in vtex init

### DIFF
--- a/src/modules/init/index.ts
+++ b/src/modules/init/index.ts
@@ -15,10 +15,7 @@ const currentFolderName = process.cwd().replace(/.*\//, '')
 const templates = {
   'react getting-started': 'render-getting-started',
   'graphql getting-started': 'product-review-graphql-example',
-  'react+graphql': 'catalogue',
-  'hello graphql': 'hello-graphql',
-  'hello react': 'hello-react',
-  'dreamstore getting-started': 'dreamstore-getting-started',
+  'react+graphql': 'render-guide',
 }
 
 const promptName = async () => {


### PR DESCRIPTION
#### What is the purpose of this pull request?
`vtex init` currently provides some broken examples. Thus this PR:
- fixes repo that have been renamed (`catalogue` -> `render-guide`)  
- removes examples from repos that no longer exist (`hello-graphql` and `hello-react`)
- removes an example that seems to be 'work in progress' (build for `dreamstore-getting-started` does not go through).

#### How should this be manually tested?
- Link (in the `yarn` sense) this version of `toolbelt`: `cd <toolbelt-folder> && yarn link`.
- Run `vtex init` and try to link (in the `VTEX IO` sense) each of the examples.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
