### PR TITLE
Accept valid (semver) versions as first argument for vtex release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.53.7] - 2019-04-01
 ### Added
 - The `vtex release` command accept a valid (semver) version as its first argument
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- The `vtex release` command accept a valid (semver) version as its first argument
 
 ## [2.53.6] - 2019-03-28
 ### Added

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ $ vtex
 
     port react       Convert your app from React 0.x to React 2.x
 
+    release [releaseType/Version] [tagName]          Bump app version, commit and push to remote (git only)
+
     settings <app> [fields]                     Get app settings
     settings set <app> <fields> <value>         Set a value
     settings unset <app> <fields>               Unset a value

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.53.6",
+  "version": "2.53.7",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/modules/release/index.ts
+++ b/src/modules/release/index.ts
@@ -28,8 +28,10 @@ const releaseTypesToUpdateChangelog = ['major', 'minor', 'patch']
 const tagNamesToUpdateChangelog = ['stable']
 
 const shouldUpdateChangelog = (releaseType, tagName) => {
-  return (releaseTypesToUpdateChangelog.indexOf(releaseType) >= 0) &&
-    (tagNamesToUpdateChangelog.indexOf(tagName) >= 0) || semver.valid(releaseType)
+  return (
+    (releaseTypesToUpdateChangelog.indexOf(releaseType) >= 0) &&
+    (tagNamesToUpdateChangelog.indexOf(tagName) >= 0)
+  ) || semver.valid(releaseType)
 }
 
 const getNewAndOldVersions = (releaseType, tagName) =>  {

--- a/src/modules/release/index.ts
+++ b/src/modules/release/index.ts
@@ -1,5 +1,6 @@
 import chalk from 'chalk'
 import { indexOf, prop } from 'ramda'
+import * as semver from 'semver'
 
 import log from '../../logger'
 import {
@@ -9,7 +10,7 @@ import {
   checkIfInGitRepo,
   commit,
   confirmRelease,
-  getNewVersion,
+  incrementVersion,
   postRelease,
   preRelease,
   push,
@@ -28,37 +29,55 @@ const tagNamesToUpdateChangelog = ['stable']
 
 const shouldUpdateChangelog = (releaseType, tagName) => {
   return (releaseTypesToUpdateChangelog.indexOf(releaseType) >= 0) &&
-    (tagNamesToUpdateChangelog.indexOf(tagName) >= 0)
+    (tagNamesToUpdateChangelog.indexOf(tagName) >= 0) || semver.valid(releaseType)
+}
+
+const getNewAndOldVersions = (releaseType, tagName) =>  {
+  if (semver.valid(releaseType)) {
+    // If `releaseType` is a valid (semver) version, use it.
+    const oldVersion = readVersion()
+    const newVersion = semver.parse(releaseType).version
+    if (!semver.gt(newVersion, oldVersion)) {
+    // TODO: Remove the below log.error when toolbelt has better error handling.
+      log.error(`The new version has to be greater than the old one: \
+${newVersion} <= ${oldVersion}`)
+      throw new Error(`The new version has to be greater than the old one: \
+${newVersion} <= ${oldVersion}`)
+    }
+    return [oldVersion, newVersion]
+  } else {
+    // Else `releaseType` is just a regular release type. Then we increment the
+    // actual version.
+    // Check if releaseType is valid.
+    if (indexOf(releaseType, supportedReleaseTypes) === -1) {
+      // TODO: Remove the below log.error when toolbelt has better error handling.
+      log.error(`Invalid release type: ${releaseType}
+Valid release types are: ${supportedReleaseTypes.join(', ')}`)
+      throw new Error(`Invalid release type: ${releaseType}
+Valid release types are: ${supportedReleaseTypes.join(', ')}`)
+    }
+    // Check if tagName is valid.
+    if (indexOf(tagName, supportedTagNames) === -1) {
+      // TODO: Remove the below log.error when toolbelt has better error handling.
+      log.error(`Invalid release tag: ${tagName}
+Valid release tags are: ${supportedTagNames.join(', ')}`)
+      throw new Error(`Invalid release tag: ${tagName}
+Valid release tags are: ${supportedTagNames.join(', ')}`)
+    }
+    const oldVersion = readVersion()
+    const newVersion = incrementVersion(oldVersion, releaseType, tagName)
+    return [oldVersion, newVersion]
+  }
 }
 
 export default async (
-  releaseType = 'patch',
+  releaseType = 'patch',  // This arg. can also be a valid (semver) version.
   tagName = 'beta'
 ) => {
   checkGit()
   checkIfInGitRepo()
-
   const normalizedReleaseType = prop<string>(releaseType, releaseTypeAliases) || releaseType
-
-  // Check if releaseType is valid.
-  if (indexOf(normalizedReleaseType, supportedReleaseTypes) === -1) {
-    // TODO: Remove the below log.error when toolbelt has better error handling.
-    log.error(`Invalid release type: ${normalizedReleaseType}
-Valid release types are: ${supportedReleaseTypes.join(', ')}`)
-    throw new Error(`Invalid release type: ${normalizedReleaseType}
-Valid release types are: ${supportedReleaseTypes.join(', ')}`)
-  }
-  // Check if tagName is valid.
-  if (indexOf(tagName, supportedTagNames) === -1) {
-    // TODO: Remove the below log.error when toolbelt has better error handling.
-    log.error(`Invalid release tag: ${tagName}
-Valid release tags are: ${supportedTagNames.join(', ')}`)
-    throw new Error(`Invalid release tag: ${tagName}
-Valid release tags are: ${supportedTagNames.join(', ')}`)
-  }
-
-  const oldVersion = readVersion()
-  const newVersion = getNewVersion(oldVersion, normalizedReleaseType, tagName)
+  const [oldVersion, newVersion] = getNewAndOldVersions(normalizedReleaseType, tagName)
 
   log.info(`Old version: ${chalk.bold(oldVersion)}`)
   log.info(`New version: ${chalk.bold.yellow(newVersion)}`)

--- a/src/modules/release/utils.ts
+++ b/src/modules/release/utils.ts
@@ -44,7 +44,7 @@ export const readVersion = () => {
   return version
 }
 
-export const getNewVersion = (
+export const incrementVersion = (
   rawOldVersion: string,
   releaseType: string,
   tagName: string

--- a/src/modules/tree.ts
+++ b/src/modules/tree.ts
@@ -411,7 +411,7 @@ export default {
     },
   },
   release: {
-    description: 'Bump app version, commit and push to remote. Only for git users',
+    description: 'Bump app version, commit and push to remote. Only for git users. The first option can also be a specific valid semver version',
     handler: './release',
     optionalArgs: ['releaseType', 'tagName'],
   },


### PR DESCRIPTION
This PR makes the `vtex release` command accept a valid (semver) version as its first argument.

It can be used if the user wants to specify the exact new version instead of having it automatically bumped.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
