### PR TITLE
Fix app root resolution for vtex release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.56.4] - 2019-05-10
 ### Fixed
 - Correctly resolve app root for the `vtex release` command
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Correctly resolve app root for the `vtex release` command
 
 ## [2.56.3] - 2019-05-10
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.56.3",
+  "version": "2.56.4",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/modules/release/utils.ts
+++ b/src/modules/release/utils.ts
@@ -11,14 +11,17 @@ import {
   writeSync,
 } from 'fs-extra'
 import { safeLoad } from 'js-yaml'
+import { resolve } from 'path'
 import { find, path }  from 'ramda'
 import * as semver from 'semver'
 import log from '../../logger'
+import { getAppRoot } from '../../manifest'
 import { promptConfirm } from '../prompts'
 
 
-const versionFile = './manifest.json'
-const changelogPath = 'CHANGELOG.md'
+const root = getAppRoot()
+const versionFile = resolve(root, 'manifest.json')
+const changelogPath = resolve(root, 'CHANGELOG.md')
 const unreleased = '## [Unreleased]'
 
 const readVersionFile = () => {


### PR DESCRIPTION
This PR makes `vtex release` work correctly even if the user's `cwd` is below the app's root.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
