### PR TITLE
Check if ab-tester returns null variables in status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Check and inform if ab-tester `status` route returns null results
 
 ## [2.55.5] - 2019-05-02
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.55.6] - 2019-05-08
 ### Fixed
 - Check and inform if ab-tester `status` route returns null results
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.55.5",
+  "version": "2.55.6",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/modules/workspace/abtest/status.ts
+++ b/src/modules/workspace/abtest/status.ts
@@ -7,7 +7,7 @@ import { abtester } from '../../../clients'
 import { getAccount } from '../../../conf'
 import log from '../../../logger'
 import { createTable } from '../../../table'
-import { checkIfABTesterIsInstalled, formatDuration } from './utils'
+import { formatDuration } from './utils'
 
 interface ABTestStatus {
   ABTestBeginning: string
@@ -23,6 +23,7 @@ interface ABTestStatus {
   ConversionA: number
   ConversionB: number
   ProbabilityAlternativeBeatMaster: number
+  KullbackLeibler: number
 }
 
 const formatPercent = (n: number) => numbro(n).format('0.000%')
@@ -46,8 +47,15 @@ const printResultsTable = (testInfo: ABTestStatus) => {
     ConversionA,
     ConversionB,
     ProbabilityAlternativeBeatMaster,
+    KullbackLeibler,
   } = testInfo
   console.log(chalk.bold(`VTEX AB Test: ${chalk.blue(`${WorkspaceA} (A)`)} vs ${chalk.blue(`${WorkspaceB} (B)`)}\n`))
+  if (R.any(R.isNil)([ExpectedLossChoosingA, ExpectedLossChoosingB, KullbackLeibler, ProbabilityAlternativeBeatMaster])) {
+    log.error('Unexpected value of conversion. Perhaps your user traffic is too small and this creates distortions in the data')
+
+  }
+  const technicalTable = createTable()
+  technicalTable.push(bold([`Kullback-Leibler divergence`, numbro(KullbackLeibler).format('0.000')]))
 
   const comparisonTable = createTable()
   comparisonTable.push(bold(['', chalk.blue(WorkspaceA), chalk.blue(WorkspaceB)]))
@@ -65,13 +73,13 @@ const printResultsTable = (testInfo: ABTestStatus) => {
   resultsTable.push(bold([`Probability B beats A`, formatPercent(ProbabilityAlternativeBeatMaster)]))
   resultsTable.push(bold([chalk.bold.green(`Winner`), chalk.bold.green(Winner)]))
 
+  console.log(`Technical:\n${technicalTable.toString()}\n`)
   console.log(`Comparative:\n${comparisonTable.toString()}\n`)
   console.log(`Results:\n${resultsTable.toString()}\n`)
 }
 
 export default async () => {
 
-  await checkIfABTesterIsInstalled()
   let abTestInfo = []
   try {
     abTestInfo = await abtester.status()


### PR DESCRIPTION
Prints a special message if ab-tester returns null variables (`status` route) this is the case.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
