### PR TITLE
Fix/revert default setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.56.2] - 2019-05-08
 ### Changed
 - Running `vtex setup` on every `vtex link` is temporarily disabled until `vtex setup` becomes less intrusive
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Running `vtex setup` on every `vtex link` is temporarily disabled until `vtex setup` becomes less intrusive
+
+### Fixed
+- Minor fix to eslint configuration in `vtex setup`
 
 ## [2.56.1] - 2019-05-08
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.56.1] - 2019-05-08
 ### Changed
-- Temporarily disable saving StickyHost locally until rounting behavior is fixed
+- Temporarily disable saving StickyHost locally until routing behavior is fixed
 
 ## [2.56.0] - 2019-05-08
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.56.1",
+  "version": "2.56.2",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/modules/apps/link.ts
+++ b/src/modules/apps/link.ts
@@ -202,7 +202,7 @@ export default async (options) => {
 
   const appId = toAppLocator(manifest)
   const context = { account: getAccount(), workspace: getWorkspace(), environment: getEnvironment() }
-  if (options.setup === undefined && options.n === false) {
+  if (options.setup || options.s) {
     await setup()
   }
   const { builder } = createClients(context, { timeout: 60000 })

--- a/src/modules/setup.ts
+++ b/src/modules/setup.ts
@@ -22,10 +22,11 @@ const buildersToAddAdditionalPackages = ['react', 'node']
 const addToPackageJson = {
   'eslint': '^5.15.1',
   'eslint-config-vtex': '^10.1.0',
+  'eslint-config-vtex-react': '^4.1.0',
 }
 const addToEslintrc = {
   'react': {
-    'extends': 'eslint-config-vtex',
+    'extends': 'vtex-react',
     'env': {
       'browser': true,
       'es6': true,
@@ -33,7 +34,7 @@ const addToEslintrc = {
     },
   },
   'node': {
-    'extends': 'eslint-config-vtex',
+    'extends': 'vtex',
     'env': {
       'node': true,
       'es6': true,

--- a/src/modules/tree.ts
+++ b/src/modules/tree.ts
@@ -120,8 +120,8 @@ export default {
       },
       {
         description: 'Do not add app dependencies to package.json and do not run Yarn',
-        long: 'no-setup',
-        short: 'n',
+        long: 'setup',
+        short: 's',
         type: 'boolean',
       },
       {


### PR DESCRIPTION
Due to the huge commotion and many suggestions/complaints regarding `vtex link` always running `vtex setup` by default (to download VTEX IO app typings, configure `eslint` and `tsconfig`), this PR removes running `vtex setup` on every `vtex link` by default.

Also, minor fixes to the `vtex setup` command, which continues to exist and will still be improved in the near future.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
