### PR TITLE
Stop trying to get forbidden app manifests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.53.2] - 2019-03-27
 ### Fixed
 - Stop trying to get manifest of apps with specific majors or minors from
   VTEX Registry, which is forbidden.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Stop trying to get manifest of apps with specific majors or minors from
+  VTEX Registry, which is forbidden.
 
 ## [2.53.1] - 2019-03-27
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.53.1",
+  "version": "2.53.2",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/modules/apps/update.ts
+++ b/src/modules/apps/update.ts
@@ -28,32 +28,12 @@ const updateVersion = (app) => {
   return app
 }
 
-const versionWithWildcards = (version: string, level='major') => {
-  const [major, minor] = version.split('.')
-  if (level === 'minor') {
-    return `${major}.x`
-  } else if (level === 'patch') {
-    return `${major}.${minor}.x`
-  }
-  // Then `level` is 'major'
-  return 'x'
-}
-
-export default async (options: any) => {
+export default async () => {
   const spinner = ora('Getting available updates').start()
   const { data } = await listApps()
   const installedApps = reject<Manifest>(isLinked, map(extractAppLocator, data))
-  let updateLevel: string
-  if (options.major || options.m) {
-    updateLevel = 'major'
-  } else {
-    updateLevel = 'minor'
-  }
   const withLatest = await Bluebird.all(map(async (app) => {
-    app.latest = await appLatestVersion(
-      `${app.vendor}.${app.name}`,
-      versionWithWildcards(app.version, updateLevel)
-    )
+    app.latest = await appLatestVersion(`${app.vendor}.${app.name}`)
     return app
   }, installedApps))
   const updateableApps = reject(sameVersion, withLatest)

--- a/src/modules/infra/utils.ts
+++ b/src/modules/infra/utils.ts
@@ -2,19 +2,21 @@ import chalk from 'chalk'
 import * as R from 'ramda'
 import * as semver from 'semver'
 
+const EMPTY_STRING = ''
+
 const stitch = (main: string, prerelease: string): string =>
   prerelease.length > 0 ? `${main}-${prerelease}` : main
 
 //
-// Zips all items from two lists using '' for any missing items.
+// Zips all items from two lists using EMPTY_STRING for any missing items.
 //
 const zipLongest = (xs: string | string[], ys: string | string[]) => {
   let l1 = xs
   let l2 = ys
   if (xs.length < ys.length) {
-    l1 = R.concat(xs, R.repeat('', ys.length - xs.length))
+    l1 = R.concat(xs, R.repeat(EMPTY_STRING, ys.length - xs.length))
   } else if (ys.length < xs.length) {
-    l2 = R.concat(ys, R.repeat('', xs.length - ys.length))
+    l2 = R.concat(ys, R.repeat(EMPTY_STRING, xs.length - ys.length))
   }
   return R.zip(l1, l2)
 }
@@ -31,10 +33,10 @@ const diff = (a: string | string[], b: string | string[]): string[] => {
           fromFormatter = x => chalk.red(x)
           toFormatter = x => chalk.green(x)
         }
-        if (aDigit !== '') {
+        if (aDigit !== EMPTY_STRING) {
           from.push(fromFormatter(aDigit))
         }
-        if (bDigit !== '') {
+        if (bDigit !== EMPTY_STRING) {
           to.push(toFormatter(bDigit))
         }
       }

--- a/src/modules/infra/utils.ts
+++ b/src/modules/infra/utils.ts
@@ -31,10 +31,10 @@ const diff = (a: string | string[], b: string | string[]): string[] => {
           fromFormatter = x => chalk.red(x)
           toFormatter = x => chalk.green(x)
         }
-        if (aDigit) {
+        if (aDigit !== '') {
           from.push(fromFormatter(aDigit))
         }
-        if (bDigit) {
+        if (bDigit !== '') {
           to.push(toFormatter(bDigit))
         }
       }


### PR DESCRIPTION
This PR partially reverts the changes made in #504. In order to get the latest app version with a fixed major, the `vtex update` command was trying to access a route in VTEX Registry that is forbidden for non-VTEX users.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
