### PR TITLE
Add JSON schema to Manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Add JSON schema to Manifest
 
 ## [2.56.7] - 2019-05-15
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.57.0] - 2019-05-21
 ### Changed
 - Add JSON schema to Manifest
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.56.7",
+  "version": "2.57.0",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/locator.test.ts
+++ b/src/locator.test.ts
@@ -10,19 +10,19 @@ test('converts version to major range', t => {
 
 
 test('creates major locator', t => {
-  t.is(locator.toMajorLocator({ vendor: 'vtex', name: 'visa-checkout', version: '0.1.2' }), 'vtex.visa-checkout@0.x')
-  t.is(locator.toMajorLocator({ vendor: 'xetv', name: 'render-builder', version: '1.20.12' }), 'xetv.render-builder@1.x')
-  t.is(locator.toMajorLocator({ vendor: 'vext', name: 'toolbelt', version: '2.0.0' }), 'vext.toolbelt@2.x')
+  t.is(locator.toMajorLocator({ vendor: 'vtex', name: 'visa-checkout', version: '0.1.2', builders: {} }), 'vtex.visa-checkout@0.x')
+  t.is(locator.toMajorLocator({ vendor: 'xetv', name: 'render-builder', version: '1.20.12', builders: {} }), 'xetv.render-builder@1.x')
+  t.is(locator.toMajorLocator({ vendor: 'vext', name: 'toolbelt', version: '2.0.0', builders: {} }), 'vext.toolbelt@2.x')
 })
 
 test('creates app locator', t => {
-  t.is(locator.toAppLocator({ vendor: 'vtex', name: 'visa-checkout', version: '0.1.2' }), 'vtex.visa-checkout@0.1.2')
-  t.is(locator.toAppLocator({ vendor: 'xetv', name: 'render-builder', version: '1.20.12' }), 'xetv.render-builder@1.20.12')
-  t.is(locator.toAppLocator({ vendor: 'vext', name: 'toolbelt', version: '2.0.0' }), 'vext.toolbelt@2.0.0')
+  t.is(locator.toAppLocator({ vendor: 'vtex', name: 'visa-checkout', version: '0.1.2', builders: {} }), 'vtex.visa-checkout@0.1.2')
+  t.is(locator.toAppLocator({ vendor: 'xetv', name: 'render-builder', version: '1.20.12', builders: {} }), 'xetv.render-builder@1.20.12')
+  t.is(locator.toAppLocator({ vendor: 'vext', name: 'toolbelt', version: '2.0.0', builders: {} }), 'vext.toolbelt@2.0.0')
 })
 
 test('parses app locator', t => {
-  t.deepEqual(locator.parseLocator('vtex.visa-checkout@0.1.2'), { vendor: 'vtex', name: 'visa-checkout', version: '0.1.2' })
-  t.deepEqual(locator.parseLocator('xetv.render-builder@1.20.12'), { vendor: 'xetv', name: 'render-builder', version: '1.20.12' })
-  t.deepEqual(locator.parseLocator('vext.toolbelt@2.0.0'), { vendor: 'vext', name: 'toolbelt', version: '2.0.0' })
+  t.deepEqual(locator.parseLocator('vtex.visa-checkout@0.1.2'), { vendor: 'vtex', name: 'visa-checkout', version: '0.1.2', builders: {} })
+  t.deepEqual(locator.parseLocator('xetv.render-builder@1.20.12'), { vendor: 'xetv', name: 'render-builder', version: '1.20.12', builders: {} })
+  t.deepEqual(locator.parseLocator('vext.toolbelt@2.0.0'), { vendor: 'vext', name: 'toolbelt', version: '2.0.0', builders: {} })
 })

--- a/src/locator.ts
+++ b/src/locator.ts
@@ -14,7 +14,7 @@ export const toAppLocator = ({ vendor, name, version }: Manifest): string => {
 export const parseLocator = (locator: string): Manifest => {
   const [vendorAndName, version] = locator.split('@')
   const [vendor, name] = vendorAndName.split('.')
-  return { vendor, name, version }
+  return { vendor, name, version, builders: {} }
 }
 
 export const removeVersion = (appId: string): string => appId.split('@')[0]

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -9,8 +9,7 @@ const readFileUtf = async (file: string): Promise<string> => {
   return await readFile(file, 'utf8')
 }
 
-// Change to master version after merge
-const MANIFEST_SCHEMA = 'https://raw.githubusercontent.com/vtex/node-vtex-api/feature/generate-json-schema/gen/manifest.schema'
+const MANIFEST_SCHEMA = 'https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema'
 
 export const MANIFEST_FILE_NAME = 'manifest.json'
 

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -1,5 +1,5 @@
 import { accessSync } from 'fs'
-import { readFile } from 'fs-extra'
+import { readFile, writeFile } from 'fs-extra'
 import * as path from 'path'
 import { memoize } from 'ramda'
 
@@ -8,6 +8,9 @@ import { CommandError } from './errors'
 const readFileUtf = async (file: string): Promise<string> => {
   return await readFile(file, 'utf8')
 }
+
+// Change to master version after merge
+const MANIFEST_SCHEMA = 'https://raw.githubusercontent.com/vtex/node-vtex-api/feature/generate-json-schema/gen/manifest.schema'
 
 export const MANIFEST_FILE_NAME = 'manifest.json'
 
@@ -96,3 +99,12 @@ export const getManifest = memoize(async (): Promise<Manifest> => {
   validateAppManifest(manifest)
   return manifest
 })
+
+export const writeManifestSchema = async () => {
+  const content = await readFileUtf(getManifestPath())
+  const json = JSON.parse(content)
+  if (!json.$schema || json.$schema !== MANIFEST_SCHEMA) {
+    json.$schema = MANIFEST_SCHEMA
+    writeFile(getManifestPath(), JSON.stringify(json, null, 2))
+  }
+}

--- a/src/modules/apps/link.ts
+++ b/src/modules/apps/link.ts
@@ -14,7 +14,7 @@ import { CommandError } from '../../errors'
 import { getSavedOrMostAvailableHost } from '../../host'
 import { toAppLocator } from '../../locator'
 import log from '../../logger'
-import { getAppRoot, getManifest } from '../../manifest'
+import { getAppRoot, getManifest, writeManifestSchema } from '../../manifest'
 import { listenBuild } from '../build'
 import { default as setup } from '../setup'
 import { formatNano } from '../utils'
@@ -192,6 +192,11 @@ export default async (options) => {
   await validateAppAction('link')
   const unsafe = !!(options.unsafe || options.u)
   const manifest = await getManifest()
+  try {
+    await writeManifestSchema()
+  } catch(e) {
+    log.debug('Failed to write schema on manifest.')
+  }
   const builderHubMessage = await checkBuilderHubMessage('link')
   if (!isEmpty(builderHubMessage)) {
     await showBuilderHubMessage(builderHubMessage.message, builderHubMessage.prompt, manifest)

--- a/src/modules/apps/utils.ts
+++ b/src/modules/apps/utils.ts
@@ -207,6 +207,6 @@ export const switchAccountMessage = (previousAccount: string, currentAccount: st
   return `Now you are logged in ${chalk.blue(currentAccount)}. Do you want to return to ${chalk.blue(previousAccount)} account?`
 }
 
-export const resolveAppId = async (appName: string, appVersion: string) =>  await apps.getApp(`${appName}@${appVersion}`).then(prop('id'))
+export const resolveAppId = async (appName: string, appVersion: string) : Promise<string> =>  await apps.getApp(`${appName}@${appVersion}`).then(prop('id'))
 
 export const isLinked = propSatisfies<string, Manifest>(contains('+build'), 'version')

--- a/src/modules/init/index.ts
+++ b/src/modules/init/index.ts
@@ -127,6 +127,7 @@ const createManifest = (name: string, vendor: string, title = '', description = 
     description,
     mustUpdateAt: `${Number(year) + 1}-${monthAndDay.join('-')}`,
     registries: ['smartcheckout'],
+    builders: {},
   }
 }
 

--- a/src/modules/setup.ts
+++ b/src/modules/setup.ts
@@ -90,7 +90,7 @@ const typingsInfo = async () => {
 const appTypingsURL = async (appName: string, appVersion: string, builder: string): Promise<string> => {
   const appId = await resolveAppId(appName, appVersion)
   const vendor = getVendor(appId)
-  if (isLinked({'version': appId})) {
+  if (isLinked({'version': appId, vendor, name: '', builders: {}})) {
     return `https://${workspace}--${account}.${publicEndpoint()}/_v/private/typings/linked/v1/${appId}/${typingsPath}/${builder}`
   }
   return `http://${vendor}.vteximg.com.br/_v/public/typings/v1/${appId}/${typingsPath}/${builder}`

--- a/src/typings/global.d.ts
+++ b/src/typings/global.d.ts
@@ -1,3 +1,4 @@
+import { AppManifest } from '@vtex/api'
 import { Readable } from 'stream'
 
 declare global {
@@ -16,20 +17,7 @@ declare global {
     content: NodeJS.ReadableStream,
   }
 
-  interface Manifest {
-    name?: string,
-    title?: string,
-    vendor?: string,
-    version: string,
-    dependencies?: Record<string, string>,
-    builders?: Record<string, string>,
-    settingsSchema?: {},
-    description?: string,
-    categories?: string[],
-    registries?: string[],
-    mustUpdateAt?: string,
-    latest?: string,
-  }
+  type Manifest = AppManifest
 
   interface InstalledApp {
     app: string,


### PR DESCRIPTION
#### What is the purpose of this pull request?
After each `vtex link`, toolbelt will try to write `$schema` tag on `manifest.json`

#### What problem is this solving?
After vtex/node-vtex-api#155, manifest has a [JSON schema](https://json-schema.org/).

Adding it to `manifest.json` will help the user to write (autocomplete) and validate (typed fields) their manifest.

#### How should this be manually tested?

1. `vtex link`
2. Check for `$schema` on `manifest.json`

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
