### PR TITLE
Start debugger tunnel only for node apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed
-- Start debugger tunnel only for node and service-js apps
+- Start debugger tunnel only for node apps
 
 ## [2.53.7] - 2019-04-01
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Start debugger tunnel only for node and service-js apps
 
 ## [2.53.7] - 2019-04-01
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.53.8] - 2019-04-02
 ### Fixed
 - Start debugger tunnel only for node apps
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.53.7",
+  "version": "2.53.8",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/modules/apps/link.ts
+++ b/src/modules/apps/link.ts
@@ -344,14 +344,14 @@ export default async (options) => {
       }
       return port
     }
-    try {
-      if (shouldStartDebugger(manifest)) {
+    if (shouldStartDebugger(manifest)) {
+      try {
         const debuggerPort = await retry(startDebugger, RETRY_OPTS_DEBUGGER)
         debuggerStarted = true
         log.info(`Debugger tunnel listening on ${chalk.green(`:${debuggerPort}`)}. Go to ${chalk.blue('chrome://inspect')} in Google Chrome to debug your running application.`)
+      } catch (e) {
+        log.error(e.message)
       }
-    } catch (e) {
-      log.error(e.message)
     }
   }
 

--- a/src/modules/apps/link.ts
+++ b/src/modules/apps/link.ts
@@ -36,6 +36,7 @@ const builderHubTypingsInfoTimeout = 2000  // 2 seconds
 const typingsPath = 'public/_types'
 const yarnPath = require.resolve('yarn/bin/yarn')
 const typingsURLRegex = /_v\/\w*\/typings/
+const buildersToStartDebugger = ['node']
 const RETRY_OPTS_INITIAL_LINK = {
   retries: 2,
   minTimeout: 1000,
@@ -50,7 +51,7 @@ const RETRY_OPTS_DEBUGGER = {
 const shouldStartDebugger = (manifest: Manifest) => compose<Manifest, any, string[], string[], boolean, boolean>(
   not,
   isEmpty,
-  intersection(['service-js', 'node']),
+  intersection(buildersToStartDebugger),
   keys,
   prop('builders')
 )(manifest)

--- a/src/modules/apps/link.ts
+++ b/src/modules/apps/link.ts
@@ -9,7 +9,7 @@ import { readFileSync } from 'fs'
 import { outputJson, pathExists, readJson } from 'fs-extra'
 import * as moment from 'moment'
 import { join, resolve as resolvePath, sep} from 'path'
-import { concat, equals, filter, has, isEmpty, isNil, map, mapObjIndexed, merge, path as ramdaPath, pipe, prop, reject as ramdaReject, test, toPairs, values } from 'ramda'
+import { compose, concat, equals, filter, has, intersection, isEmpty, isNil, keys, map, mapObjIndexed, merge, not, path as ramdaPath, pipe, prop, reject as ramdaReject, test, toPairs, values } from 'ramda'
 import { createInterface } from 'readline'
 import { createClients } from '../../clients'
 import { getAccount, getEnvironment, getToken, getWorkspace } from '../../conf'
@@ -46,6 +46,14 @@ const RETRY_OPTS_DEBUGGER = {
   minTimeout: 1000,
   factor: 2,
 }
+
+const shouldStartDebugger = (manifest: Manifest) => compose<Manifest, any, string[], string[], boolean, boolean>(
+  not,
+  isEmpty,
+  intersection(['service-js', 'node']),
+  keys,
+  prop('builders')
+)(manifest)
 
 const resolvePackageJsonPath = (builder: string) => resolvePath(process.cwd(), `${builder}/package.json`)
 
@@ -336,9 +344,12 @@ export default async (options) => {
       return port
     }
     try {
-      const debuggerPort = await retry(startDebugger, RETRY_OPTS_DEBUGGER)
-      debuggerStarted = true
-      log.info(`Debugger tunnel listening on ${chalk.green(`:${debuggerPort}`)}. Go to ${chalk.blue('chrome://inspect')} in Google Chrome to debug your running application.`)
+      if (shouldStartDebugger(manifest)) {
+        console.log('Starting debugger....')
+        const debuggerPort = await retry(startDebugger, RETRY_OPTS_DEBUGGER)
+        debuggerStarted = true
+        log.info(`Debugger tunnel listening on ${chalk.green(`:${debuggerPort}`)}. Go to ${chalk.blue('chrome://inspect')} in Google Chrome to debug your running application.`)
+      }
     } catch (e) {
       log.error(e.message)
     }

--- a/src/modules/apps/link.ts
+++ b/src/modules/apps/link.ts
@@ -346,7 +346,6 @@ export default async (options) => {
     }
     try {
       if (shouldStartDebugger(manifest)) {
-        console.log('Starting debugger....')
         const debuggerPort = await retry(startDebugger, RETRY_OPTS_DEBUGGER)
         debuggerStarted = true
         log.info(`Debugger tunnel listening on ${chalk.green(`:${debuggerPort}`)}. Go to ${chalk.blue('chrome://inspect')} in Google Chrome to debug your running application.`)


### PR DESCRIPTION
This PR makes the `vtex link` command check if the app uses the node builder before trying to start the debugger tunnel. Therefore the message `Failed to start debugger` will not appear if the user is linking apps that do not use the `node` builder.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
