### PR TITLE
Update changelog only on stable releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.41.7] - 2019-02-27
 ### Fixed
 - `vtex release` only updates CHANGELOG.md on stable releases
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `vtex release` only updates CHANGELOG.md on stable releases
 
 ## [2.41.6] - 2019-02-27
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.41.6",
+  "version": "2.41.7",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/modules/release/index.ts
+++ b/src/modules/release/index.ts
@@ -13,12 +13,19 @@ import {
   preRelease,
   push,
   readVersion,
-  tag
+  tag,
+  updateChangelog,
 } from './utils'
 
 const supportedReleaseTypes = ['major', 'minor', 'patch', 'prerelease']
-
 const supportedTagNames = ['stable', 'beta']
+const releaseTypesToUpdateChangelog = ['major', 'minor', 'patch']
+const tagNamesToUpdateChangelog = ['stable']
+
+const shouldUpdateChangelog = (releaseType, tagName) => {
+  return (releaseTypesToUpdateChangelog.indexOf(releaseType) >= 0) &&
+    (tagNamesToUpdateChangelog.indexOf(tagName) >= 0)
+}
 
 export default async (
   releaseType = 'patch',
@@ -66,7 +73,10 @@ Valid release tags are: ${supportedTagNames.join(', ')}`)
   log.info('Starting release...')
   try {
     await preRelease()
-    await bump(changelogVersion, newVersion)
+    await bump(newVersion)
+    if (shouldUpdateChangelog(releaseType, tagName)) {
+      updateChangelog(changelogVersion)
+    }
     await add()
     await commit(tagText)
     await tag(tagText)

--- a/src/modules/release/utils.ts
+++ b/src/modules/release/utils.ts
@@ -243,7 +243,6 @@ export const updateChangelog = (changelogVersion: any) => {
 }
 
 export const bump = (newVersion: string) => {
-  // Update version on CHANGELOG.md
   const manifest = readVersionFile()
   manifest.version = newVersion
   writeVersionFile(manifest)

--- a/src/modules/release/utils.ts
+++ b/src/modules/release/utils.ts
@@ -211,8 +211,7 @@ export const add = () => {
   return runCommand(gitAddCommand, successMessage, true)
 }
 
-export const bump = (changelogVersion: any, newVersion: string) => {
-  // Update version on CHANGELOG.md
+export const updateChangelog = (changelogVersion: any) => {
   if (existsSync(changelogPath)) {
     let data: string
     try {
@@ -222,24 +221,29 @@ export const bump = (changelogVersion: any, newVersion: string) => {
     }
     if (data.indexOf(unreleased) < 0) {
       log.info(chalk.red.bold(
-      `I can\'t update your CHANGELOG. :( \n
+        `I can\'t update your CHANGELOG. :( \n
         Make your CHANGELOG great again and follow the CHANGELOG format
         http://keepachangelog.com/en/1.0.0/`
       ))
-      } else {
-        const position = data.indexOf(unreleased) + unreleased.length
-        const bufferedText = Buffer.from(
-          `${changelogVersion}${data.substring(position)}`
-        )
-        const file = openSync(changelogPath, 'r+')
-        try {
-          writeSync(file, bufferedText, 0, bufferedText.length, position)
-          close(file)
-        } catch (e) {
-          throw new Error(`Error writing file: ${e}`)
-        }
+    } else {
+      const position = data.indexOf(unreleased) + unreleased.length
+      const bufferedText = Buffer.from(
+        `${changelogVersion}${data.substring(position)}`
+      )
+      const file = openSync(changelogPath, 'r+')
+      try {
+        writeSync(file, bufferedText, 0, bufferedText.length, position)
+        close(file)
+        log.info(`updated CHANGELOG`)
+      } catch (e) {
+        throw new Error(`Error writing file: ${e}`)
       }
+    }
   }
+}
+
+export const bump = (newVersion: string) => {
+  // Update version on CHANGELOG.md
   const manifest = readVersionFile()
   manifest.version = newVersion
   writeVersionFile(manifest)


### PR DESCRIPTION
This PR makes `vtex release` update the `CHANGELOG.md` only on stable releases.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
