### PR TITLE
Temporarily disable saving StickyHost locally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Disable saving `StickyHost` locally
 
 ## [2.56.0] - 2019-05-08
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
-- Disable saving `StickyHost` locally
+- Temporarily disable saving StickyHost locally until rounting behavior is fixed
 
 ## [2.56.0] - 2019-05-08
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.56.1] - 2019-05-08
 ### Changed
 - Temporarily disable saving StickyHost locally until rounting behavior is fixed
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.56.0",
+  "version": "2.56.1",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/host.ts
+++ b/src/host.ts
@@ -7,7 +7,7 @@ import { getStickyHost, hasStickyHost, saveStickyHost } from './conf'
 import { BuilderHubTimeoutError } from './errors'
 import log from './logger'
 
-const TTL_SAVED_HOST_HOURS = 6
+const TTL_SAVED_HOST_HOURS = 0
 
 const NOT_AVAILABLE = {
   hostname: undefined,


### PR DESCRIPTION
#### What is the purpose of this pull request?
Temporarily disable saving `stickyHost` locally (#540)

#### What problem is this solving?
Due to the current routing logic, patches are not being sent to the same pod if `stickyHost` dies. Will be enabled when this behavior is fixed.

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
-  [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
