### PR TITLE
Stop updating app majors by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.45.0] - 2019-03-14
 ### Added
 - Option `--major` (`-m`) in `vtex update` for updating app majors.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Option `-m` in `vtex update` for updating app majors.
 
 ## [2.44.0] - 2019-03-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- Option `-m` in `vtex update` for updating app majors.
+- Option `--major` (`-m`) in `vtex update` for updating app majors.
 
 ## [2.44.0] - 2019-03-14
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.44.0",
+  "version": "2.45.0",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/modules/apps/utils.ts
+++ b/src/modules/apps/utils.ts
@@ -87,9 +87,9 @@ export const appLatestMajor = (app: string): Promise<string | never> => {
     .then<string>(wildVersionByMajor)
 }
 
-export const appLatestVersion = (app: string): Promise<string | never> => {
+export const appLatestVersion = (app: string, version='x'): Promise<string | never> => {
   return createClients().registry
-    .getAppManifest(app, 'x')
+    .getAppManifest(app, version)
     .then<string>(prop('id'))
     .then<string>(extractVersionFromId)
     .catch(handleError(app))

--- a/src/modules/infra/utils.ts
+++ b/src/modules/infra/utils.ts
@@ -1,4 +1,5 @@
 import chalk from 'chalk'
+import * as R from 'ramda'
 import * as semver from 'semver'
 
 const stitch = (main: string, prerelease: string): string =>
@@ -7,21 +8,20 @@ const stitch = (main: string, prerelease: string): string =>
 const diff = (a: string | string[], b: string | string[]): string[] => {
   const from = []
   const to = []
-  for (let i = 0; i < Math.max(a.length, b.length); i++) {
-    const ai = a[i]
-    const bi = b[i]
-    if (ai !== bi) {
-      if (ai !== undefined) {
-        from.push(chalk.red(ai))
+  let fromFormatter = x => x
+  let toFormatter = x => x
+  R.compose(
+    R.map(
+      ([aDigit, bDigit]) => {
+        if (aDigit !== bDigit) {
+          fromFormatter = x => chalk.red(x)
+          toFormatter = x => chalk.green(x)
+        }
+        from.push(fromFormatter(aDigit))
+        to.push(toFormatter(bDigit))
       }
-      if (bi !== undefined) {
-        to.push(chalk.green(bi))
-      }
-    } else {
-      from.push(ai)
-      to.push(bi)
-    }
-  }
+    ),
+    R.zip)(a, b)
   return [from.join('.'), to.join('.')]
 }
 

--- a/src/modules/tree.ts
+++ b/src/modules/tree.ts
@@ -283,8 +283,8 @@ export default {
         long: 'major',
         short: 'm',
         type: 'boolean',
-      }
-    ]
+      },
+    ],
   },
   use: {
     description: 'Use a workspace to perform operations',

--- a/src/modules/tree.ts
+++ b/src/modules/tree.ts
@@ -277,6 +277,14 @@ export default {
   update: {
     description: 'Update all installed apps to the latest version',
     handler: './apps/update',
+    options: [
+      {
+        description: 'Update to newest majors',
+        long: 'major',
+        short: 'm',
+        type: 'boolean',
+      }
+    ]
   },
   use: {
     description: 'Use a workspace to perform operations',


### PR DESCRIPTION
This PR makes the `vtex update` command stop updating majors by default. If the user wants to update app majors, they must use `vtex update -m` or `vtex update --major`.

This also fixes the colors in the version diff table:

### Before this PR
![image](https://user-images.githubusercontent.com/20361388/54300500-c3477b80-459b-11e9-8805-58265293e8fb.png)


### After this PR
![image](https://user-images.githubusercontent.com/20361388/54300526-cc384d00-459b-11e9-97cb-50b81e9aa02a.png)


- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
- [x] Refactor
