### PR TITLE
Fix A/B test finish message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.54.3] - 2019-04-17
 ### Fixed
 - A/B Test finish message
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- A/B Test finish message
 
 ## [2.54.2] - 2019-04-16
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.54.2",
+  "version": "2.54.3",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/modules/workspace/abtest/finish.ts
+++ b/src/modules/workspace/abtest/finish.ts
@@ -25,6 +25,6 @@ export default async () => {
   log.info(`Latest results:`)
   await abTestStatus()
   await abtester.finish(currentWorkspace)
-  log.info(`All A/B testing is now finished.`)
+  log.info(`A/B testing with workspace ${chalk.blue(currentWorkspace)} is now finished`)
   log.info(`100% of traffic is now directed to ${chalk.blue('master')}`)
 }


### PR DESCRIPTION
This PR makes the following change:

- When running `vtex workspace abtest finish`, the output message `All A/B testing is now finished.` was replaced by `A/B testing with workspace {currentWorkspace} is now finished`. 

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
