### PR TITLE
Fix typings fetching and download tslint and tsconfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
-- Fix typings fetching during `vtex link`. Also makes `vtex link` fetch typings for apps by default.
+- Move typings fetching to the `vtex setup` command
+- Make `vtex setup` download tslint configuration (react and node)
+- Make `vtex setup` merge tsconfig entries from builder-hub
+- `vtex link` runs `vtex setup` by default, except when run with option `no-setup`
 
 ## [2.55.7] - 2019-05-08
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Fix typings fetching during `vtex link`. Also makes `vtex link` fetch typings for apps by default.
 
 ## [2.55.7] - 2019-05-08
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.56.0] - 2019-05-08
 ### Changed
 - Move typings fetching to the `vtex setup` command
 - Make `vtex setup` download tslint configuration (react and node)

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ $ vtex
     init                    Create basic files and folders for your VTEX app
     install [app]           Install an app (defaults to the app in the current directory)
     link                    Start a development session for this app
+    setup                   Setup your development environment (configure tsconfig and tslint, run yarn)
     list                    List your installed VTEX apps
     login                   Log into a VTEX account
     logout                  Logout of the current VTEX account

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.55.7",
+  "version": "2.56.0",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/modules/apps/link.ts
+++ b/src/modules/apps/link.ts
@@ -202,7 +202,7 @@ export default async (options) => {
 
   const appId = toAppLocator(manifest)
   const context = { account: getAccount(), workspace: getWorkspace(), environment: getEnvironment() }
-  if (!options.setup && !options.n) {
+  if (options.setup === undefined && options.n === false) {
     await setup()
   }
   const { builder } = createClients(context, { timeout: 60000 })

--- a/src/modules/apps/link.ts
+++ b/src/modules/apps/link.ts
@@ -105,7 +105,7 @@ const appTypingsURL = async (account: string, workspace: string, appName: string
   if (isLinked({'version': appId})) {
   return `https://${workspace}--${account}.${extension}.com/_v/private/typings/linked/v1/${appId}/${typingsPath}/${builder}`
   }
-  return `https://${vendor}.vteximg.com/_v/public/typings/v1/${appId}/${typingsPath}/${builder}`
+  return `https://${vendor}.vteximg.com.br/_v/public/typings/v1/${appId}/${typingsPath}/${builder}`
 }
 
 const appsWithTypingsURLs = async (builder: string, account: string, workspace: string, appDependencies: Record<string, any>) => {
@@ -178,7 +178,7 @@ const getTypings = async (manifest: Manifest, account: string, workspace: string
               runYarn(builder)
             } catch (e) {
               log.error(`Error running Yarn in ${builder}.`)
-              await outputJson(packageJsonPath, packageJson)  // Revert package.json to original state.
+              await outputJson(packageJsonPath, packageJson, { spaces: '\t' })  // Revert package.json to original state.
             }
 
           }

--- a/src/modules/apps/link.ts
+++ b/src/modules/apps/link.ts
@@ -103,7 +103,7 @@ const appTypingsURL = async (account: string, workspace: string, appName: string
   const appId = await resolveAppId(appName, appVersion)
   const vendor = getVendor(appId)
   if (isLinked({'version': appId})) {
-  return `https://${workspace}--${account}.${extension}.com/_v/private/typings/linked/v1/${appId}/${typingsPath}/${builder}`
+  return `https://${workspace}--${account}.${publicEndpoint()}/_v/private/typings/linked/v1/${appId}/${typingsPath}/${builder}`
   }
   return `https://${vendor}.vteximg.com.br/_v/public/typings/v1/${appId}/${typingsPath}/${builder}`
 }
@@ -344,7 +344,7 @@ export default async (options) => {
   const appId = toAppLocator(manifest)
   const context = { account: getAccount(), workspace: getWorkspace(), environment: getEnvironment() }
   if (!options['no-install'] && !options.n) {
-    await getTypings(manifest, context.account, context.workspace, context.environment)
+    await getTypings(manifest, context.account, context.workspace)
   }
   const { builder } = createClients(context, { timeout: 60000 })
 

--- a/src/modules/apps/link.ts
+++ b/src/modules/apps/link.ts
@@ -56,6 +56,8 @@ const shouldStartDebugger = (manifest: Manifest) => compose<Manifest, any, strin
   prop('builders')
 )(manifest)
 
+const getVendor = (appId: string) => appId.split('.')[0]
+
 const resolvePackageJsonPath = (builder: string) => resolvePath(process.cwd(), `${builder}/package.json`)
 
 const typingsInfo = async (workspace: string, account: string) => {
@@ -66,19 +68,44 @@ const typingsInfo = async (workspace: string, account: string) => {
       'Authorization': getToken(),
     },
   })
-  try {
+
+  const retryOpts = {
+    retries: 2,
+    minTimeout: 1000,
+    factor: 2,
+  }
+
+  const getTypingsInfo = async (_: any, tryCount: number) => {
+    if (tryCount > 1) {
+      log.info(`Retrying...${tryCount-1}`)
+    }
+    try {
     const res = await http.get(`/_v/builder/0/typings`)
     return res.data.typingsInfo
+    } catch (err) {
+      const statusMessage = err.response.status ?
+        `: Status ${err.response.status}` : ''
+      log.error(`Error fetching typings info ${statusMessage} (try: ${tryCount})`)
+      throw err
+    }
+  }
+
+  try {
+    return retry(getTypingsInfo, retryOpts)
   } catch (e) {
     log.error('Unable to get typings info from vtex.builder-hub.')
     return {}
   }
+
 }
 
 const appTypingsURL = async (account: string, workspace: string, appName: string, appVersion: string, builder: string): Promise<string> => {
   const appId = await resolveAppId(appName, appVersion)
-  const assetServerPath = isLinked({'version': appId}) ? 'private/typings/linked/v1' : 'public/typings/v1'
-  return `https://${workspace}--${account}.${publicEndpoint()}/_v/${assetServerPath}/${appId}/${typingsPath}/${builder}`
+  const vendor = getVendor(appId)
+  if (isLinked({'version': appId})) {
+  return `https://${workspace}--${account}.${extension}.com/_v/private/typings/linked/v1/${appId}/${typingsPath}/${builder}`
+  }
+  return `https://${vendor}.vteximg.com/_v/public/typings/v1/${appId}/${typingsPath}/${builder}`
 }
 
 const appsWithTypingsURLs = async (builder: string, account: string, workspace: string, appDependencies: Record<string, any>) => {
@@ -316,9 +343,7 @@ export default async (options) => {
 
   const appId = toAppLocator(manifest)
   const context = { account: getAccount(), workspace: getWorkspace(), environment: getEnvironment() }
-  if (options.install || options.i) {
-    await getTypings(manifest, context.account, context.workspace)
-  }
+  await getTypings(manifest, context.account, context.workspace, context.environment)
   const { builder } = createClients(context, { timeout: 60000 })
 
   if (options.c || options.clean) {

--- a/src/modules/apps/link.ts
+++ b/src/modules/apps/link.ts
@@ -343,7 +343,9 @@ export default async (options) => {
 
   const appId = toAppLocator(manifest)
   const context = { account: getAccount(), workspace: getWorkspace(), environment: getEnvironment() }
-  await getTypings(manifest, context.account, context.workspace, context.environment)
+  if (!options['no-install'] && !options.n) {
+    await getTypings(manifest, context.account, context.workspace, context.environment)
+  }
   const { builder } = createClients(context, { timeout: 60000 })
 
   if (options.c || options.clean) {

--- a/src/modules/apps/publish.ts
+++ b/src/modules/apps/publish.ts
@@ -10,7 +10,7 @@ import { UserCancelledError } from '../../errors'
 import { getSavedOrMostAvailableHost } from '../../host'
 import { toAppLocator } from '../../locator'
 import log from '../../logger'
-import { getManifest } from '../../manifest'
+import { getAppRoot, getManifest } from '../../manifest'
 import { logAll } from '../../sse'
 import switchAccount from '../auth/switch'
 import { listenBuild } from '../build'
@@ -20,7 +20,7 @@ import { legacyPublisher } from './legacyPublish'
 import { checkBuilderHubMessage, pathToFileObject, showBuilderHubMessage } from './utils'
 
 
-const root = process.cwd()
+const root = getAppRoot()
 const AVAILABILITY_TIMEOUT = 1000
 const N_HOSTS = 5
 

--- a/src/modules/setup.ts
+++ b/src/modules/setup.ts
@@ -1,0 +1,255 @@
+import * as retry from 'async-retry'
+import axios from 'axios'
+import { execSync } from 'child-process-es6-promise'
+import { outputJson, outputJsonSync, pathExists, readJson, readJsonSync } from 'fs-extra'
+import { resolve as resolvePath } from 'path'
+import { compose, difference, equals, filter, has, intersection, isEmpty, isNil, keys, map, mapObjIndexed, merge, mergeDeepRight, path as ramdaPath, pipe, prop, reject as ramdaReject, test, values } from 'ramda'
+import { getAccount, getEnvironment, getWorkspace } from '../conf'
+import { getToken } from '../conf'
+import { publicEndpoint, region } from '../env'
+import log from '../logger'
+import { getAppRoot, getManifest } from '../manifest'
+import { isLinked, resolveAppId } from './apps/utils'
+
+const root = getAppRoot()
+const builderHubTypingsInfoTimeout = 2000  // 2 seconds
+const buildersToSetTSLint = ['react', 'node']
+const lintSetup = ['tslint', 'tslint-config-vtex']
+const typingsPath = 'public/_types'
+const yarnPath = require.resolve('yarn/bin/yarn')
+const typingsURLRegex = /_v\/\w*\/typings/
+const getVendor = (appId: string) => appId.split('.')[0]
+const builderHttp = (account: string, workspace: string) =>
+  axios.create({
+    baseURL: `http://builder-hub.vtex.${region()}.vtex.io/${account}/${workspace}`,
+    timeout: builderHubTypingsInfoTimeout,
+    headers: {
+      'Authorization': getToken(),
+    },
+  })
+
+const resolvePackageJsonPath = (builder: string) => resolvePath(root, `${builder}/package.json`)
+const resolveTSConfigPath = (builder: string) => resolvePath(root, `${builder}/tsconfig.json`)
+const resolveTSLintPath = (builder: string) => resolvePath(root, `${builder}/tslint.json`)
+
+const typingsInfo = async (account: string, workspace: string) => {
+  const http = builderHttp(account, workspace)
+  const retryOpts = {
+    retries: 2,
+    minTimeout: 1000,
+    factor: 2,
+  }
+
+  const getTypingsInfo = async (_: any, tryCount: number) => {
+    if (tryCount > 1) {
+      log.info(`Retrying...${tryCount-1} typings info`)
+    }
+    try {
+    const res = await http.get(`/_v/builder/0/typings`)
+    return res.data.typingsInfo
+    } catch (err) {
+      const statusMessage = err.response.status ?
+        `: Status ${err.response.status}` : ''
+      log.error(`Error fetching typings info ${statusMessage} (try: ${tryCount})`)
+      throw err
+    }
+  }
+  try {
+    return retry(getTypingsInfo, retryOpts)
+  } catch (e) {
+    log.error('Unable to get typings info from vtex.builder-hub.')
+    return {}
+  }
+
+}
+
+const appTypingsURL = async (account: string, workspace: string, appName: string, appVersion: string, builder: string): Promise<string> => {
+  const appId = await resolveAppId(appName, appVersion)
+  const vendor = getVendor(appId)
+  if (isLinked({'version': appId})) {
+  return `https://${workspace}--${account}.${publicEndpoint()}/_v/private/typings/linked/v1/${appId}/${typingsPath}/${builder}`
+  }
+  return `http://${vendor}.vteximg.com.br/_v/public/typings/v1/${appId}/${typingsPath}/${builder}`
+}
+
+const appsWithTypingsURLs = async (builder: string, account: string, workspace: string, appDependencies: Record<string, any>) => {
+  const result: Record<string, any> = {}
+  for (const [appName, appVersion] of Object.entries(appDependencies)) {
+    try {
+      result[appName] = await appTypingsURL(account, workspace, appName, appVersion, builder)
+    } catch (e) {
+      log.error(`Unable to generate typings URL for ${appName}@${appVersion}.`)
+    }
+  }
+  return result
+}
+
+const runYarn = (relativePath: string) => {
+  log.info(`Running yarn in ${relativePath}`)
+  execSync(
+    `${yarnPath} --force --non-interactive`,
+    {stdio: 'inherit', cwd: resolvePath(root, `${relativePath}`)}
+  )
+  log.info('Finished running yarn')
+}
+
+const yarnAddTSLints = (relativePath: string) => {
+  log.info(`Adding lint configs in ${relativePath}`)
+  execSync(
+    `${yarnPath} add tslint@^5.8.0 tslint-config-vtex@^2.1.0 --dev`,
+    {stdio: 'inherit', cwd: resolvePath(root, `${relativePath}`)}
+  )
+}
+
+const getTypings = async (manifest: Manifest, account: string, workspace: string) => {
+  const typingsData = await typingsInfo(account, workspace)
+
+  const buildersWithInjectedDeps =
+    pipe(
+      prop('builders'),
+      mapObjIndexed(
+        (version: string, builder: string) => {
+          const builderTypingsData = prop(builder, typingsData)
+          if (builderTypingsData && has(version, builderTypingsData)) {
+            return ramdaPath([version, 'injectedDependencies'], builderTypingsData)
+          }
+          return null
+        }
+      ),
+      ramdaReject(isNil)
+    )(manifest)
+
+  const buildersWithAppDeps =
+    pipe(
+      mapObjIndexed(
+        (injectedDependencies) => merge(manifest.dependencies, injectedDependencies)
+      ),
+      ramdaReject(isEmpty)
+    )(buildersWithInjectedDeps as Record<string, any>)
+
+  await pipe(
+    mapObjIndexed(
+      async (appDeps: Record<string, any>, builder: string) => {
+        const packageJsonPath = resolvePackageJsonPath(builder)
+        if (await pathExists(packageJsonPath)) {
+          const packageJson = readJsonSync(packageJsonPath)
+          const oldDevDeps = packageJson.devDependencies || {}
+          const oldTypingsEntries = filter(test(typingsURLRegex), oldDevDeps)
+          const newTypingsEntries = await appsWithTypingsURLs(builder, account, workspace, appDeps)
+          if (!equals(oldTypingsEntries, newTypingsEntries)) {
+            const cleanOldDevDeps = ramdaReject(test(typingsURLRegex), oldDevDeps)
+            outputJsonSync(
+              packageJsonPath,
+              {
+                ...packageJson,
+                ...{ 'devDependencies': { ...cleanOldDevDeps, ...newTypingsEntries } },
+              },
+              { spaces: '\t' }
+            )
+            try {
+              runYarn(builder)
+            } catch (e) {
+              log.error(`Error running Yarn in ${builder}.`)
+              await outputJsonSync(packageJsonPath, packageJson, { spaces: '\t' })  // Revert package.json to original state.
+            }
+
+          }
+        }
+      }
+    ),
+    values,
+    Promise.all
+  )(buildersWithAppDeps as Record<string, any>)
+
+}
+
+const tsconfig = async (account: string, workspace: string) => {
+  const http = builderHttp(account, workspace)
+  const retryOpts = {
+    retries: 2,
+    minTimeout: 1000,
+    factor: 2,
+  }
+  const downloadTSConfig = async (_: any, tryCount: number) => {
+    if (tryCount > 1) {
+      log.info(`Retrying...${tryCount-1} ---- tsconfig`)
+    }
+    try {
+      const res = await http.get(`/_v/builder/0/tsconfig`)
+      return res.data
+    } catch (err) {
+      const statusMessage = err.response.status ?
+        `: Status ${err.response.status}` : ''
+      log.error(`Error fetching tsconfig from builder-hub ${statusMessage} (try: ${tryCount})`)
+      throw err
+    }
+  }
+  try {
+    return retry(downloadTSConfig, retryOpts)
+  } catch (e) {
+    log.error('Unable to get tsconfig.json info from vtex.builder-hub.')
+    return {}
+  }
+}
+
+export const getTSConfig = async (manifest: Manifest, account: string, workspace: string) => {
+  const tsconfigsFromBuilder = await tsconfig(account, workspace)
+  const buildersWithBaseTSConfig =
+    compose(
+      ramdaReject(isNil),
+      mapObjIndexed(
+        (version: string, builder: string) => {
+          const builderTSConfig = prop(builder, tsconfigsFromBuilder)
+          if (builderTSConfig && has(version, builderTSConfig)) {
+            return prop(version, builderTSConfig)
+          }
+          return null
+        }
+      ),
+      prop('builders')
+    )(manifest)
+
+
+  return mapObjIndexed(
+    (baseTSConfig: any, builder: any) => {
+      try {
+      const tsconfigPath = resolveTSConfigPath(builder)
+      const currentTSConfig = readJsonSync(tsconfigPath)
+      const newTSConfig = mergeDeepRight(currentTSConfig, baseTSConfig)
+      outputJsonSync(tsconfigPath, newTSConfig, { spaces: '\t' })  // Revert package.json to original state.
+      } catch(e) {
+        log.error(e)
+      }
+    }
+  )(buildersWithBaseTSConfig as Record<string, any>)
+}
+
+export const setupTSLint = async (manifest: Manifest) => {
+  const builders = keys(prop('builders', manifest) || {})
+  const filteredBuilders = intersection(builders, buildersToSetTSLint)
+  compose<any, any, any>(
+    Promise.all,
+    map(
+      async (builder: string) => {
+        try {
+          const packageJsonPath = resolvePackageJsonPath(builder)
+          const devDependencies = (prop('devDependencies', await readJson(packageJsonPath))) || {}
+          if (difference(intersection(lintSetup, keys(devDependencies)), lintSetup).length !== 0) {
+            yarnAddTSLints(builder)
+            await outputJson(resolveTSLintPath(builder), { 'extends': 'tslint-config-vtex' })
+          }
+        } catch(e) {
+          log.error(e)
+        }
+      }
+    )
+  )(filteredBuilders)
+}
+
+export default async () => {
+  const manifest = await getManifest()
+  const context = { account: getAccount(), workspace: getWorkspace(), environment: getEnvironment() }
+  await setupTSLint(manifest)
+  await getTSConfig(manifest, context.account, context.workspace)
+  await getTypings(manifest, context.account, context.workspace)
+}

--- a/src/modules/setup.ts
+++ b/src/modules/setup.ts
@@ -137,7 +137,6 @@ const getInjectedDeps = (typingsData: any, version: string, builder: string) => 
   return null
 }
 
-
 const injectTypingsInPackageJson = async (account: string, workspace: string, appDeps: Record<string, any>, builder: string) => {
   const packageJsonPath = resolvePackageJsonPath(builder)
   if (await pathExists(packageJsonPath)) {

--- a/src/modules/setup.ts
+++ b/src/modules/setup.ts
@@ -172,7 +172,7 @@ const tsconfig = async (account: string, workspace: string) => {
   }
   const downloadTSConfig = async (_: any, tryCount: number) => {
     if (tryCount > 1) {
-      log.info(`Retrying...${tryCount-1} ---- tsconfig`)
+      log.info(`Retrying...${tryCount-1}`)
     }
     try {
       const res = await http.get(`/_v/builder/0/tsconfig`)
@@ -234,7 +234,7 @@ export const setupTSLint = async (manifest: Manifest) => {
         try {
           const packageJsonPath = resolvePackageJsonPath(builder)
           const devDependencies = (prop('devDependencies', await readJson(packageJsonPath))) || {}
-          if (difference(intersection(lintSetup, keys(devDependencies)), lintSetup).length !== 0) {
+          if (difference(lintSetup, intersection(lintSetup, keys(devDependencies))).length !== 0) {
             yarnAddTSLints(builder)
             await outputJson(resolveTSLintPath(builder), { 'extends': 'tslint-config-vtex' })
           }

--- a/src/modules/setup.ts
+++ b/src/modules/setup.ts
@@ -236,7 +236,7 @@ const getTSConfig = async (manifest: Manifest) => {
           currentTSConfig = readJsonSync(tsconfigPath)
         } catch(e) {
           if (e.code === 'ENOENT') {
-            log.error(`No tsconfig.json found in ${tsconfigPath}. Generating one...`)
+            log.warn(`No tsconfig.json found in ${tsconfigPath}. Generating one...`)
           } else {
             throw e
           }

--- a/src/modules/setup.ts
+++ b/src/modules/setup.ts
@@ -256,8 +256,8 @@ const createESLintSetup = async (lintDeps: string[], builder: string) => {
     const devDependencies = (prop('devDependencies', await readJson(packageJsonPath))) || {}
     if (difference(lintDeps, intersection(lintDeps, keys(devDependencies))).length !== 0) {
       yarnAddESLint(builder)
-      await outputJson(resolveESLintPath(builder), addToEslintrc[builder], { spaces: 2 })
     }
+    await outputJson(resolveESLintPath(builder), addToEslintrc[builder], { spaces: 2 })
   } catch(e) {
     log.error(e)
   }

--- a/src/modules/setup.ts
+++ b/src/modules/setup.ts
@@ -20,7 +20,6 @@ const buildersToAddAdditionalPackages = ['react', 'node']
 const addToPackageJson = {
   'eslint': '^5.15.1',
   'eslint-config-vtex': '^10.1.0',
-  'prettier': '^1.16.4',
 }
 const addToEslintrc = {
   'react': {
@@ -68,7 +67,7 @@ const typingsInfo = async (account: string, workspace: string) => {
 
   const getTypingsInfo = async (_: any, tryCount: number) => {
     if (tryCount > 1) {
-      log.info(`Retrying...${tryCount-1} typings info`)
+      log.info(`Retrying...${tryCount-1} (get typings info from builder-hub)`)
     }
     try {
       const res = await http.get(`/_v/builder/0/typings`)
@@ -195,7 +194,7 @@ const getTSConfigFromBuilderHub = async (account: string, workspace: string) => 
   const http = builderHttp(account, workspace)
   const downloadTSConfig = async (_: any, tryCount: number) => {
     if (tryCount > 1) {
-      log.info(`Retrying...${tryCount-1}`)
+      log.info(`Retrying...${tryCount-1} (get tsconfig from builder-hub)`)
     }
     try {
       const res = await http.get(`/_v/builder/0/tsconfig`)

--- a/src/modules/tree.ts
+++ b/src/modules/tree.ts
@@ -104,6 +104,10 @@ export default {
     handler: './apps/install',
     optionalArgs: 'app',
   },
+  setup: {
+    description: 'Download react app typings, lint config and tsconfig',
+    handler: './setup'
+  },
   link: {
     description: 'Start a development session for this app',
     handler: './apps/link',

--- a/src/modules/tree.ts
+++ b/src/modules/tree.ts
@@ -115,9 +115,9 @@ export default {
         type: 'boolean',
       },
       {
-        description: 'Add app dependencies to package.json and run Yarn',
-        long: 'install',
-        short: 'i',
+        description: 'Do not add app dependencies to package.json and do not run Yarn',
+        long: 'no-install',
+        short: 'n',
         type: 'boolean',
       },
       {

--- a/src/modules/tree.ts
+++ b/src/modules/tree.ts
@@ -120,7 +120,7 @@ export default {
       },
       {
         description: 'Do not add app dependencies to package.json and do not run Yarn',
-        long: 'no-install',
+        long: 'no-setup',
         short: 'n',
         type: 'boolean',
       },

--- a/src/modules/tree.ts
+++ b/src/modules/tree.ts
@@ -106,7 +106,7 @@ export default {
   },
   setup: {
     description: 'Download react app typings, lint config and tsconfig',
-    handler: './setup'
+    handler: './setup',
   },
   link: {
     description: 'Start a development session for this app',


### PR DESCRIPTION
This PR:

- Fixes asset-server URL for typings bundle fetching when an app dependency is published (use `{vendor}.vteximg.com.br/...`)
- Implements retries in the `typingsInfo` function to account for failure in the communication with vtex.builder-hub.
- Moves typings fetching to a separate command `vtex setup`
- Implements eslint configuration download in the `vtex setup` command
- Implements merging of tsconfig entries downloaded from builder-hub (vtex/builder-hub#523)
- Makes `vtex link` run `vtex setup` by default, at the beginning of the linking process. Using `vtex link --no-setup` will make it skip this step.
- Guarantees that everything works fine even when the user runs `vtex link` in some folder below the app's root.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
