### PR TITLE
Validate expiration of token in checkLogin

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -51,13 +51,12 @@ const logToolbeltVersion = () => {
   log.debug(`Toolbelt version: ${pkg.version}`)
 }
 
-const validToken = (): boolean => {
+const hasValidToken = (): boolean => {
   const token = getToken()
   if (!token) { return false }
 
   const decoded = decode(token)
-  if (decoded === null || typeof decoded === 'string' || decoded.exp === undefined) { return false }
-  if (Number(decoded.exp) < (Date.now() / 1000)) { return false }
+  if (!decoded || !decoded.exp || Number(decoded.exp) < (Date.now() / 1000)) { return false }
 
   return true
 }
@@ -65,7 +64,7 @@ const validToken = (): boolean => {
 const checkLogin = args => {
   const first = args[0]
   const whitelist = [undefined, 'login', 'logout', 'switch', 'whoami', 'init', '-v', '--version']
-  if (!validToken() && whitelist.indexOf(first) === -1) {
+  if (!hasValidToken() && whitelist.indexOf(first) === -1) {
     log.debug('Requesting login before command:', args.join(' '))
     return run({ command: loginCmd })
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -51,12 +51,12 @@ const logToolbeltVersion = () => {
   log.debug(`Toolbelt version: ${pkg.version}`)
 }
 
-const validToken = () => {
+const validToken = (): boolean => {
   const token = getToken()
   if (!token) { return false }
 
-  const decoded = decode(token, {complete: true})
-  if (Number(decoded.payload.exp) < (Date.now() / 1000)) { return false }
+  const decoded = decode(token)
+  if (decoded === null || typeof decoded === 'string' || decoded.exp === undefined || Number(decoded.exp) < (Date.now() / 1000)) { return false }
 
   return true
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -56,7 +56,8 @@ const validToken = (): boolean => {
   if (!token) { return false }
 
   const decoded = decode(token)
-  if (decoded === null || typeof decoded === 'string' || decoded.exp === undefined || Number(decoded.exp) < (Date.now() / 1000)) { return false }
+  if (decoded === null || typeof decoded === 'string' || decoded.exp === undefined) { return false }
+  if (Number(decoded.exp) < (Date.now() / 1000)) { return false }
 
   return true
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,6 +4,7 @@ import * as Bluebird from 'bluebird'
 import chalk from 'chalk'
 import { all as clearCachedModules } from 'clear-module'
 import { CommandNotFoundError, find, MissingRequiredArgsError, run as unboundRun } from 'findhelp'
+import { decode } from 'jsonwebtoken'
 import * as moment from 'moment'
 import * as path from 'path'
 import { reject, without } from 'ramda'
@@ -50,10 +51,20 @@ const logToolbeltVersion = () => {
   log.debug(`Toolbelt version: ${pkg.version}`)
 }
 
+const validToken = () => {
+  const token = getToken()
+  if (!token) { return false }
+
+  const decoded = decode(token, {complete: true})
+  if (Number(decoded.payload.exp) < (Date.now() / 1000)) { return false }
+
+  return true
+}
+
 const checkLogin = args => {
   const first = args[0]
   const whitelist = [undefined, 'login', 'logout', 'switch', 'whoami', 'init', '-v', '--version']
-  if (!getToken() && whitelist.indexOf(first) === -1) {
+  if (!validToken() && whitelist.indexOf(first) === -1) {
     log.debug('Requesting login before command:', args.join(' '))
     return run({ command: loginCmd })
   }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Do a simple check on the expiration of local token when using the cli.

#### What problem is this solving?
Saves people some time since the local token will always be valid (if it is not valid, it will immediately prompt for login).

#### How should this be manually tested?
Run 'vtex local token' with an expired token configured.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
