### PR TITLE
Persist StickyHost between links and publishes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.55.0] - 2019-04-25
+
 ## [2.54.7] - 2019-04-24
 ### Changed
 - Check if `vtex.ab-tester` is installed before attempting to use A/B testing functionality

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.54.7",
+  "version": "2.55.0",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/conf.ts
+++ b/src/conf.ts
@@ -27,6 +27,9 @@ export const saveWorkspace = (workspace = 'master') =>
 export const saveEnvironment = (env: Environment) =>
   conf.set('env', env)
 
+export const saveStickyHost = (appId: string, stickyHost: string) =>
+  conf.set(`${appId}.sticky-host`, {stickyHost, lastUpdated: Date.now()})
+
 export const getAll = (): any => conf.all
 
 export const getAccount = (): string =>
@@ -40,6 +43,12 @@ export const getToken = (): string =>
 
 export const getWorkspace = (): string =>
   conf.get('workspace')
+
+export const getStickyHost = (appId: string): {stickyHost: string; lastUpdated: Date} =>
+  conf.get(`${appId}.sticky-host`)
+
+export const hasStickyHost = (appId: string): boolean =>
+  conf.has(`${appId}.sticky-host`)
 
 const envFromProcessEnv = {
   'beta': Environment.Staging,

--- a/src/conf.ts
+++ b/src/conf.ts
@@ -27,8 +27,8 @@ export const saveWorkspace = (workspace = 'master') =>
 export const saveEnvironment = (env: Environment) =>
   conf.set('env', env)
 
-export const saveStickyHost = (appId: string, stickyHost: string) =>
-  conf.set(`${appId}.sticky-host`, {stickyHost, lastUpdated: Date.now()})
+export const saveStickyHost = (appName: string, stickyHost: string) =>
+  conf.set(`apps.${appName}.sticky-host`, {stickyHost, lastUpdated: Date.now()})
 
 export const getAll = (): any => conf.all
 
@@ -44,11 +44,11 @@ export const getToken = (): string =>
 export const getWorkspace = (): string =>
   conf.get('workspace')
 
-export const getStickyHost = (appId: string): {stickyHost: string; lastUpdated: Date} =>
-  conf.get(`${appId}.sticky-host`)
+export const getStickyHost = (appName: string): {stickyHost: string; lastUpdated: Date} =>
+  conf.get(`apps.${appName}.sticky-host`)
 
-export const hasStickyHost = (appId: string): boolean =>
-  conf.has(`${appId}.sticky-host`)
+export const hasStickyHost = (appName: string): boolean =>
+  conf.has(`apps.${appName}.sticky-host`)
 
 const envFromProcessEnv = {
   'beta': Environment.Staging,

--- a/src/host.ts
+++ b/src/host.ts
@@ -90,7 +90,7 @@ const getMostAvailableHost = async (
   return stickyHint
 }
 
-export const getSavedOrMostAvaliableHost = async (
+export const getSavedOrMostAvailableHost = async (
   appId: string,
   builder: Builder,
   nHosts: number,
@@ -99,7 +99,7 @@ export const getSavedOrMostAvaliableHost = async (
   if (hasStickyHost(appId)) {
     log.debug(`Found sticky host saved locally`)
     const {stickyHost, lastUpdated} = getStickyHost(appId)
-    const timeElapsed = moment.duration(moment(new Date()).diff(lastUpdated))
+    const timeElapsed = moment.duration(moment().diff(lastUpdated))
     if (timeElapsed.asHours() <= TTL_SAVED_HOST_HOURS) {
       return stickyHost
     }

--- a/src/host.ts
+++ b/src/host.ts
@@ -96,9 +96,10 @@ export const getSavedOrMostAvailableHost = async (
   nHosts: number,
   timeout: number
 ): Promise<string> => {
-  if (hasStickyHost(appId)) {
+  const [appName] = appId.split('@')
+  if (hasStickyHost(appName)) {
     log.debug(`Found sticky host saved locally`)
-    const {stickyHost, lastUpdated} = getStickyHost(appId)
+    const {stickyHost, lastUpdated} = getStickyHost(appName)
     const timeElapsed = moment.duration(moment().diff(lastUpdated))
     if (timeElapsed.asHours() <= TTL_SAVED_HOST_HOURS) {
       return stickyHost
@@ -108,7 +109,7 @@ export const getSavedOrMostAvailableHost = async (
   log.debug(`Finding a new sticky host`)
   const newStickyHost = await getMostAvailableHost(appId, builder, nHosts, timeout)
   if (newStickyHost) {
-    saveStickyHost(appId, newStickyHost)
+    saveStickyHost(appName, newStickyHost)
   }
   return newStickyHost
 }

--- a/src/host.ts
+++ b/src/host.ts
@@ -103,6 +103,7 @@ export const getSavedOrMostAvailableHost = async (
     if (timeElapsed.asHours() <= TTL_SAVED_HOST_HOURS) {
       return stickyHost
     }
+    log.debug(`Saved sticky host has expired`)
   }
   log.debug(`Finding a new sticky host`)
   const newStickyHost = await getMostAvailableHost(appId, builder, nHosts, timeout)

--- a/src/host.ts
+++ b/src/host.ts
@@ -107,6 +107,8 @@ export const getSavedOrMostAvailableHost = async (
   }
   log.debug(`Finding a new sticky host`)
   const newStickyHost = await getMostAvailableHost(appId, builder, nHosts, timeout)
-  saveStickyHost(appId, newStickyHost)
+  if (newStickyHost) {
+    saveStickyHost(appId, newStickyHost)
+  }
   return newStickyHost
 }

--- a/src/modules/apps/link.ts
+++ b/src/modules/apps/link.ts
@@ -15,7 +15,7 @@ import { createClients } from '../../clients'
 import { getAccount, getEnvironment, getToken, getWorkspace } from '../../conf'
 import { publicEndpoint, region } from '../../env'
 import { CommandError } from '../../errors'
-import { getMostAvailableHost } from '../../host'
+import { getSavedOrMostAvaliableHost } from '../../host'
 import { toAppLocator } from '../../locator'
 import log from '../../logger'
 import { getAppRoot, getManifest } from '../../manifest'
@@ -274,7 +274,7 @@ const performInitialLink = async (appId: string, builder: Builder, extraData : {
       log.info(`Retrying...${tryCount-1}`)
     }
 
-    const stickyHint = await getMostAvailableHost(appId, builder, N_HOSTS, AVAILABILITY_TIMEOUT)
+    const stickyHint = await getSavedOrMostAvaliableHost(appId, builder, N_HOSTS, AVAILABILITY_TIMEOUT)
     const linkOptions = { sticky: true, stickyHint }
     try {
       const { code } = await builder.linkApp(appId, filesWithContent, linkOptions, { tsErrorsAsWarnings: unsafe })

--- a/src/modules/apps/link.ts
+++ b/src/modules/apps/link.ts
@@ -15,7 +15,7 @@ import { createClients } from '../../clients'
 import { getAccount, getEnvironment, getToken, getWorkspace } from '../../conf'
 import { publicEndpoint, region } from '../../env'
 import { CommandError } from '../../errors'
-import { getSavedOrMostAvaliableHost } from '../../host'
+import { getSavedOrMostAvailableHost } from '../../host'
 import { toAppLocator } from '../../locator'
 import log from '../../logger'
 import { getAppRoot, getManifest } from '../../manifest'
@@ -274,7 +274,7 @@ const performInitialLink = async (appId: string, builder: Builder, extraData : {
       log.info(`Retrying...${tryCount-1}`)
     }
 
-    const stickyHint = await getSavedOrMostAvaliableHost(appId, builder, N_HOSTS, AVAILABILITY_TIMEOUT)
+    const stickyHint = await getSavedOrMostAvailableHost(appId, builder, N_HOSTS, AVAILABILITY_TIMEOUT)
     const linkOptions = { sticky: true, stickyHint }
     try {
       const { code } = await builder.linkApp(appId, filesWithContent, linkOptions, { tsErrorsAsWarnings: unsafe })

--- a/src/modules/apps/publish.ts
+++ b/src/modules/apps/publish.ts
@@ -7,7 +7,7 @@ import { createClients } from '../../clients'
 import * as conf from '../../conf'
 import { region } from '../../env'
 import { UserCancelledError } from '../../errors'
-import { getSavedOrMostAvaliableHost } from '../../host'
+import { getSavedOrMostAvailableHost } from '../../host'
 import { toAppLocator } from '../../locator'
 import log from '../../logger'
 import { getManifest } from '../../manifest'
@@ -59,7 +59,7 @@ const publisher = (workspace: string = 'master') => {
       if (tryCount > 1) {
         log.info(`Retrying...${tryCount-1}`)
       }
-      const stickyHint = await getSavedOrMostAvaliableHost(
+      const stickyHint = await getSavedOrMostAvailableHost(
         appId,
         builder,
         N_HOSTS,

--- a/src/modules/apps/publish.ts
+++ b/src/modules/apps/publish.ts
@@ -7,7 +7,7 @@ import { createClients } from '../../clients'
 import * as conf from '../../conf'
 import { region } from '../../env'
 import { UserCancelledError } from '../../errors'
-import { getMostAvailableHost } from '../../host'
+import { getSavedOrMostAvaliableHost } from '../../host'
 import { toAppLocator } from '../../locator'
 import log from '../../logger'
 import { getManifest } from '../../manifest'
@@ -59,7 +59,7 @@ const publisher = (workspace: string = 'master') => {
       if (tryCount > 1) {
         log.info(`Retrying...${tryCount-1}`)
       }
-      const stickyHint = await getMostAvailableHost(
+      const stickyHint = await getSavedOrMostAvaliableHost(
         appId,
         builder,
         N_HOSTS,


### PR DESCRIPTION
#### What is the purpose of this pull request?
Locally store a host used in a link or publish. If another link or publish is done within a certain threshold, try to reuse that host.

#### What problem is this solving?
By reusing a host, we can take of advantage of caches from previous builds.

#### How should this be manually tested?

``vtex link``
``vtex publish``

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
