### PR TITLE
Add more apps to init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.51.2] - 2019-03-19
 ### Added
 - Add `render-guide` and `masterdata-graphql-guide` to the `vtex init` command options
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add `render-guide` and `masterdata-graphql-guide` to the `vtex init` command options
 
 ## [2.51.1] - 2019-03-19
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.51.1",
+  "version": "2.51.2",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/modules/init/index.ts
+++ b/src/modules/init/index.ts
@@ -16,14 +16,20 @@ const { mapSeries } = Bluebird
 
 const templates = {
   'store-theme': 'store-theme',
+  'render-guide': 'render-guide',
+  'masterdata-graphql-guide': 'masterdata-graphql-guide',
 }
 
 const titles = {
   'store-theme': 'Store Theme',
+  'render-guide': 'Render Guide',
+  'masterdata-graphql-guide': 'MasterData GraphQL Guide',
 }
 
 const descriptions = {
   'store-theme': 'VTEX IO Store Theme',
+  'render-guide': 'VTEX IO Render Guide',
+  'masterdata-graphql-guide': 'VTEX IO MasterData GraphQL Guide',
 }
 
 const promptName = async (repo: string) => {


### PR DESCRIPTION
Add [vtex-apps/render-guide](https://github.com/vtex-apps/render-guide) and [vtex-apps/masterdata-graphql-guide](https://github.com/vtex-apps/masterdata-graphql-guide) to `vtex init`.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
