### PR TITLE
Adds command `vtex browse admin`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.38.0",
+  "version": "2.39.0",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/modules/browse/admin.ts
+++ b/src/modules/browse/admin.ts
@@ -1,24 +1,15 @@
 import * as opn from 'opn'
 import * as conf from '../../conf'
 
-const buildPrefix = (account: string, workspace: string): string => {
-  const base = 'https://'
-  const workspacePrefix = workspace === 'master' ? '' : `${workspace}--`
-  return base + workspacePrefix + account
-}
-
-const buildDomain = (region: conf.Environment): string =>
+const chooseDomain = (region: conf.Environment): string =>
   region === conf.Environment.Production
-    ? '.myvtex.com'
-    : '.myvtexdev.com'
+    ? 'myvtex.com'
+    : 'myvtexdev.com'
 
 export default () => {
   const region = conf.getEnvironment()
   const { account, workspace } = conf.currentContext
-  const prefix = buildPrefix(account, workspace)
-  const domain = buildDomain(region)
-  const path = '/admin'
-  const uri = prefix + domain + path
+  const uri = `https://${workspace}--${account}.${chooseDomain(region)}/admin`
 
   opn(uri, { wait: false })
 }

--- a/src/modules/browse/admin.ts
+++ b/src/modules/browse/admin.ts
@@ -1,0 +1,24 @@
+import * as opn from 'opn'
+import * as conf from '../../conf'
+
+const buildPrefix = (account: string, workspace: string): string => {
+  const base = 'https://'
+  const workspacePrefix = workspace === 'master' ? '' : `${workspace}--`
+  return base + workspacePrefix + account
+}
+
+const buildDomain = (region: conf.Environment): string =>
+  region === conf.Environment.Production
+    ? '.myvtex.com'
+    : '.myvtexdev.com'
+
+export default () => {
+  const region = conf.getEnvironment()
+  const { account, workspace } = conf.currentContext
+  const prefix = buildPrefix(account, workspace)
+  const domain = buildDomain(region)
+  const path = '/admin'
+  const uri = prefix + domain + path
+
+  opn(uri, { wait: false })
+}

--- a/src/modules/tree.ts
+++ b/src/modules/tree.ts
@@ -16,6 +16,12 @@ export default {
       requiredArgs: ['name', 'value'],
     },
   },
+  browse: {
+    admin: {
+      description: 'Open admin in browser window',
+      handler: './browse/admin',
+    },
+  },
   deprecate: {
     description: 'Deprecate app(s)',
     handler: './apps/deprecate',


### PR DESCRIPTION
#### What is the purpose of this pull request?
To add a new set of commands: `vtex browse`. For now, it has `vtex browse admin`, but can be expanded.

#### What problem is this solving?
Currently, it is a hassle to open admin pages when you're already on toolbelt. You need to craft the url yourself if it's your first time opening it, or search through your browser history to find the correct link. 
Now, if you're already on toolbelt, just by using `vtex browse admin`, the admin panel will open in your default browser.

#### How should this be manually tested?
- download this branch and `yarn watch` it.
- login to any account/workspace, in prod or staging. It should work everywhere.
- Use `vtex browse admin`, watch magic happen.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
