### PR TITLE
Save config of current account before changing account for publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Config is saved before changing account for app publishing and is
+  automatically restored when going back to previous account.
 
 ## [2.46.0] - 2019-03-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.47.0] - 2019-03-14
 ### Fixed
 - Config is saved before changing account for app publishing and is
   automatically restored when going back to previous account.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.46.0",
+  "version": "2.47.0",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/conf.ts
+++ b/src/conf.ts
@@ -9,6 +9,9 @@ export enum Environment {
   Staging = 'staging',
 }
 
+export const saveAll = (config: any): void => {
+  conf.all = config
+}
 export const saveAccount = (account: string): void =>
   conf.set('account', account)
 
@@ -23,6 +26,8 @@ export const saveWorkspace = (workspace = 'master') =>
 
 export const saveEnvironment = (env: Environment) =>
   conf.set('env', env)
+
+export const getAll = (): any => conf.all
 
 export const getAccount = (): string =>
   conf.get('account')


### PR DESCRIPTION
This PR makes toolbelt save the current account/workspace config before switching accounts during a `vtex publish`, so that, if the user wishes to return to his previously logged account, the config is automatically reverted.

This means: no more authentication to return to previous account after running `vtex publish`.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
