### PR TITLE
Attempt to fix changed file issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- File watcher during `vtex link` should not queue files as 'deleted' when they are simply updated
 
 ## [2.41.7] - 2019-02-27
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.41.8] - 2019-02-28
 ### Fixed
 - File watcher during `vtex link` should not queue files as 'deleted' when they are simply updated
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.41.7",
+  "version": "2.41.8",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/modules/apps/link.ts
+++ b/src/modules/apps/link.ts
@@ -217,11 +217,7 @@ const watchAndSendChanges = async (appId: string, builder: Builder, extraData : 
   return new Promise((resolve, reject) => {
     watcher
       .on('add', (file, { size }) => size > 0 ? queueChange(file) : null)
-      .on('change', (file, { size }) => {
-        return size > 0
-          ? queueChange(file)
-          : queueChange(file, true)
-      })
+      .on('change', file => queueChange(file))
       .on('unlink', file => queueChange(file, true))
       .on('error', reject)
       .on('ready', resolve)

--- a/src/modules/apps/link.ts
+++ b/src/modules/apps/link.ts
@@ -216,7 +216,7 @@ const watchAndSendChanges = async (appId: string, builder: Builder, extraData : 
 
   return new Promise((resolve, reject) => {
     watcher
-      .on('add', (file, { size }) => size > 0 ? queueChange(file) : null)
+      .on('add', file => queueChange(file))
       .on('change', file => queueChange(file))
       .on('unlink', file => queueChange(file, true))
       .on('error', reject)


### PR DESCRIPTION
This PR is an attempt to fix an issue with the file system watcher during the `vtex link`. There are reports that updated files are being first queued as deleted by the watcher. This makes builder-hub 'patch' the build removing the file, and the build fails.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
