### PR TITLE
Fix/set settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.40.4",
+  "version": "2.40.5",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/modules/apps/settings/set.ts
+++ b/src/modules/apps/settings/set.ts
@@ -30,7 +30,7 @@ const transformCommandsToObj = (commandSettings) => {
 }
 
 export default (app: string, _, ___, options) => {
-  const commandSettings = transformCommandsToObj(parseArgs(options))
+  const commandSettings = transformCommandsToObj(parseArgs(options._))
   return getAppSettings(app)
     .then(merge(__, commandSettings))
     .then(newSettings => JSON.stringify(newSettings, null, 2))


### PR DESCRIPTION
This PR fixes the `vtex settings set` command.
The command was wrongly parsing the settings input. 

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
