### PR TITLE
Improve init behaviour and remove bad templates

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.37.1",
+  "version": "2.37.2",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/modules/init/git.ts
+++ b/src/modules/init/git.ts
@@ -1,4 +1,4 @@
-import { copy, emptyDir, remove } from 'fs-extra'
+import { copy, emptyDir, ensureDir, remove } from 'fs-extra'
 import * as pipeStreams from 'pipe-streams-to-promise'
 import * as request from 'request'
 import * as unzip from 'unzip-stream'
@@ -13,10 +13,12 @@ const fetchAndUnzip = async (url: string, path: string) => pipeStreams([
 export const clone = async (repo: string) => {
   const cwd = process.cwd()
   const url = urlForRepo(repo)
-  const cloned = `${cwd}/${repo}-master`
+  const destPath = `${cwd}/${repo}`
+  const cloned = `${destPath}/${repo}-master`
 
-  await emptyDir(cwd)
-  await fetchAndUnzip(url, cwd)
-  await copy(cloned, cwd)
+  await ensureDir(destPath)
+  await emptyDir(destPath)
+  await fetchAndUnzip(url, destPath)
+  await copy(cloned, destPath)
   await remove(cloned)
 }

--- a/src/modules/init/index.ts
+++ b/src/modules/init/index.ts
@@ -3,19 +3,19 @@ import chalk from 'chalk'
 import { outputJson, readJson } from 'fs-extra'
 import * as inquirer from 'inquirer'
 import * as moment from 'moment'
+import { basename, join } from 'path'
 import { keys, prop } from 'ramda'
 import log from '../../logger'
-import { manifestPath } from '../../manifest'
+import { manifestPath as rootManifestPath } from '../../manifest'
 import * as git from './git'
 
 const { mapSeries } = Bluebird
+const manifestFileName = basename(rootManifestPath)
 
 const currentFolderName = process.cwd().replace(/.*\//, '')
 
 const templates = {
-  'react getting-started': 'render-getting-started',
-  'graphql getting-started': 'product-review-graphql-example',
-  'react+graphql': 'render-guide',
+  'dreamstore': 'dreamstore',
 }
 
 const promptName = async () => {
@@ -71,10 +71,10 @@ const promptTemplates = async (): Promise<string> => {
   return chosen
 }
 
-const promptContinue = async () => {
+const promptContinue = async (repoName: string) => {
   const proceed = prop('proceed', await inquirer.prompt({
     name: 'proceed',
-    message: `You are about to remove all files in ${process.cwd()}. Do you want to continue?`,
+    message: `You are about to create the new folder ${process.cwd()}/${repoName}. Do you want to continue?`,
     type: 'confirm',
   }))
   if (!proceed) {
@@ -110,7 +110,8 @@ export default async () => {
   log.info('Hello! I will help you generate basic files and folders for your app.')
   try {
     const repo = templates[await promptTemplates()]
-    await promptContinue()
+    const manifestPath = join(process.cwd(), repo, manifestFileName)
+    await promptContinue(repo)
     log.info(`Cloning https://vtex-apps/${repo}.git`)
     const [, [name, vendor, title, description]]: any = await Bluebird.all([
       git.clone(repo),


### PR DESCRIPTION
This PR proposes 2 modifications in the `vtex init` command:

- Leave only `dreamstore` (vtex-apps/dreamstore)  as starting template.
- Instead of deleting everything in the current working folder, create a new folder with the template's content.

- [x] Refactor
