### PR TITLE
Improve unlink error message when app is not found in the workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.40.7",
+  "version": "2.40.8",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/modules/apps/unlink.ts
+++ b/src/modules/apps/unlink.ts
@@ -16,7 +16,12 @@ const unlinkApp = async (app: string) => {
     await unlink(app)
     log.info('Successfully unlinked', app)
   } catch (e) {
-    log.error(`Error unlinking ${app}.`, e.message)
+    if (e.response.status === 404) {
+      log.error(`${app} was not found in the current workspace. \
+Make sure you typed the right app vendor, name and version.`)
+    } else {
+      log.error(`Error unlinking ${app}.`, e.message)
+    }
   }
 }
 

--- a/src/modules/apps/unlink.ts
+++ b/src/modules/apps/unlink.ts
@@ -17,7 +17,7 @@ const unlinkApp = async (app: string) => {
     log.info('Successfully unlinked', app)
   } catch (e) {
     if (e.response.status === 404) {
-      log.error(`${app} was not found in the current workspace. \
+      log.error(`${app} is not linked in the current workspace. \
 Make sure you typed the right app vendor, name and version.`)
     } else {
       log.error(`Error unlinking ${app}.`, e.message)


### PR DESCRIPTION
Adds a better error message whenever the user tries to unlink an app that is not linked in the current workspace.

#### Types of changes
- [x] Minor change
