### PR TITLE
Do not allow users to create workspace names with hyphens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Do not allow users to create workspace names with hyphens
 
 ## [2.55.1] - 2019-04-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.55.2] - 2019-05-02
 ### Fixed
 - Do not allow users to create workspace names with hyphens
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.55.1",
+  "version": "2.55.2",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/modules/workspace/create.ts
+++ b/src/modules/workspace/create.ts
@@ -6,11 +6,11 @@ import { getAccount } from '../../conf'
 import { CommandError } from '../../errors'
 import log from '../../logger'
 
-const VALID_WORKSPACE = /^[a-z][a-z0-9-]{0,126}[a-z0-9]$/
+const VALID_WORKSPACE = /^[a-z][a-z0-9]{0,126}[a-z0-9]$/
 
 export default async (name: string, options: any) => {
   if (!VALID_WORKSPACE.test(name)) {
-    throw new CommandError('Whoops! That\'s not a valid workspace name. Please use only lowercase letters, numbers and hyphens.')
+    throw new CommandError('Whoops! That\'s not a valid workspace name. Please use only lowercase letters and numbers.')
   }
   log.debug('Creating workspace', name)
   let production = false


### PR DESCRIPTION
As the title says. Experience shows that workspaces with hyphens in their names can cause trouble when trying to access URLs exposed by linked apps.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
