### PR TITLE
Refactor/select ab test workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.56.6] - 2019-05-13
+
 ## [2.56.5] - 2019-05-13
 ### Added
 - Always run `yarn` locally as an initial step of `vtex link` and `vtex publish` for `./node` and `./react` folders

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.56.5",
+  "version": "2.56.6",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/clients/index.ts
+++ b/src/clients/index.ts
@@ -21,7 +21,7 @@ const context = {
   operationId: '',
 }
 
-const options = {
+export const options = {
   timeout: (envTimeout || DEFAULT_TIMEOUT) as number,
 }
 

--- a/src/clients/index.ts
+++ b/src/clients/index.ts
@@ -3,7 +3,6 @@ import { getAccount, getToken, getWorkspace } from '../conf'
 import * as env from '../env'
 import envTimeout from '../timeout'
 import userAgent from '../user-agent'
-import { ABTester } from './abTester'
 import Billing from './billingClient'
 
 const DEFAULT_TIMEOUT = 15000
@@ -44,9 +43,8 @@ const createClients = (customContext: Partial<IOContext> = {}, customOptions: In
   }
 }
 
-const [abtester, apps, router, workspaces, logger, events, billing] = getToken()
+const [apps, router, workspaces, logger, events, billing] = getToken()
   ? [
-    new ABTester(context, { ...options, retries: 3 }),
     new Apps(context, options),
     new Router(context, options),
     new Workspaces(context, options),
@@ -55,7 +53,6 @@ const [abtester, apps, router, workspaces, logger, events, billing] = getToken()
     new Billing(context, options),
   ]
   : [
-    interceptor<ABTester>('abtester'),
     interceptor<Apps>('apps'),
     interceptor<Router>('router'),
     interceptor<Workspaces>('workspaces'),
@@ -65,7 +62,6 @@ const [abtester, apps, router, workspaces, logger, events, billing] = getToken()
   ]
 
 export {
-  abtester,
   apps,
   router,
   workspaces,

--- a/src/clients/index.ts
+++ b/src/clients/index.ts
@@ -21,7 +21,7 @@ const context = {
   operationId: '',
 }
 
-export const options = {
+const options = {
   timeout: (envTimeout || DEFAULT_TIMEOUT) as number,
 }
 

--- a/src/modules/workspace/abtest/finish.ts
+++ b/src/modules/workspace/abtest/finish.ts
@@ -8,10 +8,8 @@ import log from '../../../logger'
 import { promptConfirm } from '../../prompts'
 import { default as abTestStatus } from './status'
 import {
+  abtester,
   checkIfABTesterIsInstalled,
-  getABTester,
-  promptAndUseMaster,
-  promptAndUsePreviousWorkspace,
 } from './utils'
 
 const [account] = [getAccount()]
@@ -28,7 +26,7 @@ ${chalk.blue(workspace)}, account ${chalk.green(account)}. Are you sure?`,
 }
 
 const promptWorkspaceToFinishABTest = async () =>
-  await getABTester().status()
+  await abtester.status()
     .then(map(({WorkspaceB}) => WorkspaceB))
     .then(workspaces =>
       enquirer.prompt({
@@ -41,22 +39,13 @@ const promptWorkspaceToFinishABTest = async () =>
     .then(prop('workspace'))
 
 export default async () => {
-  await promptAndUseMaster()
-  try {
-    await checkIfABTesterIsInstalled()
-    const abtester = getABTester()
-    const workspace = await promptWorkspaceToFinishABTest()
-    await promptContinue(workspace)
-    log.info('Finishing A/B tests')
-    log.info(`Latest results:`)
-    await abTestStatus()
-    await abtester.finish(workspace)
-    log.info(`A/B testing with workspace ${chalk.blue(workspace)} is now finished`)
-    log.info(`No traffic currently directed to ${chalk.blue(workspace)}`)
-  } catch (err) {
-    log.error('Unhandled exception')
-    await promptAndUsePreviousWorkspace()
-    throw err
-  }
-  await promptAndUsePreviousWorkspace()
+  await checkIfABTesterIsInstalled()
+  const workspace = await promptWorkspaceToFinishABTest()
+  await promptContinue(workspace)
+  log.info('Finishing A/B tests')
+  log.info(`Latest results:`)
+  await abTestStatus()
+  await abtester.finish(workspace)
+  log.info(`A/B testing with workspace ${chalk.blue(workspace)} is now finished`)
+  log.info(`No traffic currently directed to ${chalk.blue(workspace)}`)
 }

--- a/src/modules/workspace/abtest/finish.ts
+++ b/src/modules/workspace/abtest/finish.ts
@@ -1,19 +1,25 @@
 import chalk from 'chalk'
+import * as enquirer from 'enquirer'
+import { map, prop } from 'ramda'
 
-import { abtester } from '../../../clients'
-import { getAccount, getWorkspace } from '../../../conf'
+import { getAccount } from '../../../conf'
 import { UserCancelledError } from '../../../errors'
 import log from '../../../logger'
 import { promptConfirm } from '../../prompts'
 import { default as abTestStatus } from './status'
-import { checkIfABTesterIsInstalled } from './utils'
+import {
+  checkIfABTesterIsInstalled,
+  getABTester,
+  promptAndUseMaster,
+  promptAndUsePreviousWorkspace,
+} from './utils'
 
-const [account, currentWorkspace] = [getAccount(), getWorkspace()]
+const [account] = [getAccount()]
 
-const promptContinue = async () => {
+const promptContinue = async (workspace: string) => {
   const proceed = await promptConfirm(
     `You are about to finish A/B testing in workspace \
-${chalk.blue(currentWorkspace)}, account ${chalk.green(account)}. Are you sure?`,
+${chalk.blue(workspace)}, account ${chalk.green(account)}. Are you sure?`,
       false
     )
   if (!proceed) {
@@ -21,13 +27,36 @@ ${chalk.blue(currentWorkspace)}, account ${chalk.green(account)}. Are you sure?`
   }
 }
 
+const promptWorkspaceToFinishABTest = async () =>
+  await getABTester().status()
+    .then(map(({WorkspaceB}) => WorkspaceB))
+    .then(workspaces =>
+      enquirer.prompt({
+        name: 'workspace',
+        message: 'Choose which workspace to finish A/B testing:',
+        type: 'select',
+        choices: workspaces,
+      })
+    )
+    .then(prop('workspace'))
+
 export default async () => {
-  await checkIfABTesterIsInstalled()
-  await promptContinue()
-  log.info('Finishing A/B tests')
-  log.info(`Latest results:`)
-  await abTestStatus()
-  await abtester.finish(currentWorkspace)
-  log.info(`A/B testing with workspace ${chalk.blue(currentWorkspace)} is now finished`)
-  log.info(`No traffic currently directed to ${chalk.blue(currentWorkspace)}`)
+  await promptAndUseMaster()
+  try {
+    await checkIfABTesterIsInstalled()
+    const abtester = getABTester()
+    const workspace = await promptWorkspaceToFinishABTest()
+    await promptContinue(workspace)
+    log.info('Finishing A/B tests')
+    log.info(`Latest results:`)
+    await abTestStatus()
+    await abtester.finish(workspace)
+    log.info(`A/B testing with workspace ${chalk.blue(workspace)} is now finished`)
+    log.info(`No traffic currently directed to ${chalk.blue(workspace)}`)
+  } catch (err) {
+    log.error('Unhandled exception')
+    await promptAndUsePreviousWorkspace()
+    throw err
+  }
+  await promptAndUsePreviousWorkspace()
 }

--- a/src/modules/workspace/abtest/start.ts
+++ b/src/modules/workspace/abtest/start.ts
@@ -6,18 +6,14 @@ import { UserCancelledError } from '../../../errors'
 import log from '../../../logger'
 import { promptConfirm } from '../../prompts'
 import {
+  abtester,
   checkIfABTesterIsInstalled,
-  currentWorkspace,
   formatDays,
-  getABTester,
-  promptAndUseMaster,
-  promptAndUsePreviousWorkspace,
   promptProductionWorkspace,
   SIGNIFICANCE_LEVELS,
 } from './utils'
 
 const promptSignificanceLevel = async () => {
-  const abtester = getABTester()
   const significanceTimePreviews = await Promise.all(
     compose<any, number[], Array<Promise<number>>>(
       map(value => abtester.preview(value as number)),
@@ -46,10 +42,10 @@ const promptSignificanceLevel = async () => {
   }).then(prop('level'))
 }
 
-const promptContinue = async (significanceLevel: string) => {
+const promptContinue = async (workspace: string, significanceLevel: string) => {
   const proceed = await promptConfirm(
     `You are about to start an A/B test between workspaces \
-${chalk.green('master')} and ${chalk.green(currentWorkspace)} with \
+${chalk.green('master')} and ${chalk.green(workspace)} with \
 ${chalk.red(significanceLevel)} significance level. Proceed?`,
   false
   )
@@ -60,25 +56,16 @@ ${chalk.red(significanceLevel)} significance level. Proceed?`,
 
 
 export default async () => {
+  await checkIfABTesterIsInstalled()
   const workspace = await promptProductionWorkspace('Choose production workspace to start A/B test:')
   const significanceLevel = await promptSignificanceLevel()
-  await promptAndUseMaster()
-  try {
-    await checkIfABTesterIsInstalled()
-    await promptContinue(significanceLevel)
-    const abtester = getABTester()
-    const significanceLevelValue = SIGNIFICANCE_LEVELS[significanceLevel]
-    log.info(`Setting workspace ${chalk.green(currentWorkspace)} to A/B test with \
+  await promptContinue(workspace, significanceLevel)
+  const significanceLevelValue = SIGNIFICANCE_LEVELS[significanceLevel]
+  log.info(`Setting workspace ${chalk.green(workspace)} to A/B test with \
       ${significanceLevel} significance level`)
-    await abtester.start(workspace, significanceLevelValue)
-    log.info(`Workspace ${chalk.green(workspace)} in A/B test`)
-    log.info(
-      `You can stop the test using ${chalk.blue('vtex workspace abtest abort')}`
-    )
-  } catch (err) {
-    log.error('Unhandled exception')
-    await promptAndUsePreviousWorkspace()
-    throw err
-  }
-  await promptAndUsePreviousWorkspace()
+  await abtester.start(workspace, significanceLevelValue)
+  log.info(`Workspace ${chalk.green(workspace)} in A/B test`)
+  log.info(
+    `You can stop the test using ${chalk.blue('vtex workspace abtest finish')}`
+  )
 }

--- a/src/modules/workspace/abtest/start.ts
+++ b/src/modules/workspace/abtest/start.ts
@@ -6,12 +6,13 @@ import { abtester } from '../../../clients'
 import { UserCancelledError } from '../../../errors'
 import log from '../../../logger'
 import { promptConfirm } from '../../prompts'
+import { default as useWorkspace } from '../use'
 import {
   checkIfABTesterIsInstalled,
-  checkIfInProduction,
   currentWorkspace,
   formatDays,
-  SIGNIFICANCE_LEVELS
+  promptProductionWorkspace,
+  SIGNIFICANCE_LEVELS,
 } from './utils'
 
 const promptSignificanceLevel = async () => {
@@ -55,17 +56,52 @@ ${chalk.red(significanceLevel)} significance level. Proceed?`,
   }
 }
 
+const promptAndUseMaster = async () => {
+  if (currentWorkspace !== 'master') {
+    const proceed = await promptConfirm(
+      `To trigger an A/B test, you must be using the ${chalk.green('master')} \
+workspace. Do you whish to use it?`,
+      true
+    )
+    if (!proceed) {
+      throw new UserCancelledError()
+    }
+    await useWorkspace('master')
+  }
+}
+
+const promptAndUsePreviousWorkspace = async () => {
+  if (currentWorkspace !== 'master') {
+    const proceed = await promptConfirm(
+      `Do you wish to return to using the ${chalk.green(currentWorkspace)} workspace?`,
+      true
+    )
+    if (!proceed) {
+      throw new UserCancelledError()
+    }
+    await useWorkspace(currentWorkspace)
+  }
+}
+
 export default async () => {
-  await checkIfABTesterIsInstalled()
-  await checkIfInProduction()
+  const workspace = await promptProductionWorkspace('Choose production workspace to start A/B test:')
   const significanceLevel = await promptSignificanceLevel()
-  await promptContinue(significanceLevel)
-  const significanceLevelValue = SIGNIFICANCE_LEVELS[significanceLevel]
-  log.info(`Setting workspace ${chalk.green(currentWorkspace)} to A/B test with \
-${significanceLevel} significance level`)
-  await abtester.start(currentWorkspace, significanceLevelValue)
-  log.info(`Workspace ${chalk.green(currentWorkspace)} in A/B test`)
-  log.info(
-    `You can stop the test using ${chalk.blue('vtex workspace abtest abort')}`
-  )
+  await promptAndUseMaster()
+  try {
+    await checkIfABTesterIsInstalled()
+    await promptContinue(significanceLevel)
+    const significanceLevelValue = SIGNIFICANCE_LEVELS[significanceLevel]
+    log.info(`Setting workspace ${chalk.green(currentWorkspace)} to A/B test with \
+      ${significanceLevel} significance level`)
+    await abtester.start(workspace, significanceLevelValue)
+    log.info(`Workspace ${chalk.green(workspace)} in A/B test`)
+    log.info(
+      `You can stop the test using ${chalk.blue('vtex workspace abtest abort')}`
+    )
+    await promptAndUsePreviousWorkspace()
+  } catch (err) {
+    log.error('Unhandled exception')
+    await promptAndUsePreviousWorkspace()
+    throw err
+  }
 }

--- a/src/modules/workspace/abtest/status.ts
+++ b/src/modules/workspace/abtest/status.ts
@@ -7,11 +7,9 @@ import { getAccount } from '../../../conf'
 import log from '../../../logger'
 import { createTable } from '../../../table'
 import {
+  abtester,
   checkIfABTesterIsInstalled,
   formatDuration,
-  getABTester,
-  promptAndUseMaster,
-  promptAndUsePreviousWorkspace,
 } from './utils'
 
 
@@ -80,25 +78,16 @@ const printResultsTable = (testInfo: ABTestStatus) => {
 }
 
 export default async () => {
-  await promptAndUseMaster()
+  await checkIfABTesterIsInstalled()
+  let abTestInfo = []
   try {
-    await checkIfABTesterIsInstalled()
-    const abtester = getABTester()
-    let abTestInfo = []
-    try {
-      abTestInfo = await abtester.status()
-    } catch (e) {
-      log.error(e)
-      process.exit()
-    }
-    if (!abTestInfo || abTestInfo.length === 0) {
-      return log.info(`No AB Tests running in account ${chalk.blue(getAccount())}`)
-    }
-    R.map(printResultsTable, abTestInfo)
-  } catch (err) {
-    log.error('Unhandled exception')
-    await promptAndUsePreviousWorkspace()
-    throw err
+    abTestInfo = await abtester.status()
+  } catch (e) {
+    log.error(e)
+    process.exit()
   }
-  await promptAndUsePreviousWorkspace()
+  if (!abTestInfo || abTestInfo.length === 0) {
+    return log.info(`No AB Tests running in account ${chalk.blue(getAccount())}\n`)
+  }
+  R.map(printResultsTable, abTestInfo)
 }

--- a/src/modules/workspace/abtest/utils.ts
+++ b/src/modules/workspace/abtest/utils.ts
@@ -1,19 +1,18 @@
+import { Apps } from '@vtex/api'
 import chalk from 'chalk'
 import * as enquirer from 'enquirer'
 import * as numbro from 'numbro'
 import { compose, filter, map, prop } from 'ramda'
 
-import { apps, workspaces } from '../../../clients'
+import { workspaces } from '../../../clients'
 import { ABTester } from '../../../clients/abTester'
 import { getAccount, getToken, getWorkspace } from '../../../conf'
 import * as env from '../../../env'
-import { CommandError, UserCancelledError } from '../../../errors'
+import { CommandError } from '../../../errors'
+import envTimeout from '../../../timeout'
 import userAgent from '../../../user-agent'
-import { promptConfirm } from '../../prompts'
-import { default as useWorkspace } from '../use'
 
-const { getApp } = apps
-
+const DEFAULT_TIMEOUT = 15000
 
 export const SIGNIFICANCE_LEVELS = {
   low: 0.5,
@@ -21,7 +20,7 @@ export const SIGNIFICANCE_LEVELS = {
   high: 0.9,
 }
 
-const contextForABTester = () => ({
+const contextForMaster = {
   account: getAccount(),
   authToken: getToken(),
   production: false,
@@ -34,13 +33,16 @@ const contextForABTester = () => ({
   workspace: 'master',
   requestId: '',
   operationId: '',
-})
+}
 
-export const getABTester = () => new ABTester(contextForABTester(), { retries: 3 })
+const options = {
+  timeout: (envTimeout || DEFAULT_TIMEOUT) as number,
+}
 
-export const [account, currentWorkspace] = [getAccount(), getWorkspace()]
+export const abtester = new ABTester(contextForMaster, { ...options, retries: 3 })
+export const apps = new Apps(contextForMaster, options)
 
-const { get } = workspaces
+const account = getAccount()
 
 export const formatDays = (days: number) => {
   let suffix = 'days'
@@ -58,26 +60,14 @@ export const formatDuration = (durationInMinutes: number) => {
   return `${days} days, ${hours} hours and ${minutes} minutes`
 }
 
-export const checkIfInProduction = async (): Promise<void> => {
-  const workspaceData = await get(account, currentWorkspace)
-  if (!workspaceData.production) {
-    throw new CommandError(
-    `Only ${chalk.green('production')} workspaces can be \
-used for A/B testing. Please create a production workspace with \
-${chalk.blue('vtex use <workspace> -r -p')} or reset this one with \
-${chalk.blue('vtex workspace reset -p')}`
-)
-  }
-}
-
 export const checkIfABTesterIsInstalled = async () => {
   try {
-    await getApp('vtex.ab-tester@x')
+    await apps.getApp('vtex.ab-tester@x')
   } catch (e) {
     if (e.response.data.code === 'app_not_found') {
       throw new CommandError(`The app ${chalk.yellow('vtex.ab-tester')} is \
 not installed in account ${chalk.green(account)}, workspace \
-${chalk.blue(currentWorkspace)}. Please install it before attempting to use A/B \
+${chalk.blue(getWorkspace())}. Please install it before attempting to use A/B \
 testing functionality`)
     }
     throw e
@@ -101,31 +91,4 @@ export const promptProductionWorkspace = async (
     choices: productionWorkspaces,
   }).then(prop('workspace'))
 
-}
-
-export const promptAndUseMaster = async () => {
-  if (currentWorkspace !== 'master') {
-    const proceed = await promptConfirm(
-      `To operate A/B tests, you must be using the ${chalk.green('master')} \
-workspace. Do you whish to use it?`,
-      true
-    )
-    if (!proceed) {
-      throw new UserCancelledError()
-    }
-    await useWorkspace('master')
-  }
-}
-
-export const promptAndUsePreviousWorkspace = async () => {
-  if (currentWorkspace !== 'master') {
-    const proceed = await promptConfirm(
-      `Do you wish to return to using the ${chalk.green(currentWorkspace)} workspace?`,
-      true
-    )
-    if (!proceed) {
-      throw new UserCancelledError()
-    }
-    await useWorkspace(currentWorkspace)
-  }
 }

--- a/src/modules/workspace/abtest/utils.ts
+++ b/src/modules/workspace/abtest/utils.ts
@@ -6,11 +6,13 @@ import { compose, filter, map, prop } from 'ramda'
 
 import { workspaces } from '../../../clients'
 import { ABTester } from '../../../clients/abTester'
-import { getAccount, getToken, getWorkspace } from '../../../conf'
+import { getAccount, getToken } from '../../../conf'
 import * as env from '../../../env'
 import { CommandError } from '../../../errors'
 import envTimeout from '../../../timeout'
 import userAgent from '../../../user-agent'
+
+const account = getAccount()
 
 const DEFAULT_TIMEOUT = 15000
 
@@ -21,7 +23,7 @@ export const SIGNIFICANCE_LEVELS = {
 }
 
 const contextForMaster = {
-  account: getAccount(),
+  account,
   authToken: getToken(),
   production: false,
   region: env.region(),
@@ -39,10 +41,10 @@ const options = {
   timeout: (envTimeout || DEFAULT_TIMEOUT) as number,
 }
 
+// Clients for the 'master' workspace
 export const abtester = new ABTester(contextForMaster, { ...options, retries: 3 })
 export const apps = new Apps(contextForMaster, options)
 
-const account = getAccount()
 
 export const formatDays = (days: number) => {
   let suffix = 'days'
@@ -67,7 +69,7 @@ export const checkIfABTesterIsInstalled = async () => {
     if (e.response.data.code === 'app_not_found') {
       throw new CommandError(`The app ${chalk.yellow('vtex.ab-tester')} is \
 not installed in account ${chalk.green(account)}, workspace \
-${chalk.blue(getWorkspace())}. Please install it before attempting to use A/B \
+${chalk.blue('master')}. Please install it before attempting to use A/B \
 testing functionality`)
     }
     throw e

--- a/src/modules/workspace/abtest/utils.ts
+++ b/src/modules/workspace/abtest/utils.ts
@@ -1,5 +1,7 @@
 import chalk from 'chalk'
+import * as enquirer from 'enquirer'
 import * as numbro from 'numbro'
+import { compose, filter, map, prop } from 'ramda'
 
 import { apps, workspaces } from '../../../clients'
 import { getAccount, getWorkspace } from '../../../conf'
@@ -58,4 +60,24 @@ testing functionality`)
     }
     throw e
   }
+}
+
+
+export const promptProductionWorkspace = async (
+  promptMessage: string
+) => {
+  const productionWorkspaces = await workspaces.list(account)
+    .then(
+      compose<any, any, any>(
+        map(({name}) => name),
+        filter(({name, production}) => (production === true && name !== 'master'))
+      )
+    )
+  return await enquirer.prompt({
+    name: 'workspace',
+    message: promptMessage,
+    type: 'select',
+    choices: productionWorkspaces,
+  }).then(prop('workspace'))
+
 }


### PR DESCRIPTION
Because the `vtex.ab-tester` app should only be writing in the `master` workspace's `vbase`, this PR changes the A/B test operation in the following way:

- User now needs to select from a list which (production) workspaces to start and finish A/B testing.
- Always instantiate the VTEX API clients for the `master` workspace, to avoid inconsistencies.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
