### PR TITLE
Stop making `vtex update` attempt to update app major

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.57.0",
+  "version": "2.57.1",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/locator.ts
+++ b/src/locator.ts
@@ -1,5 +1,5 @@
 export const toMajorRange = (version: string): string => {
-  return `${version.split('.')[0]}.x`
+  return `${version.split('.', 2)[0]}.x`
 }
 
 export const toMajorLocator = ({ vendor, name, version }: Manifest): string => {
@@ -17,4 +17,4 @@ export const parseLocator = (locator: string): Manifest => {
   return { vendor, name, version, builders: {} }
 }
 
-export const removeVersion = (appId: string): string => appId.split('@')[0]
+export const removeVersion = (appId: string): string => appId.split('@', 2)[0]

--- a/src/modules/apps/update.ts
+++ b/src/modules/apps/update.ts
@@ -4,7 +4,7 @@ import * as ora from 'ora'
 import { isEmpty, map, pipe, prop, reject } from 'ramda'
 
 import { apps } from '../../clients'
-import { parseLocator, toAppLocator } from '../../locator'
+import { parseLocator, toAppLocator, toMajorRange } from '../../locator'
 import log from '../../logger'
 import { createTable } from '../../table'
 import { diffVersions } from '../infra/utils'
@@ -33,7 +33,7 @@ export default async () => {
   const { data } = await listApps()
   const installedApps = reject<Manifest>(isLinked, map(extractAppLocator, data))
   const withLatest = await Bluebird.all(map(async (app) => {
-    app.latest = await appLatestVersion(`${app.vendor}.${app.name}`)
+    app.latest = await appLatestVersion(`${app.vendor}.${app.name}`, toMajorRange(app.version))
     return app
   }, installedApps))
   const updateableApps = reject(sameVersion, withLatest)


### PR DESCRIPTION
Trying to update the major makes the API call to apps fail, as the
apps service currently doesn't allow an installation request to change
the major of an existing installation. I'm removing that check in
apps, but for that we need to make toolbelt not accidentally update
the apps majors in users' accounts.

That would erroneously make many people update their apps to
the latest majors, when many times the latest major are actually
"unstable" and kept in active development until they are actually
released (when we would normally update the accounts automatically).
This is currently the case for many apps such as vtex.admin, vtex.store,
render-server, render-ssr, etc.

#### How should this be manually tested?
 - Run `vtex update`
 - Check that no updates of majors are suggested
 - Profit

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
