### PR TITLE
Handle error when publish fails

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.34.1",
+  "version": "2.34.2",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/modules/apps/publish.ts
+++ b/src/modules/apps/publish.ts
@@ -122,10 +122,7 @@ const publisher = (workspace: string = 'master') => {
             spinner.succeed(`${appId} was published successfully!`)
         }
       } catch (e) {
-        spinner.fail(`Fail to publish ${appId}`)
-        log.error(e.message)
-        await switchToPreviousAccount(previousAccount, previousWorkspace)
-        throw e
+        spinner.fail(`Failed to publish ${appId}`)
       }
     }
     await switchToPreviousAccount(previousAccount, previousWorkspace)


### PR DESCRIPTION
This commit changes toolbelt's behaviour whenever a `publish` command fails:

- Stop throwing 'Something exploded'.
- Reduce the amount of error messages that appear.


#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
