### PR TITLE
Implement --no-watch option for `vtex link`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
-## [2.41.1] - 2019-02-25
+### Added
+- `--no-watch` option for `vtex link`
 
 
 ## [2.41.0] - 2018-02-21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.41.2] - 2019-02-25
 ### Added
 - `--no-watch` option for `vtex link`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.41.1",
+  "version": "2.41.2",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/modules/apps/link.ts
+++ b/src/modules/apps/link.ts
@@ -345,9 +345,8 @@ export default async (options) => {
     if (options.watch === false) {
       await listenBuild(subject, buildTrigger, { waitCompletion: true })
       return
-    } else {
-      unlistenBuild = await listenBuild(subject, buildTrigger, { waitCompletion: false, onBuild, onError }).then(prop('unlisten'))
     }
+    unlistenBuild = await listenBuild(subject, buildTrigger, { waitCompletion: false, onBuild, onError }).then(prop('unlisten'))
   } catch (e) {
     if (e.response) {
       const { data } = e.response

--- a/src/modules/apps/link.ts
+++ b/src/modules/apps/link.ts
@@ -342,8 +342,12 @@ export default async (options) => {
   try {
     const buildTrigger = performInitialLink.bind(this, appId, builder, extraData)
     const [subject] = appId.split('@')
-    const { unlisten } = await listenBuild(subject, buildTrigger, { waitCompletion: false, onBuild, onError })
-    unlistenBuild = unlisten
+    if (options.watch === false) {
+      await listenBuild(subject, buildTrigger, { waitCompletion: true })
+      return
+    } else {
+      unlistenBuild = await listenBuild(subject, buildTrigger, { waitCompletion: false, onBuild, onError }).then(prop('unlisten'))
+    }
   } catch (e) {
     if (e.response) {
       const { data } = e.response

--- a/src/modules/tree.ts
+++ b/src/modules/tree.ts
@@ -116,6 +116,11 @@ export default {
         short: 'i',
         type: 'boolean',
       },
+      {
+        description: `Don't watch for file changes after initial link`,
+        long: 'no-watch',
+        type: 'boolean',
+      },
     ],
   },
   list: {


### PR DESCRIPTION
As the title says, this PR implements an option for the `vtex link` command.

Issuing `vtex link --no-watch` will make the command exit as soon as the app has finished the linking process.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
