### PR TITLE
Implement `vtex url` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `vtex url` command to print the base URL for the current account, workspace and environment
+
+## [2.57.1] - 2019-05-21
+### Changed
+- Stop making `vtex update` attempt to update app major
 
 ## [2.57.0] - 2019-05-21
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.58.0] - 2019-05-21
 ### Added
 - `vtex url` command to print the base URL for the current account, workspace and environment
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ $ vtex
     settings set <app> <fields> <value>         Set a value
     settings unset <app> <fields>               Unset a value
 
+    url                               Prints base URL for current account, workspace and account
+
     workspace                         Alias for vtex workspace info
     workspace create <name>           Create a new workspace with this name
     workspace delete <name>           Delete a single or various workspaces

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.57.1",
+  "version": "2.58.0",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/modules/tree.ts
+++ b/src/modules/tree.ts
@@ -422,4 +422,8 @@ export default {
     handler: './release',
     optionalArgs: ['releaseType', 'tagName'],
   },
+  url: {
+    description: 'Prints base URL for current account, workspace and environment',
+    handler: './url',
+  },
 }

--- a/src/modules/url.ts
+++ b/src/modules/url.ts
@@ -1,0 +1,7 @@
+import * as conf from '../conf'
+import { clusterIdDomainInfix, publicEndpoint } from '../env'
+
+export default () => {
+  const { account, workspace } = conf.currentContext
+  console.log(`https://${workspace}--${account}${clusterIdDomainInfix()}.${publicEndpoint()}`)
+}


### PR DESCRIPTION
This PR implements the `vtex url` command which prints the base URL for the current account, workspace and evironment ('prod' or 'staging').

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
