### PR TITLE
Use relink path for linked deps based on app root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.53.1] - 2019-03-27
 ### Fixed
 - Fix relink behaviour for linked node dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix relink behaviour for linked node dependencies
 
 ## [2.53.0] - 2019-03-25
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.53.0",
+  "version": "2.53.1",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/modules/apps/link.ts
+++ b/src/modules/apps/link.ts
@@ -183,7 +183,7 @@ const watchAndSendChanges = async (appId: string, builder: Builder, extraData : 
   const moduleAndMetadata = toPairs(extraData.linkConfig.metadata)
 
   const mapLocalToBuiderPath = path => {
-    const abs = resolvePath(path)
+    const abs = resolvePath(root, path)
     for (const [module, modulePath] of moduleAndMetadata) {
       if (abs.startsWith(modulePath)) {
         return abs.replace(modulePath, join('.linked_deps', module))


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix `relink` behavior for linked node dependencies.

#### What problem is this solving?
The previous implementation assumed that `cwd === appRoot`, which is not true anymore.
As result of this when one executed `vtex` in any folder nested in the app root folder, the path of linked dependencies was calculated relatively to the nested folder, breaking the server side.

#### How should this be manually tested?
`cd {node-vtex-api-folder}`
`yarn link`
`cd {any-vtex-app-which-depends-on-it}/node`
`yarn link @vtex/api`
`vtex link`
`# Update (or just save) some file in node-vtex-api`

This should send the correct path of the dependency to `builder-hub`.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
