### PR TITLE
Adds vtex browse admin on support accounts

### DIFF
--- a/src/modules/browse/admin.ts
+++ b/src/modules/browse/admin.ts
@@ -1,15 +1,57 @@
+import axios from 'axios'
+import * as jwt from 'jsonwebtoken'
 import * as opn from 'opn'
+import * as R from 'ramda'
 import * as conf from '../../conf'
+import { publicEndpoint } from '../../env'
+import log from '../../logger'
 
-const chooseDomain = (region: conf.Environment): string =>
-  region === conf.Environment.Production
-    ? 'myvtex.com'
-    : 'myvtexdev.com'
+const isSupportRole = (role: string): boolean => role && role.startsWith('vtex.support-authority')
 
-export default () => {
-  const region = conf.getEnvironment()
+const isSupportSession = (): boolean => {
+  const token = conf.getToken()
+  const decoded = jwt.decode(token)
+  if (!decoded) {
+    return false
+  }
+
+  return R.any(role => isSupportRole(role), decoded.roles as string[])
+}
+
+const prepareSupportBrowser = async (account: string, workspace: string): Promise<string> => {
+  const token = conf.getToken()
+
+  const uri = `https://${workspace}--${account}.${publicEndpoint()}/_v/private/support-login/prepare`
+  const response = await axios.get(uri,
+    {
+      headers: {
+        'X-Vtex-Original-Credential': token,
+      },
+    })
+  return response.data.oneTimeToken
+}
+
+export default async () => {
+  const supportSession = isSupportSession()
   const { account, workspace } = conf.currentContext
-  const uri = `https://${workspace}--${account}.${chooseDomain(region)}/admin`
 
-  opn(uri, { wait: false })
+  try {
+    const token = supportSession ? await prepareSupportBrowser(account, workspace) : null
+    const url = `https://${workspace}--${account}.${publicEndpoint()}`
+    const urn = supportSession ? `/_v/private/support-login/login?token=${token}` : '/admin'
+    const uri = url + urn
+
+    opn(uri, { wait: false })
+  }
+  catch (err) {
+    if (err.message) {
+      log.error(err.message)
+      if (err.response && err.response.status === 404) {
+        log.info('Make sure vtex.support-browse-admin is installed in your workspace.')
+      }
+      console.log({ response: err.response })
+      return
+    }
+    log.error(err)
+  }
 }


### PR DESCRIPTION
### Please note that this is not a merge to master.

#### What is the purpose of this pull request?
To make `vtex browse admin` work directly on supported accounts.

#### What problem is this solving?
`vtex support` is not very useful if there isn't a way to 

#### How should this be manually tested?
- `yarn watch` this branch.
- go to `vtexgame2/pedro823`.
- Do `vtex support vtexgame3`. You should now be in `vtexgame3`.
- Do `vtex use pedro823`.
- Do `vtex browse admin`. This should open the browser in the admin,
with the support cookie on `VtexIdClientAutCookie`.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
