### PR TITLE
Implement most of the states and transitions as chronos expects

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ $ vtex
     list                    List your installed VTEX apps
     login                   Log into a VTEX account
     logout                  Logout of the current VTEX account
-    production [production] Set this workspace's production mode to true or false
     promote                 Promote this workspace to master
     publish [path]          Publish the current app or a path containing an app
     switch <account>        Switch to another VTEX account
@@ -95,7 +94,6 @@ $ vtex
     workspace delete <name>           Delete a single or various workspaces
     workspace info                    Display information about the current workspace
     workspace list                    List workspaces on this account
-    workspace production [production] Set this workspace's production mode to true or false
     workspace promote                 Promote this workspace to master
     workspace reset [name]            Delete and create a workspace
     workspace test [weight]           Set AB test in current workspace
@@ -119,7 +117,7 @@ VTEX Toolbelt will now monitor your files for changes and sync them automaticall
 
 ## Customizing your prompt
 
-You can configure your **terminal prompt** to display relevant information about your current context, like what **environment** you are using (`prod` or `staging`), which **account** you're logged into and which **workspace** you are currently using. 
+You can configure your **terminal prompt** to display relevant information about your current context, like what **environment** you are using (`prod` or `staging`), which **account** you're logged into and which **workspace** you are currently using.
 
 Just like knowing which `git` branch you're currently in, having this info in your prompt you help you avoid mistakes and be faster when using VTEX IO.
 

--- a/src/modules/apps/link.ts
+++ b/src/modules/apps/link.ts
@@ -358,7 +358,7 @@ export default async (options) => {
       }
 
       if (data.code === 'link_on_production') {
-        throw new CommandError(`Please remove your workspace from production (${chalk.blue('vtex workspace production false')}) to enable app linking`)
+        throw new CommandError(`Please use a dev workspace to link apps. Create one with (${chalk.blue('vtex use <workspace> -rp')}) to be able to link apps`)
       }
     }
     throw e

--- a/src/modules/tree.ts
+++ b/src/modules/tree.ts
@@ -192,7 +192,7 @@ export default {
     },
   },
   production: {
-    description: 'Set this workspace\'s production mode to true or false',
+    description: 'Set this workspace\'s production mode to true or false (deprecated)',
     handler: './workspace/production',
     optionalArgs: 'production',
   },
