### PR TITLE
Enable saving StickyHost locally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.56.7] - 2019-05-15
 ### Changed
 - Enable saving StickyHost locally
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Enable saving StickyHost locally
 
 ## [2.56.6] - 2019-05-13
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.56.6",
+  "version": "2.56.7",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/host.ts
+++ b/src/host.ts
@@ -7,7 +7,7 @@ import { getStickyHost, hasStickyHost, saveStickyHost } from './conf'
 import { BuilderHubTimeoutError } from './errors'
 import log from './logger'
 
-const TTL_SAVED_HOST_HOURS = 0
+const TTL_SAVED_HOST_HOURS = 6
 
 const NOT_AVAILABLE = {
   hostname: undefined,


### PR DESCRIPTION
#### What is the purpose of this pull request?
Re-enable StickyHost that was disabled on #549 , since `kube-router` was fixed on vtex/kube-router#719

#### What problem is this solving?

#### How should this be manually tested?
Link app, kill builder-hub and relink. Check if `sticky-host` is always present, even if locally saved.

#### Screenshots or example usage

#### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
