### PR TITLE
Upgrade node vtex api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.48.0] - 2019-03-14
 ### Changed
 - Upgrade @vtex/api to version 2.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Upgrade @vtex/api to version 2.3.0
 
 ## [2.47.0] - 2019-03-14
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "url": "https://github.com/vtex/toolbelt/issues"
   },
   "dependencies": {
-    "@vtex/api": "^1.8.1",
+    "@vtex/api": "^2.3.0",
     "any-promise": "^1.3.0",
     "async-retry": "^1.2.3",
     "babel-eslint": "^8.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.47.0",
+  "version": "2.48.0",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/modules/tree.ts
+++ b/src/modules/tree.ts
@@ -305,6 +305,14 @@ export default {
       description: 'Create a new workspace with this name',
       handler: './workspace/create',
       requiredArgs: 'name',
+      options: [
+        {
+          description: 'Create a production workspace',
+          long: 'production',
+          short: 'p',
+          type: 'boolean'
+        }
+      ]
     },
     delete: {
       description: 'Delete a single or various workspaces',

--- a/src/modules/tree.ts
+++ b/src/modules/tree.ts
@@ -311,7 +311,7 @@ export default {
           long: 'production',
           short: 'p',
           type: 'boolean'
-        }
+        },
       ]
     },
     delete: {

--- a/src/modules/tree.ts
+++ b/src/modules/tree.ts
@@ -310,9 +310,9 @@ export default {
           description: 'Create a production workspace',
           long: 'production',
           short: 'p',
-          type: 'boolean'
+          type: 'boolean',
         },
-      ]
+      ],
     },
     delete: {
       description: 'Delete a single or various workspaces',

--- a/src/modules/workspace/create.ts
+++ b/src/modules/workspace/create.ts
@@ -9,15 +9,18 @@ import log from '../../logger'
 const VALID_WORKSPACE = /^[a-z][a-z0-9-]{0,126}[a-z0-9]$/
 const routeMapURL = (workspace) => `http://colossus.aws-us-east-1.vtex.io/${getAccount()}/${workspace}/routes`
 
-export default async (name: string) => {
+export default async (name: string, options: any) => {
   if (!VALID_WORKSPACE.test(name)) {
     throw new CommandError('Whoops! That\'s not a valid workspace name. Please use only lowercase letters, numbers and hyphens.')
   }
   log.debug('Creating workspace', name)
+  let production = false
+  if (options.p || options.production) {
+    production = true
+  }
   try {
-    await workspaces.create(getAccount(), name)
-    log.info(`Workspace ${chalk.green(name)} created ${chalk.green('successfully')}`)
-
+    await workspaces.create(getAccount(), name, production)
+    log.info(`Workspace ${chalk.green(name)} created ${chalk.green('successfully')} with ${chalk.green(`production=${production}`)}`)
     // First request on a brand new workspace takes very long because of route map generation, so we warm it up.
     const token = getToken()
     await axios.get(routeMapURL(name), {headers: {Authorization: token}})

--- a/src/modules/workspace/use.ts
+++ b/src/modules/workspace/use.ts
@@ -22,6 +22,18 @@ const promptWorkspaceCreation = (name: string): Bluebird<boolean> => {
     .then<boolean>(prop('confirm'))
 }
 
+const promptWorkspaceProductionFlag = (): Bluebird<boolean> => {
+  return Promise.resolve(
+    inquirer.prompt({
+      default: false,
+      type: 'confirm',
+      name: 'confirm',
+      message: 'Should the workspace be in production mode?',
+    })
+  )
+    .then<boolean>(prop('confirm'))
+}
+
 export default async (name: string, options?) => {
   const reset = options ? (options.r || options.reset) : null
   let confirm
@@ -33,7 +45,8 @@ export default async (name: string, options?) => {
       if (!confirm) {
         throw new UserCancelledError()
       }
-      await createCmd(name)
+      const production = await promptWorkspaceProductionFlag()
+      await createCmd(name, {production})
     } else {
       throw err
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5921,7 +5921,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -301,9 +301,9 @@
     "@types/through" "*"
 
 "@types/lru-cache@^4.1.1":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@types/lru-cache/-/lru-cache-4.1.1.tgz#b2d87a5e3df8d4b18ca426c5105cd701c2306d40"
-  integrity sha512-8mNEUG6diOrI6pMqOHrHPDBB1JsrpedeMK9AWGzVCQ7StRRribiT9BRvUmF8aUws9iBbVlgVekOT5Sgzc1MTKw==
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/@types/lru-cache/-/lru-cache-4.1.2.tgz#528ba392658055dba78fc3be906ca338a1a2d1c5"
+  integrity sha512-ve2IoUJClE+4S/sG2zoLGEHP6DCvqgyz7UkHZdiICdQaAYRaCXsRWfJlbL8B0KvUyo9lgzD+oR0YSy4YikFyFQ==
 
 "@types/node@*":
   version "11.9.4"
@@ -321,9 +321,9 @@
   integrity sha512-eKAv5Ql6k78dh3ULCsSBxX6bFNuGjTmof5Q/T6PiECDq0Yf8IIn46jCyp3RJvCi8owaEmm3DZH1PEImjBMd/vQ==
 
 "@types/ramda@^0.25.38":
-  version "0.25.50"
-  resolved "https://registry.yarnpkg.com/@types/ramda/-/ramda-0.25.50.tgz#7f21d47c650f85b8a61c2b608adf8aa0f1a8fccf"
-  integrity sha512-hkGWVWyPEXkXSh7rxJIGg6ELG1/WlR2BB8JemZW8v2l50bfMUw6CjrETJpgd9i3jUxaxOE/X57DvclWd9wkZhg==
+  version "0.25.51"
+  resolved "https://registry.yarnpkg.com/@types/ramda/-/ramda-0.25.51.tgz#d5421d0e190c56c64c112a761a85782fc971409d"
+  integrity sha512-xcmtfHIgF9SYjhGdsZR1nQslxG4hu0cIpFfLQ4CWdw3KzHvl7ki1AzFLQUkbDTG42ZN3ZsQfdRzXRlkAvbIy5Q==
 
 "@types/ramda@types/npm-ramda#dist":
   version "0.25.0"
@@ -442,10 +442,10 @@
   dependencies:
     "@types/node" "*"
 
-"@vtex/api@^1.8.1":
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-1.8.1.tgz#00126cad1aab01c8e437e2de192dcb60e1349884"
-  integrity sha512-N0h+tIWm0VCrdAG21TJ/WNTeUeCE6oTh1qxLwFxCaltdncA+pyBc2qqpzVpqhuUcQlXkqKRLf2/Nxbk9Vp3MuA==
+"@vtex/api@^2.3.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-2.3.0.tgz#dfebc639eae1fcef74fb7cb6a8f52415126e43ac"
+  integrity sha512-vzuXA79k0jGaedS9e1b00Te7/wLeTHpfS2xB1ps8L8wWY1aqFY0kMUza8z/ZKkEyAA4kDtpSJba+K82jMcFMNw==
   dependencies:
     "@types/graphql" "^14.0.4"
     "@types/lru-cache" "^4.1.1"
@@ -454,7 +454,7 @@
     apollo-datasource "^0.1.3"
     archiver "^3.0.0"
     axios "^0.18.0"
-    axios-retry "^3.0.3"
+    axios-retry "^3.1.2"
     fs-extra "^7.0.0"
     graphql "^14.0.2"
     graphql-tools "^4.0.3"
@@ -463,6 +463,7 @@
     lru-cache "^4.1.3"
     mime-types "^2.1.12"
     multipart-stream "^2.0.1"
+    p-limit "^2.2.0"
     p-queue "^3.0.0"
     qs "^6.5.1"
     querystring "^0.2.0"
@@ -571,11 +572,14 @@ apollo-datasource@^0.1.3:
     apollo-server-env "2.0.3"
 
 apollo-link@^1.2.3:
-  version "1.2.8"
-  resolved "https://registry.yarnpkg.com/apollo-link/-/apollo-link-1.2.8.tgz#0f252adefd5047ac1a9f35ba9439d216587dcd84"
-  integrity sha512-lfzGRxhK9RmiH3HPFi7TIEBhhDY9M5a2ZDnllcfy5QDk7cCQHQ1WQArcw1FK0g1B+mV4Kl72DSrlvZHZJEolrA==
+  version "1.2.9"
+  resolved "https://registry.yarnpkg.com/apollo-link/-/apollo-link-1.2.9.tgz#40a8f0b90716ce3fd6beb27b7eae1108b92e0054"
+  integrity sha512-ZLUwthOFZq4lxchQ2jeBfVqS/UDdcVmmh8aUw6Ar9awZH4r+RgkcDeu2ooFLUfodWE3mZr7wIZuYsBas/MaNVA==
   dependencies:
-    zen-observable-ts "^0.8.15"
+    apollo-utilities "^1.2.1"
+    ts-invariant "^0.3.2"
+    tslib "^1.9.3"
+    zen-observable-ts "^0.8.16"
 
 apollo-server-caching@0.1.2:
   version "0.1.2"
@@ -592,12 +596,13 @@ apollo-server-env@2.0.3:
     node-fetch "^2.1.2"
     util.promisify "^1.0.0"
 
-apollo-utilities@^1.0.1:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/apollo-utilities/-/apollo-utilities-1.1.3.tgz#a8883c0392f6b46eac0d366204ebf34be9307c87"
-  integrity sha512-pF9abhiClX5gfj/WFWZh8DiI33nOLGxRhXH9ZMquaM1V8bhq1WLFPt2QjShWH3kGQVeIGUK+FQefnhe+ZaaAYg==
+apollo-utilities@^1.0.1, apollo-utilities@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/apollo-utilities/-/apollo-utilities-1.2.1.tgz#1c3a1ebf5607d7c8efe7636daaf58e7463b41b3c"
+  integrity sha512-Zv8Udp9XTSFiN8oyXOjf6PMHepD4yxxReLsl6dPUy5Ths7jti3nmlBzZUOxuTWRwZn0MoclqL7RQ5UEJN8MAxg==
   dependencies:
     fast-json-stable-stringify "^2.0.0"
+    ts-invariant "^0.2.1"
     tslib "^1.9.3"
 
 append-transform@^1.0.0:
@@ -936,7 +941,7 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
-axios-retry@^3.0.3:
+axios-retry@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/axios-retry/-/axios-retry-3.1.2.tgz#4f4dcbefb0b434e22b72bd5e28a027d77b8a3458"
   integrity sha512-+X0mtJ3S0mmia1kTVi1eA3DAC+oWnT2A29g3CpkzcBPMT6vJm+hn/WiV9wPt/KXLHVmg5zev9mWqkPx7bHMovg==
@@ -4705,9 +4710,9 @@ object-copy@^0.1.0:
     kind-of "^3.0.3"
 
 object-keys@^1.0.12:
-  version "1.0.12"
-  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.12.tgz#09c53855377575310cca62f55bb334abff7b3ed2"
-  integrity sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.0.tgz#11bd22348dd2e096a045ab06f6c85bcc340fa032"
+  integrity sha512-6OO5X1+2tYkNyNEx6TsCxEqFfRWaqx6EtMiSbGrw8Ob8v9Ne+Hl8rBAgLBZn5wjEz3s/s6U1WXFUFOcxxAwUpg==
 
 object-visit@^1.0.0:
   version "1.0.1"
@@ -4868,6 +4873,13 @@ p-limit@^2.0.0:
   dependencies:
     p-try "^2.0.0"
 
+p-limit@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.2.0.tgz#417c9941e6027a9abcba5092dd2904e255b5fbc2"
+  integrity sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==
+  dependencies:
+    p-try "^2.0.0"
+
 p-locate@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
@@ -4883,9 +4895,9 @@ p-locate@^3.0.0:
     p-limit "^2.0.0"
 
 p-queue@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/p-queue/-/p-queue-3.0.0.tgz#0ef247082f0dd5a21b66e2cfe8fb7b06db13fb52"
-  integrity sha512-2tv/MRmPXfmfnjLLJAHl+DdU8p2DhZafAnlpm/C/T5BpF5L9wKz5tMin4A4N2zVpJL2YMhPlRmtO7s5EtNrjfA==
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/p-queue/-/p-queue-3.2.0.tgz#039001d544550b85fce205935acd43bd3a97d0bb"
+  integrity sha512-D2OjWeETS1Bjov7d82VclyMRigjZtMdALWV04u0H2zPvV3sYC8f6sYBgQ2Z0OHoBGUYh9S8cHtJqMAO8xaHEwg==
 
 p-timeout@^2.0.1:
   version "2.0.1"
@@ -5909,7 +5921,7 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-stats-lite@vtex/node-stats-lite#dist:
+"stats-lite@github:vtex/node-stats-lite#dist":
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:
@@ -6228,6 +6240,20 @@ trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
   integrity sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=
+
+ts-invariant@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.2.1.tgz#3d587f9d6e3bded97bf9ec17951dd9814d5a9d3f"
+  integrity sha512-Z/JSxzVmhTo50I+LKagEISFJW3pvPCqsMWLamCTX8Kr3N5aMrnGOqcflbe5hLUzwjvgPfnLzQtHZv0yWQ+FIHg==
+  dependencies:
+    tslib "^1.9.3"
+
+ts-invariant@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.3.2.tgz#89a2ffeb70879b777258df1df1c59383c35209b0"
+  integrity sha512-QsY8BCaRnHiB5T6iE4DPlJMAKEG3gzMiUco9FEt1jUXQf0XP6zi0idT0i0rMTu8A326JqNSDsmlkA9dRSh1TRg==
+  dependencies:
+    tslib "^1.9.3"
 
 tslib@1.9.0:
   version "1.9.0"
@@ -6676,11 +6702,12 @@ yarn@^1.9.4:
   resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.13.0.tgz#affa9c956739548024068532a902cf18c9cb523f"
   integrity sha512-Unfw2eefv8imt4ZMPhvFVP44WCz38huDxkHs+Yqrx4wBTK75Tr0mh3V4rh+2Nw5iQq0rcM/VafotCZo9qTb5DA==
 
-zen-observable-ts@^0.8.15:
-  version "0.8.15"
-  resolved "https://registry.yarnpkg.com/zen-observable-ts/-/zen-observable-ts-0.8.15.tgz#6cf7df6aa619076e4af2f707ccf8a6290d26699b"
-  integrity sha512-sXKPWiw6JszNEkRv5dQ+lQCttyjHM2Iks74QU5NP8mMPS/NrzTlHDr780gf/wOBqmHkPO6NCLMlsa+fAQ8VE8w==
+zen-observable-ts@^0.8.16:
+  version "0.8.16"
+  resolved "https://registry.yarnpkg.com/zen-observable-ts/-/zen-observable-ts-0.8.16.tgz#969367299074fe17422fe2f46ee417e9a30cf3fa"
+  integrity sha512-pQl75N7qwgybKVsh6WFO+WwPRijeQ52Gn1vSf4uvPFXald9CbVQXLa5QrOPEJhdZiC+CD4quqOVqSG+Ptz5XLA==
   dependencies:
+    tslib "^1.9.3"
     zen-observable "^0.8.0"
 
 zen-observable@^0.8.0:


### PR DESCRIPTION
Upgrade to @vtex/api to newest version (^2.3.0).

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
- [x] Upgrade dependency