### PR TITLE
Increase watcher debouncer wait time to 1s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Watcher debouncer wait time from 300ms to 1000ms
 
 ## [2.54.4] - 2019-04-17
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.54.5] - 2019-04-18
 ### Changed
 - Watcher debouncer wait time from 300ms to 1000ms
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.54.4",
+  "version": "2.54.5",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/modules/apps/link.ts
+++ b/src/modules/apps/link.ts
@@ -193,7 +193,7 @@ const watchAndSendChanges = async (appId: string, builder: Builder, extraData : 
   const sendChanges = debounce(() => {
     builder.relinkApp(appId, changeQueue.splice(0, changeQueue.length), { tsErrorsAsWarnings: unsafe })
       .catch(onInitialLinkRequired)
-  }, 300)
+  }, 1000)
 
   const pathToChange = (path: string, remove?: boolean): Change => ({
     content: remove ? null : readFileSync(resolvePath(root, path)).toString('base64'), path : pathModifier(path),


### PR DESCRIPTION
#### What is the purpose of this pull request?
As the title says.

#### What problem is this solving?
With the current value of `300ms`, making simultaneous changes to multiple files would sometimes cause toolbelt to send multiple `patch` requests to Builder-hub instead of a single request with all changes.

#### How should this be manually tested?
One relatively consistent way of reproducing this bug is by linking `@vtex/api`:
- In `node-vtex-api` root folder, run `yarn link`, then `yarn watch`.
- Pick any node app and run `yarn link @vtex/api` in the `node` folder.
- `vtex link` your app.
- Make any change to `index.ts` in `node-vtex-api`. This should trigger 3 file change events.

Before changes, toolbelt would sometimes make two requests to Builder-hub (this can be verified by either looking at the logs of the pod running Builder-hub or observing another build happening right after the first one had finished). After changes, it sends only one.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
