### PR TITLE
Add VTEX IO cluster targeting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.52.1] - 2019-03-21
 ### Fixed
 - Conflicts with the master
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Conflicts with the master
 
 ## [2.52.0] - 2019-03-21
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Allows usage of VTEX IO clusters other than production and staging, by setting
+  the environment variable VTEXIO_REGION
 
 ## [2.51.4] - 2019-03-21
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.52.0] - 2019-03-21
 ### Added
 - Allows usage of VTEX IO clusters other than production and staging, by setting
   the environment variable `VTEXIO_REGION`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Allows usage of VTEX IO clusters other than production and staging, by setting
-  the environment variable VTEXIO_REGION
+  the environment variable `VTEXIO_REGION`
 
 ## [2.51.4] - 2019-03-21
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.51.4",
+  "version": "2.52.0",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.52.0",
+  "version": "2.52.1",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -1,6 +1,6 @@
 import * as archiver from 'archiver'
 import axios, { AxiosInstance } from 'axios'
-import { publicEndpoint } from './env'
+import { publicEndpoint, envCookies } from './env'
 
 const routes = {
   Publish: '_v/publish',

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -1,6 +1,6 @@
 import * as archiver from 'archiver'
 import axios, { AxiosInstance } from 'axios'
-import { publicEndpoint, envCookies } from './env'
+import { publicEndpoint } from './env'
 
 const routes = {
   Publish: '_v/publish',

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,10 +11,19 @@ import { reject, without } from 'ramda'
 import { isFunction } from 'ramda-adjunct'
 import * as pkg from '../package.json'
 import { getToken } from './conf'
+import { envCookies } from './env'
 import { CommandError, SSEConnectionError, UserCancelledError } from './errors'
 import log from './logger'
 import tree from './modules/tree'
 import notify from './update'
+import axios from 'axios'
+
+axios.interceptors.request.use(config => {
+  if (envCookies()) {
+    config.headers['Cookie'] = `${envCookies()}; ${config.headers['Cookie'] || ''}`
+  }
+  return config
+})
 
 global.Promise = Bluebird
 Bluebird.config({

--- a/src/env.ts
+++ b/src/env.ts
@@ -27,7 +27,7 @@ export function publicEndpoint(): string {
 }
 
 export function clusterIdDomainInfix(): string {
-  return process.env.VTEX_REGION ? `.${region()}` : ''
+  return process.env.VTEX_REGION ? `.${process.env.VTEX_REGION}` : ''
 }
 
 export function envCookies(): string {

--- a/src/env.ts
+++ b/src/env.ts
@@ -25,3 +25,11 @@ export function region(): string {
 export function publicEndpoint(): string {
   return getEnvironment() === Environment.Staging ? 'myvtexdev.com' : 'myvtex.com'
 }
+
+export function clusterIdDomainInfix(): string {
+  return process.env.VTEX_REGION ? `.${region()}` : ''
+}
+
+export function envCookies(): string {
+  return process.env.VTEX_REGION ? `VtexIoClusterId=${process.env.VTEX_REGION}` : ''
+}

--- a/src/modules/apps/link.ts
+++ b/src/modules/apps/link.ts
@@ -13,7 +13,7 @@ import { concat, equals, filter, has, isEmpty, isNil, map, mapObjIndexed, merge,
 import { createInterface } from 'readline'
 import { createClients } from '../../clients'
 import { getAccount, getEnvironment, getToken, getWorkspace } from '../../conf'
-import { region } from '../../env'
+import { region, publicEndpoint } from '../../env'
 import { CommandError } from '../../errors'
 import { getMostAvailableHost } from '../../host'
 import { toAppLocator } from '../../locator'
@@ -57,10 +57,9 @@ const typingsInfo = async (workspace: string, account: string) => {
 }
 
 const appTypingsURL = async (account: string, workspace: string, environment: string, appName: string, appVersion: string, builder: string): Promise<string> => {
-  const extension = (environment === 'prod') ? 'myvtex' : 'myvtexdev'
   const appId = await resolveAppId(appName, appVersion)
   const assetServerPath = isLinked({'version': appId}) ? 'private/typings/linked/v1' : 'public/typings/v1'
-  return `https://${workspace}--${account}.${extension}.com/_v/${assetServerPath}/${appId}/${typingsPath}/${builder}`
+  return `https://${workspace}--${account}.${publicEndpoint()}/_v/${assetServerPath}/${appId}/${typingsPath}/${builder}`
 }
 
 const appsWithTypingsURLs = async (builder: string, account: string, workspace: string, environment: string, appDependencies: Record<string, any>) => {

--- a/src/modules/auth/login.ts
+++ b/src/modules/auth/login.ts
@@ -10,7 +10,7 @@ import { prop } from 'ramda'
 import * as randomstring from 'randomstring'
 
 import * as conf from '../../conf'
-import { publicEndpoint } from '../../env'
+import { publicEndpoint, clusterIdDomainInfix } from '../../env'
 import log from '../../logger'
 import { onAuth } from '../../sse'
 
@@ -19,7 +19,7 @@ const details = cachedAccount && `${chalk.green(cachedLogin)} @ ${chalk.green(ca
 
 const startUserAuth = (account: string, workspace: string): Bluebird<string[] | never> => {
   const state = randomstring.generate()
-  const baseUrl = `https://${account}.${publicEndpoint()}`
+  const baseUrl = `https://${account}${clusterIdDomainInfix()}.${publicEndpoint()}`
   const returnUrl = `/_v/private/auth-server/v1/callback?workspace=${workspace}&state=${state}`
   const returnUrlEncoded = encodeURIComponent(returnUrl)
   const fullReturnUrl = baseUrl + returnUrl

--- a/src/modules/browse/admin.ts
+++ b/src/modules/browse/admin.ts
@@ -1,10 +1,10 @@
 import * as opn from 'opn'
 import * as conf from '../../conf'
-import { publicEndpoint } from '../../env'
+import { publicEndpoint, clusterIdDomainInfix } from '../../env'
 
 export default () => {
   const { account, workspace } = conf.currentContext
-  const uri = `https://${workspace}--${account}.${publicEndpoint()}/admin`
+  const uri = `https://${workspace}--${account}${clusterIdDomainInfix()}.${publicEndpoint()}/admin`
 
   opn(uri, { wait: false })
 }

--- a/src/sse.ts
+++ b/src/sse.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk'
 import { compose, forEach, path, pathOr } from 'ramda'
 
 import { getToken } from './conf'
-import { endpoint, publicEndpoint, clusterIdDomainInfix, envCookies } from './env'
+import { endpoint, publicEndpoint, envCookies } from './env'
 import { SSEConnectionError } from './errors'
 import EventSource from './eventsource'
 import log from './logger'

--- a/src/sse.ts
+++ b/src/sse.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk'
 import { compose, forEach, path, pathOr } from 'ramda'
 
 import { getToken } from './conf'
-import { endpoint, publicEndpoint, clusterIdDomainInfix } from './env'
+import { endpoint, publicEndpoint, clusterIdDomainInfix, envCookies } from './env'
 import { SSEConnectionError } from './errors'
 import EventSource from './eventsource'
 import log from './logger'
@@ -35,6 +35,7 @@ const createEventSource = (source: string) =>
   new EventSource(source, {
     headers: {
       authorization: `bearer ${getToken()}`,
+      'cookie': envCookies(),
       'user-agent': userAgent,
     },
   })
@@ -101,7 +102,7 @@ export const logAll = (context: Context, logLevel: string, id: string) => {
 }
 
 export const onAuth = (account: string, workspace: string, state: string, returnUrl: string): Promise<[string, string]> => {
-  const source = `https://${workspace}--${account}${clusterIdDomainInfix()}.${publicEndpoint()}/_v//private/auth-server/v1/sse/${state}`
+  const source = `https://${workspace}--${account}.${publicEndpoint()}/_v//private/auth-server/v1/sse/${state}`
   const es = createEventSource(source)
   return new Promise((resolve, reject) => {
     es.onmessage = (msg: MessageJSON) => {

--- a/src/sse.ts
+++ b/src/sse.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk'
 import { compose, forEach, path, pathOr } from 'ramda'
 
 import { getToken } from './conf'
-import { endpoint, publicEndpoint } from './env'
+import { endpoint, publicEndpoint, clusterIdDomainInfix } from './env'
 import { SSEConnectionError } from './errors'
 import EventSource from './eventsource'
 import log from './logger'
@@ -101,7 +101,7 @@ export const logAll = (context: Context, logLevel: string, id: string) => {
 }
 
 export const onAuth = (account: string, workspace: string, state: string, returnUrl: string): Promise<[string, string]> => {
-  const source = `https://${workspace}--${account}.${publicEndpoint()}/_v//private/auth-server/v1/sse/${state}`
+  const source = `https://${workspace}--${account}${clusterIdDomainInfix()}.${publicEndpoint()}/_v//private/auth-server/v1/sse/${state}`
   const es = createEventSource(source)
   return new Promise((resolve, reject) => {
     es.onmessage = (msg: MessageJSON) => {


### PR DESCRIPTION
This PR intends to enable VTEX Toolbelt to target any VTEX IO cluster
by providing the routing cookie on some routes, and adding the
cluster id domain infix in other routes.

#### What is the purpose of this pull request?
To allow VTEX Toolbelt to communicate with any VTEX IO clutser
#### What problem is this solving?
This generalizes the communication between toolbelt and vtex io clusters, in such a way that we're no longe limited to two environments (prod and staging), but we can out-of-the-box to use it against any created environment

#### How should this be manually tested?
Basically execute common operations against multiple clusters, by specify the environment variable `VTEXIO_REGION`

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
