### PR TITLE
Small refactoring to centralize region handling

### DIFF
--- a/src/modules/apps/link.ts
+++ b/src/modules/apps/link.ts
@@ -13,6 +13,7 @@ import { concat, equals, filter, has, isEmpty, isNil, map, mapObjIndexed, merge,
 import { createInterface } from 'readline'
 import { createClients } from '../../clients'
 import { getAccount, getEnvironment, getToken, getWorkspace } from '../../conf'
+import { region } from '../../env'
 import { CommandError } from '../../errors'
 import { getMostAvailableHost } from '../../host'
 import { toAppLocator } from '../../locator'
@@ -39,10 +40,9 @@ const typingsURLRegex = /_v\/\w*\/typings/
 
 const resolvePackageJsonPath = (builder: string) => resolvePath(process.cwd(), `${builder}/package.json`)
 
-const typingsInfo = async (workspace: string, account: string, environment: string) => {
-  const extension = (environment === 'prod') ? '1' : '2'
+const typingsInfo = async (workspace: string, account: string) => {
   const http = axios.create({
-    baseURL: `http://builder-hub.vtex.aws-us-east-${extension}.vtex.io/${account}/${workspace}`,
+    baseURL: `http://builder-hub.vtex.${region()}.vtex.io/${account}/${workspace}`,
     timeout: builderHubTypingsInfoTimeout,
     headers: {
       'Authorization': getToken(),
@@ -86,7 +86,7 @@ const runYarn = (relativePath: string) => {
 }
 
 const getTypings = async (manifest: Manifest, account: string, workspace: string, environment: string) => {
-  const typingsData = await typingsInfo(workspace, account, environment)
+  const typingsData = await typingsInfo(workspace, account)
 
   const buildersWithInjectedDeps =
     pipe(

--- a/src/modules/apps/undeprecate.ts
+++ b/src/modules/apps/undeprecate.ts
@@ -4,7 +4,7 @@ import * as Bluebird from 'bluebird'
 import chalk from 'chalk'
 import * as inquirer from 'inquirer'
 import { head, prepend, prop, tail } from 'ramda'
-import { getAccount, getToken, getWorkspace } from '../../conf'
+import { getAccount, getToken, getWorkspace, Region } from '../../conf'
 import { UserCancelledError } from '../../errors'
 import log from '../../logger'
 import { getManifest, validateApp } from '../../manifest'
@@ -62,14 +62,14 @@ const undeprecateApp = async (app: string): Promise<AxiosResponse> => {
   // `undeprecateApp` method in node-vtex-api and upgrade the library version
   // used in this project.
   const http = axios.create({
-    baseURL: `http://apps.aws-us-east-1.vtex.io/`,
+    baseURL: `http://apps.${Region.Production}.vtex.io/`,
     timeout: undeprecateRequestTimeOut,
     headers: {
       'Authorization': getToken(),
       'Content-Type': 'application/json',
     },
   })
-  const finalroute = `http://apps.aws-us-east-1.vtex.io/${vendor}/master/registry/${vendor}.${name}/${version}`
+  const finalroute = `http://apps.${Region.Production}.vtex.io/${vendor}/master/registry/${vendor}.${name}/${version}`
   return await http.patch(finalroute, {deprecated: false})
 }
 

--- a/src/modules/browse/admin.ts
+++ b/src/modules/browse/admin.ts
@@ -1,15 +1,10 @@
 import * as opn from 'opn'
 import * as conf from '../../conf'
-
-const chooseDomain = (region: conf.Environment): string =>
-  region === conf.Environment.Production
-    ? 'myvtex.com'
-    : 'myvtexdev.com'
+import { publicEndpoint } from '../../env'
 
 export default () => {
-  const region = conf.getEnvironment()
   const { account, workspace } = conf.currentContext
-  const uri = `https://${workspace}--${account}.${chooseDomain(region)}/admin`
+  const uri = `https://${workspace}--${account}.${publicEndpoint()}/admin`
 
   opn(uri, { wait: false })
 }

--- a/src/modules/infra/install.ts
+++ b/src/modules/infra/install.ts
@@ -6,6 +6,7 @@ import { curry, path, prop } from 'ramda'
 import * as semver from 'semver'
 
 import { router } from '../../clients'
+import { Region } from '../../conf'
 import log from '../../logger'
 import { diffVersions, getTag } from './utils'
 
@@ -79,13 +80,13 @@ const getInstalledVersion = (service: string): Bluebird<string> =>
 export default (name: string) => {
   const [service, suffix] = name.split('@')
   const spinner = ora('Getting versions').start()
-  // We force getting versions from the aws-us-east-1 region as currently all
+  // We force getting versions from the Production region as currently all
   // regions use the same ECR on us-east-1 region. This API is old and weird,
   // as it shouldn't return the regions in the response if I'm already querying
   // a single region. Only change to use `env.region()` when router fixed.
   return Promise.all([
     getInstalledVersion(service),
-    getAvailableVersions(service).then(path(['versions', 'aws-us-east-1'])),
+    getAvailableVersions(service).then(path(['versions', Region.Production])),
   ])
     .tap(() => spinner.stop())
     .spread(getNewVersion(suffix))

--- a/src/modules/infra/update.ts
+++ b/src/modules/infra/update.ts
@@ -8,6 +8,7 @@ import { prop } from 'ramda'
 import * as semver from 'semver'
 
 import { router } from '../../clients'
+import { Region } from '../../conf'
 import log from '../../logger'
 import { diffVersions, getTag } from './utils'
 
@@ -45,7 +46,7 @@ const logVersionMap = ({ latest, update }: InfraVersionMap): void => {
 const createVersionMap = (availableRes: AvailableServices, installedRes: InstalledService[]): InfraVersionMap =>
   installedRes.reduce((acc, { name, version: currentVersion }) => {
     const tag = getTag(currentVersion)
-    const latestVersion = availableRes[name].versions['aws-us-east-1'] // See comment in src/modules/infra/install.ts:82
+    const latestVersion = availableRes[name].versions[Region.Production] // See comment in src/modules/infra/install.ts:82
       .filter(v => getTag(v) === tag)
       .sort(semver.rcompare)[0]
     if (currentVersion !== latestVersion) {

--- a/src/modules/workspace/create.ts
+++ b/src/modules/workspace/create.ts
@@ -3,11 +3,12 @@ import chalk from 'chalk'
 
 import { workspaces } from '../../clients'
 import { getAccount, getToken } from '../../conf'
+import { region } from '../../env'
 import { CommandError } from '../../errors'
 import log from '../../logger'
 
 const VALID_WORKSPACE = /^[a-z][a-z0-9-]{0,126}[a-z0-9]$/
-const routeMapURL = (workspace) => `http://colossus.aws-us-east-1.vtex.io/${getAccount()}/${workspace}/routes`
+const routeMapURL = (workspace) => `http://colossus.${region()}.vtex.io/${getAccount()}/${workspace}/routes`
 
 export default async (name: string) => {
   if (!VALID_WORKSPACE.test(name)) {


### PR DESCRIPTION
#### What is the purpose of this pull request?
The goal is to move all region handling to a single place so we can easily change a region's name or add/remove regions at will.

#### What problem is this solving?
We are going to need this kind of thing a lot now that we have dev clusters.

#### How should this be manually tested?
1. Create a workspace both in staging and in production.
2. Use `vtex browse admin` both in staging and in production.
3. Link an app both in staging and in production.
4. Install and update infra apps both in staging and in production.
5. Undeprecate an app.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
- [x] Refactor for which people should thank me in the future.
