### PR TITLE
Add retries for builder-hub availability requests and debugger connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Request vtex.builder-hub's availability for route map warm-up instead of
   querying Colossus, which not every user is allowed to do
 
+### Added
+- Retries for vtex.builder-hub availability requests and debugger connection
+
 ## [2.53.3] - 2019-03-28
 ### Added
 - Workspace information (whether it is in dev or production mode) in the output

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.53.4] - 2019-03-28
 ### Fixed
 - Request vtex.builder-hub's availability for route map warm-up instead of
   querying Colossus, which not every user is allowed to do

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.53.3",
+  "version": "2.53.4",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import 'any-promise/register/bluebird'
+import axios from 'axios'
 import * as Bluebird from 'bluebird'
 import chalk from 'chalk'
 import { all as clearCachedModules } from 'clear-module'
@@ -16,11 +17,10 @@ import { CommandError, SSEConnectionError, UserCancelledError } from './errors'
 import log from './logger'
 import tree from './modules/tree'
 import notify from './update'
-import axios from 'axios'
 
 axios.interceptors.request.use(config => {
   if (envCookies()) {
-    config.headers['Cookie'] = `${envCookies()}; ${config.headers['Cookie'] || ''}`
+    config.headers.Cookie = `${envCookies()}; ${config.headers.Cookie || ''}`
   }
   return config
 })

--- a/src/host.ts
+++ b/src/host.ts
@@ -1,4 +1,5 @@
 import { Builder } from '@vtex/api'
+import * as retry from 'async-retry'
 import { map, reduce } from 'ramda'
 
 import { BuilderHubTimeoutError } from './errors'
@@ -8,6 +9,12 @@ const NOT_AVAILABLE = {
   hostname: undefined,
   score: -1000,
   stickyHint: undefined,
+}
+
+const AVAILABILITY_RETRY_OPTS = {
+  retries: 2,
+  minTimeout: 1000,
+  factor: 2,
 }
 
 const withTimeout = (promise: Promise<any>, timeout: number) => {
@@ -28,14 +35,23 @@ const withTimeout = (promise: Promise<any>, timeout: number) => {
   })
 }
 
+
 const mapAvailability = (appId: string, builder: Builder, timeout: number) => {
   return map(async (hintIdx: number) => {
-    try {
+    const getAvailabilityWithTimeout = (_: any, tryCount: number) => {
+      if (tryCount > 1) {
+        log.info(`Retrying to get availability... ${tryCount-1}`)
+      }
       const availabilityP = builder.availability(appId, hintIdx)
-      const response = await withTimeout(availabilityP, timeout) as AvailabilityResponse
+      return withTimeout(availabilityP, timeout)
+    }
+    try {
+      const response = await retry(
+        getAvailabilityWithTimeout,
+        AVAILABILITY_RETRY_OPTS
+      ) as AvailabilityResponse
       const { host: stickyHint, hostname, score } = response
       log.debug(`Retrieved availability score ${score} from host ${hostname}`)
-
       return { hostname, score, stickyHint }
     } catch (e) {
       e.code === 'builder_hub_timeout'

--- a/src/host.ts
+++ b/src/host.ts
@@ -38,10 +38,7 @@ const withTimeout = (promise: Promise<any>, timeout: number) => {
 
 const mapAvailability = (appId: string, builder: Builder, timeout: number) => {
   return map(async (hintIdx: number) => {
-    const getAvailabilityWithTimeout = (_: any, tryCount: number) => {
-      if (tryCount > 1) {
-        log.info(`Retrying to get availability... ${tryCount-1}`)
-      }
+    const getAvailabilityWithTimeout = () => {
       const availabilityP = builder.availability(appId, hintIdx)
       return withTimeout(availabilityP, timeout)
     }


### PR DESCRIPTION
As the title says, to avoid `vtex link` failures. 

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
