### PR TITLE
 Add handling for billing app install codes and KR forbidden errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.42.3] - 2019-03-09
 ### Added
 - Error messages for missing install licenses and unsupported regions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Error messages for missing install licenses and unsupported regions
 
 ## [2.42.2] - 2019-03-07
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.42.2",
+  "version": "2.42.3",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/modules/apps/install.ts
+++ b/src/modules/apps/install.ts
@@ -57,12 +57,6 @@ export const prepareInstall = async (appsList: string[]): Promise<void> => {
         case 'installed_free':
           log.debug('Free app')
           break
-        case 'no_buy_app_license':
-          log.error('You do not have the necessary license to purchase apps. Please check your VTEX IO resources access')
-          break
-        case 'area_unavailable':
-          log.error('Unfortunately, app purchases are not yet available in your region')
-          break
         case 'check_terms':
           if (!billingOptions) {
             throw new Error('Failed to get billing options')
@@ -79,11 +73,20 @@ export const prepareInstall = async (appsList: string[]): Promise<void> => {
     if (isNotFoundError(e)) {
       log.warn(`Billing app not found in current workspace. Please install it with ${chalk.green('vtex install vtex.billing')}`)
     } else if (isForbiddenError(e)) {
-      log.error('You do not have permission to perform this operation. Please check your VTEX IO resources access')
+      log.error(`You do not have permission to install apps. Please check your VTEX IO 'Install App' resource access in Account Management`)
     } else if (hasErrorMessage(e)) {
       log.error(e.response.data.message)
     } else {
-      logGraphQLErrorMessage(e)
+      switch (e.message) {
+        case 'no_buy_app_license':
+          log.error(`You do not have permission to purchase apps. Please check your VTEX IO 'Buy Apps' resource access in Account Managament`)
+          break
+        case 'area_unavailable':
+          log.error('Unfortunately, app purchases are not yet available in your region')
+          break
+        default:
+          logGraphQLErrorMessage(e)
+      }
     }
     log.warn(`The following app was not installed: ${app}`)
   }

--- a/src/modules/apps/install.ts
+++ b/src/modules/apps/install.ts
@@ -57,9 +57,6 @@ export const prepareInstall = async (appsList: string[]): Promise<void> => {
         case 'installed_free':
           log.debug('Free app')
           break
-        case 'no_install_app_license':
-          log.error('You do not have the necessary license to install apps. Please check your VTEX IO resources access')
-          break
         case 'no_buy_app_license':
           log.error('You do not have the necessary license to purchase apps. Please check your VTEX IO resources access')
           break


### PR DESCRIPTION
#### What is the purpose of this pull request?
Improve error messages for install errors

#### What problem is this solving?
Current displaying of install error codes do not help users on how to proceed to fix them. The proposed fix addresses this problem by giving more complete error messages

#### How should this be manually tested?
1. In account `extensions`, create a new workspace;
2. Associate a user with a `VTEX IO no-buy` or a `VTEX IO no-install` profile in Account Management (License Manager);
3. Login in your workspace with the created user email;
4. Try to install `vtex.google-shopping`, you should receive the message correspondent to the associated profile.

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
- [x] Other: Improvement of existing functionality