### PR TITLE
Add .git to .npmignore and fix changelog

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -21,3 +21,4 @@ tsconfig.json
 coverage/
 scripts/
 yarn.lock
+.git/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.54.2] - 2019-04-16
 ### Fixed
 - Fix Changelog and add `.git/` to `.npmignore`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix Changelog and add `.git/` to `.npmignore`
 
 ## [2.54.1] - 2019-04-16
+### Fixed
+- Builder availability requests being cached by updating to `@vtex/api^3.3.1`
 
 ## [2.54.0] - 2019-04-15
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix Changelog and add `.git/` to `.npmignore`
 
 ## [2.54.1] - 2019-04-16
 
 ## [2.54.0] - 2019-04-15
+### Added
+- Implement workspace A/B testing interface
 
 ## [2.53.11] - 2019-04-10
+### Fixed
+- Undesired logs appearing during `vtex publish`
 
 ## [2.53.10] - 2019-04-08
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.54.1",
+  "version": "2.54.2",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",


### PR DESCRIPTION
As the title says, to prevent files in `.git` to be published by `npm`.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
