### PR TITLE
Add workspace state (dev/production) to whoami message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.53.3] - 2019-03-28
 ### Added
 - Workspace information (whether it is in dev or production mode) in the output
   of the `vtex whoami` command

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Workspace information (whether it is in dev or production mode) in the output
+  of the `vtex whoami` command
 
 ## [2.53.2] - 2019-03-27
 ### Fixed
 - Stop trying to get manifest of apps with specific majors or minors from
-  VTEX Registry, which is forbidden.
+  VTEX Registry, which is forbidden
 
 ## [2.53.1] - 2019-03-27
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.53.2",
+  "version": "2.53.3",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/greeting.ts
+++ b/src/greeting.ts
@@ -1,12 +1,33 @@
 import chalk from 'chalk'
 
+import { workspaces } from './clients'
 import { getAccount, getEnvironment, getLogin, getWorkspace } from './conf'
+import log from './logger'
 
 const login = getLogin()
 const account = getAccount()
 const workspace = getWorkspace()
 const environment = getEnvironment()
 
-export const greeting = account && login && workspace
-  ? [`Logged into ${chalk.blue(account)} as ${chalk.green(login)} at workspace ${chalk.green(workspace)} in environment ${chalk.red(environment)}`]
-  : ['Welcome to VTEX I/O', `Login with ${chalk.green('vtex login')} ${chalk.blue('<account>')}`]
+const workspaceState = (meta: WorkspaceResponse) => meta.production ? 'production' : 'dev'
+
+const getWorkspaceState = async (): Promise<string> => {
+  try {
+    const meta = await workspaces.get(account, workspace)
+
+    return workspaceState(meta) + ' '
+  } catch (err) {
+    log.error(`Unable to fetch workspace state`)
+    log.debug(err.message)
+    return ''
+  }
+}
+
+export const greeting = async (): Promise<string[]> => {
+  if (account && login && workspace) {
+    const state = await getWorkspaceState()
+    return [`Logged into ${chalk.blue(account)} as ${chalk.green(login)} at ${chalk.yellowBright(state)}workspace ${chalk.green(workspace)} in environment ${chalk.red(environment)}`]
+  }
+
+  return ['Welcome to VTEX I/O', `Login with ${chalk.green('vtex login')} ${chalk.blue('<account>')}`]
+}

--- a/src/modules/auth/whoami.ts
+++ b/src/modules/auth/whoami.ts
@@ -1,7 +1,7 @@
 import { greeting } from '../../greeting'
 import log from '../../logger'
 
-export default () => {
-  greeting.forEach((msg: string) => log.info(msg))
-  return Promise.resolve()
+export default async (): Promise<void> => {
+  const lines = await greeting()
+  lines.forEach((msg: string) => log.info(msg))
 }

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -4,13 +4,14 @@ import * as pkg from '../../package.json'
 import { greeting } from '../greeting'
 import tree from './tree'
 
-export default (options) => {
+export default async (options) => {
   if (options.h || options.help) {
     console.log(help(tree, pkg))
   } else if (options.v || options.version) {
     console.log(pkg.version)
   } else {
-    console.log(`  ${greeting.join('\n  ')}`)
+    const lines = await greeting()
+    console.log(`  ${lines.join('\n  ')}`)
     console.log(help(tree, pkg))
   }
   return Promise.resolve()


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add information about workspace state (dev/production) to the `whoami` command, which is the go-to command for when you want to know where you are.

Since `whoami` is currently network-independent, I felt like it would be a regression to see it blowing up if the request for workspace state fails. To address this, I tried to make the failure not stop the rest of the command, opting for just displaying an error message and omitting the information we could not fetch. See example screenshot if this is not clear enough.

#### What problem is this solving?
People are used to running `vtex whoami` to get info about the current account and workspace, so they end up having to run two commands to get the necessary info.

#### How should this be manually tested?
Run `vtex whoami` and see the prepended workspace status.

#### Screenshots or example usage
![Example use](https://user-images.githubusercontent.com/6957289/55111711-c7a28700-50b9-11e9-9222-fa8d12cd36ba.png)

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
