### PR TITLE
Fix retries for app linking and publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.42.1] - 2019-02-28
+
 ## [2.42.0] - 2019-02-28
 ### Added
 - Close Chrome tab after successful login on Mac.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.42.0",
+  "version": "2.42.1",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",


### PR DESCRIPTION
This PR:
- Includes the file stream creation inside the retried functions, solving the stream errors appearing when the first try fails.
- Makes retries happen only when vtex.builder-hub responds with status code >= 500.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
