### PR TITLE
Fix unrelevant logs being shown during publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.53.11] - 2019-04-10
+
 ## [2.53.10] - 2019-04-08
 ### Added
 - `delivery-theme` repo to the `vtex init` command

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.53.10",
+  "version": "2.53.11",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/locator.ts
+++ b/src/locator.ts
@@ -16,3 +16,5 @@ export const parseLocator = (locator: string): Manifest => {
   const [vendor, name] = vendorAndName.split('.')
   return { vendor, name, version }
 }
+
+export const removeVersion = (appId: string): string => appId.split('@')[0]

--- a/src/modules/apps/publish.ts
+++ b/src/modules/apps/publish.ts
@@ -126,7 +126,8 @@ const publisher = (workspace: string = 'master') => {
       const oraMessage = ora(`Publishing ${appId} ...`)
       const spinner = log.level === 'debug' ? oraMessage.info() : oraMessage.start()
       try {
-        const { response } = await listenBuild(appId, () => publishApp(path, appId, pubTag, builder), { waitCompletion: true, context })
+        const senders = ['vtex.builder-hub', 'apps']
+        const { response } = await listenBuild(appId, () => publishApp(path, appId, pubTag, builder), { waitCompletion: true, context, senders })
         if (response.code !== 'build.accepted') {
           spinner.warn(`${appId} was published successfully, but you should update your builder hub to the latest version.`)
         } else {


### PR DESCRIPTION
#### What is the purpose of this pull request?
This PR makes toolbelt display only logs sent by `builder-hub` or `apps` during a `publish`.

#### What problem is this solving?
During a build, toolbelt displays to the user all logs that either has the corresponding app as `subject` of the message or has no subject at all. Since `publish` runs on workspace `master`, this causes toolbelt to show a lot of unrelevant logs to the user.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
