### PR TITLE
Fix yarn running in vtex link --install

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.37.0",
+  "version": "2.37.1",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/modules/apps/link.ts
+++ b/src/modules/apps/link.ts
@@ -114,10 +114,12 @@ const getTypings = async (manifest: Manifest, account: string, workspace: string
         if (await pathExists(packageJsonPath)) {
           const packageJson = await readJson(packageJsonPath)
           const oldDevDeps = packageJson.devDependencies || {}
-          const oldTypingsEntries = filter(test(/_v\/private\/typings/), oldDevDeps)
+          const oldTypingsEntries = filter(test(/_v\/\w*\/typings/), oldDevDeps)
           const newTypingsEntries = await appsWithTypingsURLs(builder, account, workspace, environment, appDeps)
+          console.log(oldTypingsEntries)
+          console.log(newTypingsEntries)
           if (!equals(oldTypingsEntries, newTypingsEntries)) {
-            const cleanOldDevDeps = ramdaReject(test(/_v\/private\/typings/), oldDevDeps)
+            const cleanOldDevDeps = ramdaReject(test(/_v\/\w*\/typings/), oldDevDeps)
             await outputJson(
               packageJsonPath,
               {

--- a/src/modules/apps/link.ts
+++ b/src/modules/apps/link.ts
@@ -73,7 +73,6 @@ const appsWithTypingsURLs = async (builder: string, account: string, workspace: 
 }
 
 const runYarn = (relativePath: string) => {
-  console.log(yarnPath)
   log.info(`Running yarn in ${relativePath}`)
   execSync(
     `${yarnPath} --force`,
@@ -117,8 +116,6 @@ const getTypings = async (manifest: Manifest, account: string, workspace: string
           const oldDevDeps = packageJson.devDependencies || {}
           const oldTypingsEntries = filter(test(typingsURLRegex), oldDevDeps)
           const newTypingsEntries = await appsWithTypingsURLs(builder, account, workspace, environment, appDeps)
-          console.log(oldTypingsEntries)
-          console.log(newTypingsEntries)
           if (!equals(oldTypingsEntries, newTypingsEntries)) {
             const cleanOldDevDeps = ramdaReject(test(typingsURLRegex), oldDevDeps)
             await outputJson(

--- a/src/modules/apps/link.ts
+++ b/src/modules/apps/link.ts
@@ -34,6 +34,7 @@ const N_HOSTS = 3
 const builderHubTypingsInfoTimeout = 2000  // 2 seconds
 const typingsPath = 'public/_types'
 const yarnPath = require.resolve('yarn/bin/yarn')
+const typingsURLRegex = /_v\/\w*\/typings/
 
 const resolvePackageJsonPath = (builder: string) => resolvePath(process.cwd(), `${builder}/package.json`)
 
@@ -114,12 +115,12 @@ const getTypings = async (manifest: Manifest, account: string, workspace: string
         if (await pathExists(packageJsonPath)) {
           const packageJson = await readJson(packageJsonPath)
           const oldDevDeps = packageJson.devDependencies || {}
-          const oldTypingsEntries = filter(test(/_v\/\w*\/typings/), oldDevDeps)
+          const oldTypingsEntries = filter(test(typingsURLRegex), oldDevDeps)
           const newTypingsEntries = await appsWithTypingsURLs(builder, account, workspace, environment, appDeps)
           console.log(oldTypingsEntries)
           console.log(newTypingsEntries)
           if (!equals(oldTypingsEntries, newTypingsEntries)) {
-            const cleanOldDevDeps = ramdaReject(test(/_v\/\w*\/typings/), oldDevDeps)
+            const cleanOldDevDeps = ramdaReject(test(typingsURLRegex), oldDevDeps)
             await outputJson(
               packageJsonPath,
               {


### PR DESCRIPTION
This PR attempts to fix the issue the error when running `yarn` for the `vtex link --install` command. Also adds some convenient error handling and updates the routes for typings fetching from vtex/asset-server.

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