@@ -295,6 +295,14 @@ export default {
     description: 'Use a workspace to perform operations',
     handler: './workspace/use',
     requiredArgs: 'name',
+    options: [
+      {
+        description: 'If workspace does not exist, whether to create it as a production workspace',
+        long: 'production',
+        short: 'p',
+        type: 'boolean',
+      },
+    ],
   },
   whoami: {
     description: 'See your credentials current status',
@@ -345,7 +353,7 @@ export default {
       handler: './workspace/list',
     },
     production: {
-      description: 'Set this workspace\'s production mode to true or false',
+      description: 'Set this workspace\'s production mode to true or false (deprecated)',
       handler: './workspace/production',
       optionalArgs: 'production',
     },
@@ -356,6 +364,19 @@ export default {
     reset: {
       description: 'Delete and create a workspace',
       handler: './workspace/reset',
+      optionalArgs: 'name',
+      options: [
+        {
+          description: 'Whether to re-create the workspace as a production one',
+          long: 'production',
+          short: 'p',
+          type: 'boolean',
+        },
+      ],
+    },
+    status: {
+      description: 'Display information about a workspace',
+      handler: './workspace/status',
       optionalArgs: 'name',
     },
     test: {
@@ -371,6 +392,12 @@ export default {
           description: 'Resets workspace before using it',
           long: 'reset',
           short: 'r',
+          type: 'boolean',
+        },
+        {
+          description: 'Whether to create the workspace as production if it does not exist or is reset',
+          long: 'production',
+          short: 'p',
           type: 'boolean',
         },
       ],

--- a/src/modules/workspace/abTest.ts
+++ b/src/modules/workspace/abTest.ts
@@ -25,7 +25,7 @@ const promptContinue = async () => {
 const canGoLive = async (): Promise<void> => {
   const workspaceData = await get(account, currentWorkspace)
   if (!workspaceData.production) {
-    throw new CommandError(`A workspace must be in production before you can test it. Please run ${chalk.blue('vtex production true')} and try again`)
+    throw new CommandError(`Only ${chalk.green('production')} workspaces can be used for testing. Please create a production workspace with ${chalk.blue('vtex use <workspace> -r -p')} or reset this one with ${chalk.blue('vtex workspace reset -p')}`)
   }
 }
 

--- a/src/modules/workspace/production.ts
+++ b/src/modules/workspace/production.ts
@@ -1,47 +1,7 @@
 import chalk from 'chalk'
 
-import { apps, workspaces } from '../../clients'
-import { getAccount, getWorkspace } from '../../conf'
 import { CommandError } from '../../errors'
-import log from '../../logger'
 
-const { listLinks } = apps
-const { set } = workspaces
-const [account, currentWorkspace] = [getAccount(), getWorkspace()]
-
-const canGoLive = async (): Promise<void> => {
-  const links = await listLinks()
-  if (links.length > 0) {
-    throw new CommandError(`You have links on your workspace. Please try another workspace or reset this one (${chalk.blue('vtex workspace reset ' + currentWorkspace)}) before setting production mode`)
-  }
-}
-
-const pretty = p => p ? chalk.green('production mode') : chalk.red('development mode')
-
-export default async (production: any) => {
-  let prod
-
-  if (production === null || production === 'true' || production === undefined) {
-    prod = true
-  } else if (production === 'false') {
-    prod = false
-  } else {
-    throw new CommandError('Argument for command production must be either true or false.')
-  }
-
-  if (prod) {
-    await canGoLive()
-  } else if (currentWorkspace === 'master') {
-    throw new CommandError(`Cannot set workspace master to production=${pretty(prod)}`)
-  }
-
-  log.debug(`Setting workspace ${currentWorkspace} to production=${prod}`)
-  await set(account, currentWorkspace, { production: prod })
-  log.info(`Workspace ${chalk.green(currentWorkspace)} set to ${pretty(prod)}`)
-  if (prod) {
-    log.info(`You can now check your changes before publishing them`)
-    log.info(`If everything is fine, promote with ${chalk.blue('vtex promote')}`)
-  } else {
-    log.info(`You may now link apps again`)
-  }
+export default async (_: any) => {
+  throw new CommandError(`Converting a dev workspace into production is no longer allowed. To create a production workspace, run ${chalk.blue('vtex use <workspace> -rp')}`)
 }

--- a/src/modules/workspace/reset.ts
+++ b/src/modules/workspace/reset.ts
@@ -22,6 +22,7 @@ export default async (name: string, options) => {
   const account = getAccount()
   const workspace = name || getWorkspace()
   const preConfirm = options.y || options.yes
+  const production = options.p || options.production
 
   log.debug('Resetting workspace', workspace)
 
@@ -31,8 +32,8 @@ export default async (name: string, options) => {
 
   try {
     log.debug('Starting to reset workspace', workspace)
-    await (workspaces as any).reset(account, workspace)
-    log.info(`Workspace ${chalk.green(workspace)} was reset ${chalk.green('successfully')}`)
+    await (workspaces as any).reset(account, workspace, { production })
+    log.info(`Workspace ${chalk.green(workspace)} was reset ${chalk.green('successfully')} using ${chalk.green(`production=${production}`)}`)
   } catch (err) {
     log.warn(`Workspace ${chalk.green(workspace)} was ${chalk.red('not')} reset`)
     if (err.response) {

--- a/src/modules/workspace/status.ts
+++ b/src/modules/workspace/status.ts
@@ -1,0 +1,16 @@
+import chalk from 'chalk'
+
+import { workspaces } from '../../clients'
+import { getAccount, getWorkspace } from '../../conf'
+import log from '../../logger'
+
+const workspaceState = (meta: WorkspaceResponse) => meta.production ? 'production' : 'dev'
+
+export default async (name: string): Promise<void> => {
+  const account = getAccount()
+  const workspace = name || getWorkspace()
+
+  const meta = await workspaces.get(account, workspace)
+
+  log.info(`Workspace ${chalk.green(workspace)} in account ${chalk.blue(account)} is a ${chalk.yellowBright(workspaceState(meta))} workspace with weight ${chalk.yellowBright(`${meta.weight}`)}`)
+}

--- a/src/modules/workspace/use.ts
+++ b/src/modules/workspace/use.ts
@@ -34,8 +34,13 @@ const promptWorkspaceProductionFlag = (): Bluebird<boolean> => {
     .then<boolean>(prop('confirm'))
 }
 
+const shouldPromptProduction = (production: boolean): boolean => {
+  return production === undefined || production === null
+}
+
 export default async (name: string, options?) => {
   const reset = options ? (options.r || options.reset) : null
+  let production = options ? (options.p || options.production) : null
   let confirm
   try {
     await workspaces.get(getAccount(), name)
@@ -45,7 +50,9 @@ export default async (name: string, options?) => {
       if (!confirm) {
         throw new UserCancelledError()
       }
-      const production = await promptWorkspaceProductionFlag()
+      if (shouldPromptProduction(production)) {
+        production = await promptWorkspaceProductionFlag()
+      }
       await createCmd(name, {production})
     } else {
       throw err


### PR DESCRIPTION
We do not allow `dev` workspaces to become `production` workspaces and the
opposite is not something we should do either (`dev` and `production` are mostly
separate worlds).

This means that a workspace reset (re-create the workspace
from scratch) should be allowed to create the workspace as any of those, but
`vtex production` no longer exists, neither with `true` nor with `false` as the
last argument. To phase out the command, first mark it as deprecated in the list
shown by `vtex help` and replace the actual command with an error message with
instructions.

Another consequence is that links are not allowed in a production workspace.
This change should avoid that for most cases, though we still need to update
apps to really forbid it for good.

I had also to update a few messages that instructed the user to change the
workspace state to production. All these messages should now instruct the user
to either create or reset a workspace to make it a production one.

Finally, I felt that the information about the workspace state was not so
evident for a user, so I have created a new command to allow one to answer the
question "is the workspace I am using a production or a dev workspace?" It is
called `status` because it was the best word I could find for it, but I am not
100% happy with it. My feeling is that `production` was the best name, but it is
already taken, so I would gladly accept suggestions of better names for this new
command.

As far as I can tell, I have changed all the places that we have to change now.
We will still need to adapt Kube Router (and the whole platform) to the new
"beta" concept that came up this week, but that is for later.

#### How should this be manually tested?
Run all the commands mentioned above with both a production and a dev workspace.

#### Screenshots or example usage
![Example screenshot](https://user-images.githubusercontent.com/6957289/54468798-44a33780-476f-11e9-99b8-5983812aa5bb.png)


#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Requires change to documentation, which has been updated accordingly.
