### PR TITLE
vtex whoami shows better message if unable to read workspace state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.55.3] - 2019-05-02
 ### Fixed
 - `vtex whoami` shows that the user is not logged in if it fails to read the workspace state
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `vtex whoami` shows that the user is not logged in if it fails to read the workspace state
 
 ## [2.55.2] - 2019-05-02
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.55.2",
+  "version": "2.55.3",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/greeting.ts
+++ b/src/greeting.ts
@@ -28,7 +28,7 @@ export const greeting = async (): Promise<string[]> => {
     let loggedMessage = 'Logged into'
     let state = await getWorkspaceState()
     if (!state) {
-      loggedMessage = 'Not logged in. Previously logged into'
+      loggedMessage = `${chalk.red('Not logged in')}. Previously logged into`
       state = ''
     }
     return [`${loggedMessage} ${chalk.blue(account)} as ${chalk.green(login)} at ${chalk.yellowBright(state)}workspace ${chalk.green(workspace)} in environment ${chalk.red(environment)}`]

--- a/src/greeting.ts
+++ b/src/greeting.ts
@@ -17,16 +17,21 @@ const getWorkspaceState = async (): Promise<string> => {
 
     return workspaceState(meta) + ' '
   } catch (err) {
-    log.error(`Unable to fetch workspace state`)
+    log.debug(`Unable to fetch workspace state`)
     log.debug(err.message)
-    return ''
+    return undefined
   }
 }
 
 export const greeting = async (): Promise<string[]> => {
   if (account && login && workspace) {
-    const state = await getWorkspaceState()
-    return [`Logged into ${chalk.blue(account)} as ${chalk.green(login)} at ${chalk.yellowBright(state)}workspace ${chalk.green(workspace)} in environment ${chalk.red(environment)}`]
+    let loggedMessage = 'Logged into'
+    let state = await getWorkspaceState()
+    if (!state) {
+      loggedMessage = 'Not logged in. Previously logged into'
+      state = ''
+    }
+    return [`${loggedMessage} ${chalk.blue(account)} as ${chalk.green(login)} at ${chalk.yellowBright(state)}workspace ${chalk.green(workspace)} in environment ${chalk.red(environment)}`]
   }
 
   return ['Welcome to VTEX I/O', `Login with ${chalk.green('vtex login')} ${chalk.blue('<account>')}`]


### PR DESCRIPTION
If toolbelt is unable to read the current workspace's state, it must be logged out of the platform. This PR makes the `vtex whoami` message replace the `Logged into` message part by `Not logged in. Previously logged into` in this case.


#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
