### PR TITLE
Check if vtex.ab-tester is installed before attempting to use it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Check if `vtex.ab-tester` is installed before attempting to use A/B testing functionality
 
 ## [2.54.6] - 2019-04-18
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.54.7] - 2019-04-24
 ### Changed
 - Check if `vtex.ab-tester` is installed before attempting to use A/B testing functionality
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.54.6",
+  "version": "2.54.7",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/modules/workspace/abtest/finish.ts
+++ b/src/modules/workspace/abtest/finish.ts
@@ -6,6 +6,7 @@ import { UserCancelledError } from '../../../errors'
 import log from '../../../logger'
 import { promptConfirm } from '../../prompts'
 import { default as abTestStatus } from './status'
+import { checkIfABTesterIsInstalled } from './utils'
 
 const [account, currentWorkspace] = [getAccount(), getWorkspace()]
 
@@ -20,6 +21,7 @@ const promptContinue = async () => {
 }
 
 export default async () => {
+  await checkIfABTesterIsInstalled()
   await promptContinue()
   log.info('Finishing A/B tests')
   log.info(`Latest results:`)

--- a/src/modules/workspace/abtest/start.ts
+++ b/src/modules/workspace/abtest/start.ts
@@ -7,6 +7,7 @@ import { UserCancelledError } from '../../../errors'
 import log from '../../../logger'
 import { promptConfirm } from '../../prompts'
 import {
+  checkIfABTesterIsInstalled,
   checkIfInProduction,
   currentWorkspace,
   formatDays,
@@ -55,9 +56,10 @@ ${chalk.red(significanceLevel)} significance level. Proceed?`,
 }
 
 export default async () => {
+  await checkIfABTesterIsInstalled()
+  await checkIfInProduction()
   const significanceLevel = await promptSignificanceLevel()
   await promptContinue(significanceLevel)
-  await checkIfInProduction()
   const significanceLevelValue = SIGNIFICANCE_LEVELS[significanceLevel]
   log.info(`Setting workspace ${chalk.green(currentWorkspace)} to A/B test with \
 ${significanceLevel} significance level`)

--- a/src/modules/workspace/abtest/status.ts
+++ b/src/modules/workspace/abtest/status.ts
@@ -7,7 +7,7 @@ import { abtester } from '../../../clients'
 import { getAccount } from '../../../conf'
 import log from '../../../logger'
 import { createTable } from '../../../table'
-import { formatDuration } from './utils'
+import { checkIfABTesterIsInstalled, formatDuration } from './utils'
 
 interface ABTestStatus {
   ABTestBeginning: string
@@ -76,6 +76,7 @@ const printResultsTable = (testInfo: ABTestStatus) => {
 
 export default async () => {
 
+  await checkIfABTesterIsInstalled()
   let abTestInfo = []
   try {
     abTestInfo = await abtester.status()

--- a/src/modules/workspace/abtest/utils.ts
+++ b/src/modules/workspace/abtest/utils.ts
@@ -1,9 +1,11 @@
 import chalk from 'chalk'
 import * as numbro from 'numbro'
 
-import { workspaces } from '../../../clients'
+import { apps, workspaces } from '../../../clients'
 import { getAccount, getWorkspace } from '../../../conf'
 import { CommandError } from '../../../errors'
+
+const { getApp } = apps
 
 
 export const SIGNIFICANCE_LEVELS = {
@@ -41,5 +43,19 @@ used for A/B testing. Please create a production workspace with \
 ${chalk.blue('vtex use <workspace> -r -p')} or reset this one with \
 ${chalk.blue('vtex workspace reset -p')}`
 )
+  }
+}
+
+export const checkIfABTesterIsInstalled = async () => {
+  try {
+    await getApp('vtex.ab-tester@x')
+  } catch (e) {
+    if (e.response.data.code === 'app_not_found') {
+      throw new CommandError(`The app ${chalk.yellow('vtex.ab-tester')} is \
+not installed in account ${chalk.green(account)}, workspace \
+${chalk.blue(currentWorkspace)}. Please install it before attempting to use A/B \
+testing functionality`)
+    }
+    throw e
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6272,7 +6272,7 @@ static-extend@^0.1.1, static-extend@^0.1.2:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
As the title says. Throws a nice message if the `vtex.ab-tester` is not installed:

![image](https://user-images.githubusercontent.com/20361388/56537398-ce94ac00-6536-11e9-9eae-e147adedac79.png)

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
