### PR TITLE
Always run yarn locally on link and publish (react and node folders)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.56.5] - 2019-05-13
 ### Added
 - Always run `yarn` locally as an initial step of `vtex link` and `vtex publish` for `./node` and `./react` folders
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Always run `yarn` locally as an initial step of `vtex link` and `vtex publish` for `./node` and `./react` folders
 
 ## [2.56.4] - 2019-05-10
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.56.4",
+  "version": "2.56.5",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/modules/apps/link.ts
+++ b/src/modules/apps/link.ts
@@ -18,6 +18,7 @@ import { getAppRoot, getManifest } from '../../manifest'
 import { listenBuild } from '../build'
 import { default as setup } from '../setup'
 import { formatNano } from '../utils'
+import { runYarnIfPathExists } from '../utils'
 import startDebuggerTunnel from './debugger'
 import { createLinkConfig, getIgnoredPaths, getLinkedDepsDirs, getLinkedFiles, listLocalFiles } from './file'
 import legacyLink from './legacyLink'
@@ -30,6 +31,7 @@ const stabilityThreshold = process.platform === 'darwin' ? 100 : 200
 const AVAILABILITY_TIMEOUT = 1000
 const N_HOSTS = 3
 const buildersToStartDebugger = ['node']
+const buildersToRunLocalYarn = ['node', 'react']
 const RETRY_OPTS_INITIAL_LINK = {
   retries: 2,
   minTimeout: 1000,
@@ -205,6 +207,9 @@ export default async (options) => {
   if (options.setup || options.s) {
     await setup()
   }
+  // Always run yarn locally for some builders
+  map(runYarnIfPathExists, buildersToRunLocalYarn)
+
   const { builder } = createClients(context, { timeout: 60000 })
 
   if (options.c || options.clean) {

--- a/src/modules/apps/publish.ts
+++ b/src/modules/apps/publish.ts
@@ -15,6 +15,7 @@ import { logAll } from '../../sse'
 import switchAccount from '../auth/switch'
 import { listenBuild } from '../build'
 import { promptConfirm } from '../prompts'
+import { runYarnIfPathExists } from '../utils'
 import { listLocalFiles } from './file'
 import { legacyPublisher } from './legacyPublish'
 import { checkBuilderHubMessage, pathToFileObject, showBuilderHubMessage } from './utils'
@@ -23,6 +24,7 @@ import { checkBuilderHubMessage, pathToFileObject, showBuilderHubMessage } from 
 const root = getAppRoot()
 const AVAILABILITY_TIMEOUT = 1000
 const N_HOSTS = 5
+const buildersToRunLocalYarn = ['node', 'react']
 
 const getSwitchAccountMessage = (previousAccount: string, currentAccount = conf.getAccount()) :string => {
   return `Now you are logged in ${chalk.blue(currentAccount)}. Do you want to return to ${chalk.blue(previousAccount)} account?`
@@ -154,6 +156,10 @@ export default (path: string, options) => {
 
   path = path || root
   const workspace = options.w || options.workspace
+
+  // Always run yarn locally for some builders
+  map(runYarnIfPathExists, buildersToRunLocalYarn)
+
   const { publishApps } = publisher(workspace)
   return publishApps(path, options.tag)
 }

--- a/src/modules/setup.ts
+++ b/src/modules/setup.ts
@@ -13,6 +13,7 @@ import { publicEndpoint, region } from '../env'
 import log from '../logger'
 import { getAppRoot, getManifest } from '../manifest'
 import { isLinked, resolveAppId } from './apps/utils'
+import { runYarn, yarnPath } from './utils'
 
 const account = getAccount()
 const workspace = getWorkspace()
@@ -43,7 +44,6 @@ const addToEslintrc = {
   },
 }
 const typingsPath = 'public/_types'
-const yarnPath = require.resolve('yarn/bin/yarn')
 const typingsURLRegex = /_v\/\w*\/typings/
 const getVendor = (appId: string) => appId.split('.')[0]
 const builderHttp = axios.create({
@@ -112,15 +112,6 @@ const appsWithTypingsURLs = async (builder: string, appDependencies: Record<stri
   return result
 }
 
-const runYarn = (relativePath: string) => {
-  log.info(`Running yarn in ${relativePath}`)
-  execSync(
-    `${yarnPath} --force --non-interactive`,
-    {stdio: 'inherit', cwd: resolvePath(root, `${relativePath}`)}
-  )
-  log.info('Finished running yarn')
-}
-
 const yarnAddESLint = (relativePath: string) => {
   log.info(`Adding lint configs in ${relativePath}`)
   const lintDeps = join(' ', values(mapObjIndexed((version, name) => `${name}@${version}`, addToPackageJson)))
@@ -155,7 +146,7 @@ const injectTypingsInPackageJson = async (appDeps: Record<string, any>, builder:
         { spaces: 2 }
       )
       try {
-        runYarn(builder)
+        runYarn(builder, true)
       } catch (e) {
         log.error(`Error running Yarn in ${builder}.`)
         await outputJsonSync(packageJsonPath, packageJson, { spaces: 2 })  // Revert package.json to original state.

--- a/src/modules/utils.ts
+++ b/src/modules/utils.ts
@@ -84,7 +84,6 @@ export const formatNano = (nanoseconds: number): string =>
     0
   )}ms`
 
-
 export const runYarn = (relativePath: string, force: boolean) => {
   log.info(`Running yarn in ${chalk.green(relativePath)}`)
   const root = getAppRoot()

--- a/src/modules/utils.ts
+++ b/src/modules/utils.ts
@@ -1,6 +1,11 @@
+import chalk from 'chalk'
+import { execSync } from 'child-process-es6-promise'
+import { existsSync } from 'fs'
+import { resolve as resolvePath } from 'path'
 import { currentContext } from '../conf'
 import { BuildFailError } from '../errors'
 import log from '../logger'
+import { getAppRoot } from '../manifest'
 import { logAll, onEvent } from '../sse'
 
 interface BuildListeningOptions {
@@ -15,6 +20,8 @@ type AnyFunction = (...args: any[]) => any
 const allEvents: BuildEvent[] = ['start', 'success', 'fail', 'timeout', 'logs']
 
 const flowEvents: BuildEvent[] = ['start', 'success', 'fail']
+
+export const yarnPath = require.resolve('yarn/bin/yarn')
 
 const onBuildEvent = (ctx: Context, timeout: number, appOrKey: string, callback: (type: BuildEvent, message?: Message) => void) => {
   const [subject] = appOrKey.split('@')
@@ -76,3 +83,25 @@ export const formatNano = (nanoseconds: number): string =>
   `${(nanoseconds / 1e9).toFixed(0)}s ${((nanoseconds / 1e6) % 1e3).toFixed(
     0
   )}ms`
+
+
+export const runYarn = (relativePath: string, force: boolean) => {
+  log.info(`Running yarn in ${chalk.green(relativePath)}`)
+  const root = getAppRoot()
+  const command = force ?
+    `${yarnPath} --force --non-interactive` :
+    `${yarnPath} --non-interactive`
+  execSync(
+    command,
+    {stdio: 'inherit', cwd: resolvePath(root, `${relativePath}`)}
+  )
+  log.info('Finished running yarn')
+}
+
+export const runYarnIfPathExists = (relativePath: string) => {
+  const root = getAppRoot()
+  const pathName = resolvePath(root, `${relativePath}/`)
+  if (existsSync(pathName)) {
+    runYarn(relativePath, false)
+  }
+}

--- a/src/modules/utils.ts
+++ b/src/modules/utils.ts
@@ -92,14 +92,14 @@ export const runYarn = (relativePath: string, force: boolean) => {
     `${yarnPath} --non-interactive`
   execSync(
     command,
-    {stdio: 'inherit', cwd: resolvePath(root, `${relativePath}`)}
+    {stdio: 'inherit', cwd: resolvePath(root, relativePath)}
   )
   log.info('Finished running yarn')
 }
 
 export const runYarnIfPathExists = (relativePath: string) => {
   const root = getAppRoot()
-  const pathName = resolvePath(root, `${relativePath}/`)
+  const pathName = resolvePath(root, relativePath)
   if (existsSync(pathName)) {
     try {
       runYarn(relativePath, false)

--- a/src/modules/utils.ts
+++ b/src/modules/utils.ts
@@ -101,6 +101,11 @@ export const runYarnIfPathExists = (relativePath: string) => {
   const root = getAppRoot()
   const pathName = resolvePath(root, `${relativePath}/`)
   if (existsSync(pathName)) {
-    runYarn(relativePath, false)
+    try {
+      runYarn(relativePath, false)
+    } catch (e) {
+      log.error(`Failed to run yarn in ${chalk.green(relativePath)}`)
+      throw e
+    }
   }
 }


### PR DESCRIPTION
As the titles says, to avoid inconsistencies between `yarn.lock` and `package.json` when the code is processed by `builder-hub`.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
