### PR TITLE
Some fixes to workspace handling for production and AB test

### DIFF
--- a/src/modules/workspace/abTest.ts
+++ b/src/modules/workspace/abTest.ts
@@ -2,14 +2,13 @@ import chalk from 'chalk'
 import * as inquirer from 'inquirer'
 import {prop} from 'ramda'
 
-import {apps, workspaces} from '../../clients'
+import {workspaces} from '../../clients'
 import {getAccount, getWorkspace} from '../../conf'
 import {CommandError, UserCancelledError} from '../../errors'
 import log from '../../logger'
 import list from './list'
 
-const { listLinks } = apps
-const { set } = workspaces
+const { get, set } = workspaces
 const [account, currentWorkspace] = [getAccount(), getWorkspace()]
 
 const promptContinue = async () => {
@@ -24,9 +23,9 @@ const promptContinue = async () => {
 }
 
 const canGoLive = async (): Promise<void> => {
-  const links = await listLinks()
-  if (links.length > 0) {
-    throw new CommandError(`You have links on your workspace. Please unlink all apps (${chalk.blue('vtex unlink --all')}) before setting AB test mode`)
+  const workspaceData = await get(account, currentWorkspace)
+  if (!workspaceData.production) {
+    throw new CommandError(`A workspace must be in production before you can test it. Please run ${chalk.blue('vtex production true')} and try again`)
   }
 }
 
@@ -53,7 +52,7 @@ export default async (optionWeight: number) => {
 
   try {
     log.debug(`Setting workspace ${chalk.green(currentWorkspace)} to AB test with weight=${weight}`)
-    await set(account, currentWorkspace, { production: weight !== 0, weight })
+    await set(account, currentWorkspace, { production: true, weight })
     if (weight !== 0) {
       log.info(`Workspace ${chalk.green(currentWorkspace)} in AB Test with weight=${weight}`)
       if (currentWorkspace !== 'master') {

--- a/src/modules/workspace/abTest.ts
+++ b/src/modules/workspace/abTest.ts
@@ -43,7 +43,7 @@ export default async (optionWeight: number) => {
   } else if (Number.isInteger(optionWeight) && optionWeight >= 0) {
     weight = optionWeight
   } else {
-    throw new CommandError('The weight for workspace AB test must be a positive integer')
+    throw new CommandError('The weight for workspace AB test must be a non-negative integer')
   }
 
   if (weight) {

--- a/src/modules/workspace/production.ts
+++ b/src/modules/workspace/production.ts
@@ -21,7 +21,7 @@ const pretty = p => p ? chalk.green('production mode') : chalk.red('development 
 export default async (production: any) => {
   let prod
 
-  if (production === null || production === 'true') {
+  if (production === null || production === 'true' || production === undefined) {
     prod = true
   } else if (production === 'false') {
     prod = false

--- a/src/modules/workspace/production.ts
+++ b/src/modules/workspace/production.ts
@@ -12,7 +12,7 @@ const [account, currentWorkspace] = [getAccount(), getWorkspace()]
 const canGoLive = async (): Promise<void> => {
   const links = await listLinks()
   if (links.length > 0) {
-    throw new CommandError(`You have links on your workspace. Please unlink all apps (${chalk.blue('vtex unlink --all')}) before setting production mode`)
+    throw new CommandError(`You have links on your workspace. Please try another workspace or reset this one (${chalk.blue('vtex workspace reset ' + currentWorkspace)}) before setting production mode`)
   }
 }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
Most of the changes are error messages that suggest a better course of action to the users. More specifically, we should not suggest that a user simply unlinks all apps before moving a workspace to production. Although we cannot currently forbid it, this will not be allowed in the future and, because of that, we should encourage the users to either create a new workspace or reset the current one instead.

Another thing that is being fixed is that we should not skip the `vtex production` step for workspaces that are going to be put into A/B tests. The workflow for those should be the same as for promoting a workspace directly right until the last step, which is `vtex workspace test <weight>` instead of `vtex promote`, so users should run `vtex production` **before** that. This means updating the check that was being done to ensure the workspace is already in production instead of looking for links and also stop messing with this flag when changing the weight.

#### What problem is this solving?
We need to make our workspaces respect what has been agreed with Chronos team, but that is not something quick to do. Instead, we take the low-hanging fruit of at least updating error messages to nudge users in the right direction.

#### How should this be manually tested?
Set workspaces to production and into A/B test. The following scenarios have been tested before submitting the PR:
1. Try to set a workspace that has links to production with `vtex production`.
    * Result should be: message appears indicating that user should either **reset** workspace or **create a new one**.
2. Try to set a workspace that has no links to production with `vtex production`.
    * Result should be: workspace is set to production.
3. Try to set a weight into a workspace that is not in production and has no links:
    * Result should be: workspace should keep weight 0 and a message telling the user to run `vtex production` first should appear.
4. Try to set a weight into a workspace that is in production:
    * Result should be: workspace should have the new weight.

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/6957289/52874018-912b3100-3137-11e9-82bc-e5859e87e39c.png)

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
