### PR TITLE
Fix "switch to previous account" answer parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.48.1] - 2019-03-14
 ### Fixed
 - Answer for switching to previous account after `vtex publish` is now correctly
   considered

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Answer for switching to previous account after `vtex publish` is now correctly
+  considered
 
 ## [2.48.0] - 2019-03-14
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.48.0",
+  "version": "2.48.1",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/modules/apps/publish.ts
+++ b/src/modules/apps/publish.ts
@@ -32,7 +32,7 @@ const getSwitchAccountMessage = (previousAccount: string, currentAccount = conf.
 const switchToPreviousAccount = async (previousConf: any) => {
   const previousAccount = previousConf.account
   if (previousAccount !== conf.getAccount()) {
-    const canSwitchToPrevious = promptPublishOnVendor(getSwitchAccountMessage(previousAccount))
+    const canSwitchToPrevious = await promptPublishOnVendor(getSwitchAccountMessage(previousAccount))
     if (canSwitchToPrevious) {
       conf.saveAll(previousConf)
     }


### PR DESCRIPTION
This PR solves the following problem:

- The answer to the prompt asking if the user wants to go to his previously logged account after publishing an app was not being correctly parsed.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
