### PR TITLE
Add config to whitelist

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.37.3",
+  "version": "2.37.4",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -63,7 +63,7 @@ const hasValidToken = (): boolean => {
 
 const checkLogin = args => {
   const first = args[0]
-  const whitelist = [undefined, 'login', 'logout', 'switch', 'whoami', 'init', '-v', '--version']
+  const whitelist = [undefined, 'config', 'login', 'logout', 'switch', 'whoami', 'init', '-v', '--version']
   if (!hasValidToken() && whitelist.indexOf(first) === -1) {
     log.debug('Requesting login before command:', args.join(' '))
     return run({ command: loginCmd })


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add `config` to whitelist of commands that don't need a valid credential to run.

#### What problem is this solving?
Config must be in this whitelist so the environment can be changed even when it is not working.

#### How should this be manually tested?
Build and try to change environment with an expired/non-existent token.

#### Screenshots or example usage

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
