### PR TITLE
Check builder-hub's availability for route map warm-up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Request vtex.builder-hub's availability for route map warm-up instead of
+  querying Colossus, which not every user is allowed to do
 
 ## [2.53.2] - 2019-03-27
 ### Fixed


### PR DESCRIPTION
This PR solves the `403 Forbidden` error that is raised when toolbelt is querying Colossus for the route map after creating a new workspace.

The solution was to:

- Request vtex.builder-hub's availability for route map warm-up instead of querying Colossus, which is something not every user is allowed to do.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
