### PR TITLE
Enable linking in subdirectories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ### Unreleased
 
 Features:
-- Enable linking in any subdirectory of the app
+- Enable running commands inside subdirectories
 
 ### v2.35.0 (2018-01-17)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### Unreleased
+
+Features:
+- Enable linking in any subdirectory of the app
+
 ### v2.35.0 (2018-01-17)
 
 Features:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.37.4",
+  "version": "2.38.0",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -9,7 +9,7 @@ const readFileUtf = async (file: string): Promise<string> => {
   return await readFile(file, 'utf8')
 }
 
-export const manifestFileName = 'manifest.json'
+export const MANIFEST_FILE_NAME = 'manifest.json'
 
 export const getAppRoot = () => {
   const cwd = process.cwd()
@@ -17,7 +17,7 @@ export const getAppRoot = () => {
 
   const find = dir => {
     try {
-      accessSync(path.join(dir, manifestFileName))
+      accessSync(path.join(dir, MANIFEST_FILE_NAME))
       return dir
     } catch (e) {
       if (dir === rootDirName) {
@@ -37,7 +37,7 @@ export const namePattern = '[\\w_-]+'
 export const vendorPattern = '[\\w_-]+'
 export const versionPattern = '\\d+\\.\\d+\\.\\d+(-.*)?'
 export const wildVersionPattern = '\\d+\\.((\\d+\\.\\d+)|(\\d+\\.x)|x)(-.*)?'
-export const getManifestPath = () => path.resolve(getAppRoot(), manifestFileName)
+export const getManifestPath = () => path.resolve(getAppRoot(), MANIFEST_FILE_NAME)
 
 export const isManifestReadable = async (): Promise<boolean> => {
   try {

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -13,14 +13,17 @@ export const manifestFileName = 'manifest.json'
 
 export const getAppRoot = () => {
   const cwd = process.cwd()
+  const { root: rootDirName } = path.parse(cwd)
 
   const find = dir => {
     try {
       accessSync(path.join(dir, manifestFileName))
       return dir
     } catch (e) {
-      if (dir === '/') {
-        throw new CommandError(`Manifest file doesn't exist or is not readable. Please add a manifest.json file in the root of the app folder.`)
+      if (dir === rootDirName) {
+        throw new CommandError(
+          `Manifest file doesn't exist or is not readable. Please make sure you're in the app's directory or add a manifest.json file in the root folder of the app.`
+        )
       }
 
       return find(path.resolve(dir, '..'))

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -9,14 +9,14 @@ const readFileUtf = async (file: string): Promise<string> => {
   return await readFile(file, 'utf8')
 }
 
-export const manifestFilename = 'manifest.json'
+export const manifestFileName = 'manifest.json'
 
 export const getAppRoot = () => {
   const cwd = process.cwd()
 
   const find = dir => {
     try {
-      accessSync(path.join(dir, manifestFilename))
+      accessSync(path.join(dir, manifestFileName))
       return dir
     } catch (e) {
       if (dir === '/') {
@@ -34,11 +34,11 @@ export const namePattern = '[\\w_-]+'
 export const vendorPattern = '[\\w_-]+'
 export const versionPattern = '\\d+\\.\\d+\\.\\d+(-.*)?'
 export const wildVersionPattern = '\\d+\\.((\\d+\\.\\d+)|(\\d+\\.x)|x)(-.*)?'
-export const manifestPath = path.resolve(getAppRoot(), manifestFilename)
+export const getManifestPath = () => path.resolve(getAppRoot(), manifestFileName)
 
 export const isManifestReadable = async (): Promise<boolean> => {
   try {
-    await readFileUtf(manifestPath)
+    await readFileUtf(getManifestPath())
     return true
   } catch (error) {
     return false
@@ -89,7 +89,7 @@ export const validateApp = (app: string, skipVersion: boolean = false) => {
 }
 
 export const getManifest = memoize(async (): Promise<Manifest> => {
-  const manifest = parseManifest(await readFileUtf(manifestPath))
+  const manifest = parseManifest(await readFileUtf(getManifestPath()))
   validateAppManifest(manifest)
   return manifest
 })

--- a/src/modules/apps/add.ts
+++ b/src/modules/apps/add.ts
@@ -17,7 +17,7 @@ import { CommandError } from '../../errors'
 import log from '../../logger'
 import {
   getManifest,
-  manifestPath,
+  getManifestPath,
   namePattern,
   vendorPattern,
   wildVersionPattern,
@@ -54,7 +54,7 @@ const updateManifestDependencies = (app: string, version: string): Promise<void>
       }
     })
     .then((newManifest: Manifest) => JSON.stringify(newManifest, null, 2) + '\n')
-    .then((manifestJson: string) => writeFile(manifestPath, manifestJson))
+    .then((manifestJson: string) => writeFile(getManifestPath(), manifestJson))
 }
 
 const addApp = (app: string): Promise<void> => {

--- a/src/modules/apps/link.ts
+++ b/src/modules/apps/link.ts
@@ -16,7 +16,7 @@ import { CommandError } from '../../errors'
 import { getMostAvailableHost } from '../../host'
 import { toAppLocator } from '../../locator'
 import log from '../../logger'
-import { getManifest } from '../../manifest'
+import { getAppRoot, getManifest } from '../../manifest'
 import { listenBuild } from '../build'
 import { formatNano } from '../utils'
 import startDebuggerTunnel from './debugger'
@@ -25,7 +25,7 @@ import legacyLink from './legacyLink'
 import lint from './lint'
 import { checkBuilderHubMessage, isLinked, pathToFileObject, resolveAppId, showBuilderHubMessage, validateAppAction } from './utils'
 
-const root = process.cwd()
+const root = getAppRoot()
 const DELETE_SIGN = chalk.red('D')
 const UPDATE_SIGN = chalk.blue('U')
 const stabilityThreshold = process.platform === 'darwin' ? 100 : 200

--- a/src/modules/init/index.ts
+++ b/src/modules/init/index.ts
@@ -3,14 +3,13 @@ import chalk from 'chalk'
 import { outputJson, readJson } from 'fs-extra'
 import * as inquirer from 'inquirer'
 import * as moment from 'moment'
-import { basename, join } from 'path'
+import { join } from 'path'
 import { keys, prop } from 'ramda'
 import log from '../../logger'
-import { manifestPath as rootManifestPath } from '../../manifest'
+import { manifestFileName } from '../../manifest'
 import * as git from './git'
 
 const { mapSeries } = Bluebird
-const manifestFileName = basename(rootManifestPath)
 
 const currentFolderName = process.cwd().replace(/.*\//, '')
 

--- a/src/modules/init/index.ts
+++ b/src/modules/init/index.ts
@@ -6,7 +6,7 @@ import * as moment from 'moment'
 import { join } from 'path'
 import { keys, prop } from 'ramda'
 import log from '../../logger'
-import { manifestFileName } from '../../manifest'
+import { MANIFEST_FILE_NAME } from '../../manifest'
 import * as git from './git'
 
 const { mapSeries } = Bluebird
@@ -109,7 +109,7 @@ export default async () => {
   log.info('Hello! I will help you generate basic files and folders for your app.')
   try {
     const repo = templates[await promptTemplates()]
-    const manifestPath = join(process.cwd(), repo, manifestFileName)
+    const manifestPath = join(process.cwd(), repo, MANIFEST_FILE_NAME)
     await promptContinue(repo)
     log.info(`Cloning https://vtex-apps/${repo}.git`)
     const [, [name, vendor, title, description]]: any = await Bluebird.all([


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add possibility to link in any subdirectory of an app.

#### What problem is this solving?
It was kind of annoying to go to the root of the app to be able to link.

#### How should this be manually tested?
 - Generate a executable running `yarn build`
 - Inside any app, go to a subdirectory and run `~/path/to/toolbelt/lib/cli.js link`

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
