### PR TITLE
Fix/settings promises

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.55.7] - 2019-05-08
 ### Fixed
 - Wrap `apps` client promises in Bluebird, so we can use `.tap`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Wrap `apps` client promises in Bluebird, so we can use `.tap`
 
 ## [2.55.6] - 2019-05-08
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.55.6",
+  "version": "2.55.7",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/modules/apps/settings/index.ts
+++ b/src/modules/apps/settings/index.ts
@@ -2,7 +2,7 @@ import { path } from 'ramda'
 
 import { apps } from '../../../clients'
 
-const { getAppSettings } = apps
+const getAppSettings = Promise.method(apps.getAppSettings)
 
 const FIELDS_START_INDEX = 2
 

--- a/src/modules/apps/settings/set.ts
+++ b/src/modules/apps/settings/set.ts
@@ -2,7 +2,8 @@ import { __, merge, zipObj } from 'ramda'
 import { apps } from '../../../clients'
 import { parseArgs } from '../utils'
 
-const { getAppSettings, saveAppSettings } = apps
+const getAppSettings = Promise.method(apps.getAppSettings)
+const saveAppSettings = Promise.method(apps.saveAppSettings)
 
 const castValue = value => {
   let parsedValue

--- a/src/modules/apps/settings/unset.ts
+++ b/src/modules/apps/settings/unset.ts
@@ -2,7 +2,8 @@ import { dissocPath } from 'ramda'
 
 import { apps } from '../../../clients'
 
-const { getAppSettings, saveAppSettings } = apps
+const getAppSettings = Promise.method(apps.getAppSettings)
+const saveAppSettings = Promise.method(apps.saveAppSettings)
 
 const FIELDS_START_INDEX = 3
 


### PR DESCRIPTION
Usage of the `.tap` method in promises returned from the `apps` client were throwing errors because they were not `Bluebird` promises. This PR wraps these promises in `Bluebird` so `tap` does not throw errors.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
