### PR TITLE
Implement cross workspace link

### DIFF
--- a/src/conf.ts
+++ b/src/conf.ts
@@ -27,8 +27,8 @@ export const saveWorkspace = (workspace = 'master') =>
 export const saveEnvironment = (env: Environment) =>
   conf.set('env', env)
 
-export const saveStickyHost = (appName: string, stickyHost: string) =>
-  conf.set(`apps.${appName}.sticky-host`, {stickyHost, lastUpdated: Date.now()})
+export const saveStickyHost = (appName: string, buildWorkspace: string, stickyHost: string) =>
+  conf.set(`apps.${buildWorkspace}.${appName}.sticky-host`, {stickyHost, lastUpdated: Date.now()})
 
 export const getAll = (): any => conf.all
 
@@ -44,11 +44,11 @@ export const getToken = (): string =>
 export const getWorkspace = (): string =>
   conf.get('workspace')
 
-export const getStickyHost = (appName: string): {stickyHost: string; lastUpdated: Date} =>
-  conf.get(`apps.${appName}.sticky-host`)
+export const getStickyHost = (appName: string, buildWorkspace: string): {stickyHost: string; lastUpdated: Date} =>
+  conf.get(`apps.${buildWorkspace}.${appName}.sticky-host`)
 
-export const hasStickyHost = (appName: string): boolean =>
-  conf.has(`apps.${appName}.sticky-host`)
+export const hasStickyHost = (appName: string, buildWorkspace: string): boolean =>
+  conf.has(`apps.${buildWorkspace}.${appName}.sticky-host`)
 
 const envFromProcessEnv = {
   'beta': Environment.Staging,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,2 @@
+export const APPS_ID = 'apps'
+export const BUILDER_HUB_ID = 'vtex.builder-hub'

--- a/src/host.ts
+++ b/src/host.ts
@@ -94,12 +94,13 @@ export const getSavedOrMostAvailableHost = async (
   appId: string,
   builder: Builder,
   nHosts: number,
-  timeout: number
+  timeout: number,
+  buildWorkspace: string,
 ): Promise<string> => {
   const [appName] = appId.split('@')
-  if (hasStickyHost(appName)) {
+  if (hasStickyHost(appName, buildWorkspace)) {
     log.debug(`Found sticky host saved locally`)
-    const {stickyHost, lastUpdated} = getStickyHost(appName)
+    const {stickyHost, lastUpdated} = getStickyHost(appName, buildWorkspace)
     const timeElapsed = moment.duration(moment().diff(lastUpdated))
     if (timeElapsed.asHours() <= TTL_SAVED_HOST_HOURS) {
       return stickyHost
@@ -109,7 +110,7 @@ export const getSavedOrMostAvailableHost = async (
   log.debug(`Finding a new sticky host`)
   const newStickyHost = await getMostAvailableHost(appId, builder, nHosts, timeout)
   if (newStickyHost) {
-    saveStickyHost(appName, newStickyHost)
+    saveStickyHost(appName, buildWorkspace, newStickyHost)
   }
   return newStickyHost
 }

--- a/src/modules/build.ts
+++ b/src/modules/build.ts
@@ -1,4 +1,5 @@
 import { currentContext } from '../conf'
+import { BUILDER_HUB_ID } from '../constants'
 import { BuildFailError } from '../errors'
 import log from '../logger'
 import { logAll, onEvent } from '../sse'
@@ -25,7 +26,7 @@ const allEvents: BuildEvent[] = ['logs', 'build.status']
 
 const onBuildEvent = (ctx: Context, appOrKey: string, callback: (type: BuildEvent, message?: Message) => void, senders?: string[]) => {
   const unlistenLogs = logAll(ctx, log.level, appOrKey, senders)
-  const unlistenBuild = onEvent(ctx, 'vtex.builder-hub', appOrKey, ['build.status'], message => callback('build.status', message))
+  const unlistenBuild = onEvent({ ...ctx, workspace: ctx.buildWorkspace }, BUILDER_HUB_ID, appOrKey, ['build.status'], message => callback('build.status', message))
   const unlistenMap: Record<BuildEvent, AnyFunction> = {
     'build.status': unlistenBuild,
     logs: unlistenLogs,

--- a/src/modules/tree.ts
+++ b/src/modules/tree.ts
@@ -132,6 +132,12 @@ export default {
         short: 'u',
         type: 'boolean',
       },
+      {
+        description: 'Specify the workspace whose Builder-hub will be used to build the app',
+        long: 'workspace',
+        short: 'w',
+        type: 'string',
+      },
     ],
   },
   list: {

--- a/src/modules/workspace/create.ts
+++ b/src/modules/workspace/create.ts
@@ -3,6 +3,7 @@ import chalk from 'chalk'
 import { workspaces } from '../../clients'
 import { createClients } from '../../clients'
 import { getAccount } from '../../conf'
+import { BUILDER_HUB_ID } from '../../constants'
 import { CommandError } from '../../errors'
 import log from '../../logger'
 
@@ -22,7 +23,7 @@ export default async (name: string, options: any) => {
     log.info(`Workspace ${chalk.green(name)} created ${chalk.green('successfully')} with ${chalk.green(`production=${production}`)}`)
     // First request on a brand new workspace takes very long because of route map generation, so we warm it up.
     const { builder } = createClients({ workspace: name })
-    await builder.availability('vtex.builder-hub@0.x', null)
+    await builder.availability(`${BUILDER_HUB_ID}@0.x`, null)
     log.debug('Warmed up route map')
   } catch (err) {
     if (err.response && err.response.data.code === 'WorkspaceAlreadyExists') {

--- a/src/typings/global.d.ts
+++ b/src/typings/global.d.ts
@@ -113,6 +113,7 @@ declare global {
   interface Context {
     account: string,
     workspace: string,
+    buildWorkspace?: string,
   }
 
   interface InstallResponse {


### PR DESCRIPTION
This should be reviewed along with https://github.com/vtex/builder-hub/pull/513.

#### What is the purpose of this pull request?
This enables linking apps across workspaces. For example, we can run `vtex link -w wk2` in workspace `wk1` to use `wk2`'s builder-hub to build an app and link it on `wk1`.

#### What problem is this solving?
Ever since builder-hub became self-hosted developing on it has been a huge pain. That's because once builder-hub is linked, it does the following `patch`es on itself, so if a change breaks the linked builder-hub, we're forced to `unlink` and `link`, which takes a lot of time.

With these changes, we can now link builder-hub with `vtex link -w master`, for example. As a result, following `vtex link`s will use the linked builder-hub, and any changes on the linked builder-hub will trigger a patch on `master`'s builder-hub.

#### How should this be manually tested?
- `vtex switch` to a test account (for instance, `vtexgame23`).
- On `master`, run `vtex infra install sphinx@0.18.18-marcos`, which contains a new policy necessary to perform cross workspace links.
- Still on `master`, run `vtex install builder-hub@0.100.9-beta`, which is [this PR](https://github.com/vtex/builder-hub/pull/513)'s builder-hub.
- On `someworkspace`, link builder-hub with `vtex link --verbose --workspace master`.
- Enjoy developing on builder-hub without having to `unlink` and `link` all the time.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
