### PR TITLE
Implement `vtex undeprecate`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.35.0",
+  "version": "2.36.0",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/modules/apps/deprecate.ts
+++ b/src/modules/apps/deprecate.ts
@@ -10,14 +10,11 @@ import log from '../../logger'
 import { getManifest, validateApp } from '../../manifest'
 import switchAccount from '../auth/switch'
 import { parseLocator, toAppLocator } from './../../locator'
-import { parseArgs } from './utils'
+import { parseArgs, switchAccountMessage } from './utils'
 
 let originalAccount
 let originalWorkspace
 
-const switchAccountMessage = (previousAccount: string, currentAccount: string): string => {
-  return `Now you are logged in ${chalk.blue(currentAccount)}. Do you want to return to ${chalk.blue(previousAccount)} account?`
-}
 
 const switchToVendorMessage = (vendor: string): string => {
   return `You are trying to deprecate this app in an account that differs from the indicated vendor. Do you want to deprecate in account ${chalk.blue(vendor)}?`

--- a/src/modules/apps/undeprecate.ts
+++ b/src/modules/apps/undeprecate.ts
@@ -41,7 +41,8 @@ const switchToPreviousAccount = async (previousAccount: string, previousWorkspac
   if (previousAccount !== currentAccount) {
     const canSwitchToPrevious = await promptUndeprecateOnVendor(switchAccountMessage(previousAccount, currentAccount))
     if (canSwitchToPrevious) {
-      return await switchAccount(previousAccount, {workspace: previousWorkspace})
+      await switchAccount(previousAccount, {workspace: previousWorkspace})
+      return
     }
   }
   return

--- a/src/modules/apps/undeprecate.ts
+++ b/src/modules/apps/undeprecate.ts
@@ -1,0 +1,112 @@
+import axios from 'axios'
+import { AxiosResponse } from 'axios'
+import * as Bluebird from 'bluebird'
+import chalk from 'chalk'
+import * as inquirer from 'inquirer'
+import { head, prepend, prop, tail } from 'ramda'
+import { getAccount, getToken, getWorkspace } from '../../conf'
+import { UserCancelledError } from '../../errors'
+import log from '../../logger'
+import { getManifest, validateApp } from '../../manifest'
+import switchAccount from '../auth/switch'
+import { parseLocator, toAppLocator } from './../../locator'
+import { parseArgs } from './utils'
+
+const undeprecateRequestTimeOut = 10000  // 10 seconds
+let originalAccount
+let originalWorkspace
+
+const switchAccountMessage = (previousAccount: string, currentAccount: string): string => {
+  return `Now you are logged in ${chalk.blue(currentAccount)}. Do you want to return to ${chalk.blue(previousAccount)} account?`
+}
+
+const switchToVendorMessage = (vendor: string): string => {
+  return `You are trying to undeprecate this app in an account that differs from the indicated vendor. Do you want to undeprecate in account ${chalk.blue(vendor)}?`
+}
+
+const promptUndeprecate = (appsList: string[]): Bluebird<boolean> =>
+  inquirer.prompt({
+    message: `Are you sure you want to undeprecate app` + (appsList.length > 1 ? 's' : '') + ` ${chalk.green(appsList.join(', '))}?`,
+    name: 'confirm',
+    type: 'confirm',
+  })
+    .then<boolean>(prop('confirm'))
+
+const promptUndeprecateOnVendor = (msg: string): Bluebird<boolean> =>
+  inquirer.prompt({
+    message: msg,
+    name: 'confirm',
+    type: 'confirm',
+  })
+    .then<boolean>(prop('confirm'))
+
+const switchToPreviousAccount = async (previousAccount: string, previousWorkspace: string) => {
+  const currentAccount = getAccount()
+  if (previousAccount !== currentAccount) {
+    const canSwitchToPrevious = await promptUndeprecateOnVendor(switchAccountMessage(previousAccount, currentAccount))
+    if (canSwitchToPrevious) {
+      return await switchAccount(previousAccount, {workspace: previousWorkspace})
+    }
+  }
+  return
+}
+
+const undeprecateApp = async (app: string): Promise<AxiosResponse> => {
+  const { vendor, name, version } = parseLocator(app)
+  const account = getAccount()
+  if (vendor !== account) {
+    const canSwitchToVendor = await promptUndeprecateOnVendor(switchToVendorMessage(vendor))
+    if (!canSwitchToVendor) {
+      throw new UserCancelledError()
+    }
+    await switchAccount(vendor, {})
+  }
+  // The below 'axios' request is temporary until we implement an
+  // `undeprecateApp` method in node-vtex-api and upgrade the library version
+  // used in this project.
+  const http = axios.create({
+    baseURL: `http://apps.aws-us-east-1.vtex.io`,
+    timeout: undeprecateRequestTimeOut,
+    data: {deprecated: false},
+    headers: {Authorization: getToken()},
+  })
+  return await http.patch(`/${vendor}/master/registry/${vendor}.${name}/${version}`)
+}
+
+const prepareUndeprecate = async (appsList: string[]): Promise<void> => {
+  if (appsList.length === 0) {
+    await switchToPreviousAccount(originalAccount, originalWorkspace)
+    return
+  }
+
+  const app = await validateApp(head(appsList))
+  try {
+    log.debug('Starting to undeprecate app:', app)
+    await undeprecateApp(app)
+    log.info('Successfully undeprecated', app)
+  } catch (e) {
+    if (e.response && e.response.status && e.response.status === 404) {
+      log.error(`Error undeprecating ${app}. App not found`)
+    } else if (e.message && e.response.statusText) {
+      log.error(`Error undeprecating ${app}. ${e.message}. ${e.response.statusText}`)
+      return await switchToPreviousAccount(originalAccount, originalWorkspace)
+    } else {
+      await switchToPreviousAccount(originalAccount, originalWorkspace)
+      throw e
+    }
+  }
+  await prepareUndeprecate(tail(appsList))
+}
+
+export default async (optionalApp: string, options) => {
+  const preConfirm = options.y || options.yes
+  originalAccount = getAccount()
+  originalWorkspace = getWorkspace()
+  const appsList = prepend(optionalApp || toAppLocator(await getManifest()), parseArgs(options._))
+
+  if (!preConfirm && !await promptUndeprecate(appsList)) {
+    throw new UserCancelledError()
+  }
+  log.debug('Undeprecating app' + (appsList.length > 1 ? 's' : '') + `: ${appsList.join(', ')}`)
+  return prepareUndeprecate(appsList)
+}

--- a/src/modules/apps/utils.ts
+++ b/src/modules/apps/utils.ts
@@ -184,3 +184,7 @@ export async function showBuilderHubMessage(message: string, showPrompt: boolean
     }
   }
 }
+
+export const switchAccountMessage = (previousAccount: string, currentAccount: string): string => {
+  return `Now you are logged in ${chalk.blue(currentAccount)}. Do you want to return to ${chalk.blue(previousAccount)} account?`
+}

--- a/src/modules/tree.ts
+++ b/src/modules/tree.ts
@@ -21,6 +21,11 @@ export default {
     handler: './apps/deprecate',
     optionalArgs: 'app',
   },
+  undeprecate: {
+    description: 'Undeprecate app(s)',
+    handler: './apps/undeprecate',
+    optionalArgs: 'app',
+  },
   deps: {
     list: {
       alias: 'ls',


### PR DESCRIPTION
Used to revert deprecation of apps. The usage is exactly the same as the `vtex deprecate` command.

The code is also almost the same as the 'deprecate.ts' module, except that we need to manually implement a http request, because `node-vtex-api` does not expose any method for undeprecating apps.

In the near future we will implement an `undeprecateApp` method in `node-vtex-api`, upgrade the version of `node-vtex-api` used in this project and use it instead of the `axios` http request.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
