### PR TITLE
Fix call to builder-hub's typingsInfo route

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.37.2",
+  "version": "2.37.3",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/modules/apps/link.ts
+++ b/src/modules/apps/link.ts
@@ -11,7 +11,7 @@ import { join, resolve as resolvePath, sep} from 'path'
 import { concat, equals, filter, has, isEmpty, isNil, map, mapObjIndexed, merge, path as ramdaPath, pipe, prop, reject as ramdaReject, test, toPairs, values } from 'ramda'
 import { createInterface } from 'readline'
 import { createClients } from '../../clients'
-import { getAccount, getEnvironment, getWorkspace } from '../../conf'
+import { getAccount, getEnvironment, getToken, getWorkspace } from '../../conf'
 import { CommandError } from '../../errors'
 import { getMostAvailableHost } from '../../host'
 import { toAppLocator } from '../../locator'
@@ -39,15 +39,19 @@ const typingsURLRegex = /_v\/\w*\/typings/
 const resolvePackageJsonPath = (builder: string) => resolvePath(process.cwd(), `${builder}/package.json`)
 
 const typingsInfo = async (workspace: string, account: string, environment: string) => {
-  const extension = (environment === 'prod') ? 'myvtex' : 'myvtexdev'
+  const extension = (environment === 'prod') ? '1' : '2'
   const http = axios.create({
-    baseURL: `https://${workspace}--${account}.${extension}.com`,
+    baseURL: `http://builder-hub.vtex.aws-us-east-${extension}.vtex.io/${account}/${workspace}`,
     timeout: builderHubTypingsInfoTimeout,
+    headers: {
+      'Authorization': getToken(),
+    },
   })
   try {
-    const res = await http.get(`/_v/private/builder/0/typings`)
+    const res = await http.get(`/_v/builder/0/typings`)
     return res.data.typingsInfo
   } catch (e) {
+    console.log(e)
     log.error('Unable to get typings info from vtex.builder-hub.')
     return {}
   }

--- a/src/modules/apps/link.ts
+++ b/src/modules/apps/link.ts
@@ -51,7 +51,6 @@ const typingsInfo = async (workspace: string, account: string, environment: stri
     const res = await http.get(`/_v/builder/0/typings`)
     return res.data.typingsInfo
   } catch (e) {
-    console.log(e)
     log.error('Unable to get typings info from vtex.builder-hub.')
     return {}
   }

--- a/src/modules/apps/undeprecate.ts
+++ b/src/modules/apps/undeprecate.ts
@@ -70,7 +70,6 @@ const undeprecateApp = async (app: string): Promise<AxiosResponse> => {
     },
   })
   const finalroute = `http://apps.aws-us-east-1.vtex.io/${vendor}/master/registry/${vendor}.${name}/${version}`
-  console.log(finalroute)
   return await http.patch(finalroute, {deprecated: false})
 }
 


### PR DESCRIPTION
This PR changes the route of the typingsInfo call to builder-hub, reflecting the changes made in #vtex/builder-hub/pull/340.


- [x] Bug fix (non-breaking change which fixes an issue)

