### PR TITLE
Implement `vtex switch {account}/{workspace}`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Makes possible to switch directly to another account/workspace with the `vtex switch {account}/{workspace}` syntax
 
 ## [2.51.0] - 2019-03-19
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.51.1] - 2019-03-19
 ### Added
 - Makes possible to switch directly to another account/workspace with the `vtex switch {account}/{workspace}` syntax
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.51.0",
+  "version": "2.51.1",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/modules/auth/switch.ts
+++ b/src/modules/auth/switch.ts
@@ -1,5 +1,6 @@
 import chalk from 'chalk'
 
+import { split } from 'ramda'
 import { getAccount } from '../../conf'
 import { CommandError } from '../../errors'
 import log from '../../logger'
@@ -17,7 +18,7 @@ export const switchAccount = async (account: string, options, previousAccount = 
   } else if (previousAccount === account) {
     throw new CommandError(`You're already using the account ${chalk.blue(account)}`)
   }
-  
+
   return await loginCmd({ account, workspace })
 }
 
@@ -27,7 +28,13 @@ const hasAccountSwitched = (account: string) => {
 
 export default async (account: string, options) => {
   const previousAccount = getAccount()
-  await switchAccount(account, options)
+  // Enable users to type `vtex switch {account}/{workspace}` and switch
+  // directly to a workspace without typing the `-w` option.
+  const [ parsedAccount, parsedWorkspace ] = split('/', account)
+  if (parsedWorkspace) {
+    options = {...options, w: parsedWorkspace, workspace: parsedWorkspace}
+  }
+  await switchAccount(parsedAccount, options)
   if (hasAccountSwitched(account)) {
     log.info(`Switched from ${chalk.blue(previousAccount)} to ${chalk.blue(account)}`)
   }


### PR DESCRIPTION
As the title says, enable users to switch directly to a workspace in another account without having to type the `-w` option.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
