### PR TITLE
Refactor/use new login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.59.0] - 2019-05-24
+
 ## [2.58.0] - 2019-05-24
 ### Changed
 - Use new login route whenever it is available in the current workspace

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Use new login route whenever it is available in the current workspace
 
 ## [2.58.0] - 2019-05-21
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.58.0] - 2019-05-24
 ### Changed
 - Use new login route whenever it is available in the current workspace
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.58.0",
+  "version": "2.59.0",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/modules/auth/login.ts
+++ b/src/modules/auth/login.ts
@@ -51,7 +51,6 @@ const getLoginUrl = async (account: string, workspace: string, state: string): P
 const startUserAuth = async (account: string, workspace: string): Promise<string[] | never> => {
   const state = randomstring.generate()
   const [url, fullReturnUrl] = await getLoginUrl(account, workspace, state)
-  console.log(url, fullReturnUrl)
   opn(url, { wait: false })
   return onAuth(account, workspace, state, fullReturnUrl)
 }

--- a/src/modules/auth/login.ts
+++ b/src/modules/auth/login.ts
@@ -26,7 +26,7 @@ const oldLoginUrls = (workspace: string, state: string): [string, string] => {
 
 const newLoginUrls = (workspace: string, state: string): [string, string] => {
   const returnUrl = `/_v/private/auth-server/v1/callback?workspace=${workspace}&state=${state}`
-  const url = `/_v/segment/admin-login/v1/login/?workspace=${workspace}`
+  const url = `/_v/segment/admin-login/v1/login?workspace=${workspace}`
   return [url, returnUrl]
 }
 
@@ -34,12 +34,8 @@ const getLoginUrl = async (account: string, workspace: string, state: string): P
   const baseUrl = `https://${account}${clusterIdDomainInfix()}.${publicEndpoint()}`
   let [url, returnUrl] = newLoginUrls(workspace, state)
   try {
-    const response = await axios.get(`${baseUrl}${url}`)
-    console.log('it worked')
-    console.log(response)
+    await axios.get(`${baseUrl}${url}`)
   } catch (e) {
-    console.log('got an error')
-    console.log(e)
     const oldUrls = oldLoginUrls(workspace, state)
     url = oldUrls[0]
     returnUrl = oldUrls[1]
@@ -55,6 +51,7 @@ const getLoginUrl = async (account: string, workspace: string, state: string): P
 const startUserAuth = async (account: string, workspace: string): Promise<string[] | never> => {
   const state = randomstring.generate()
   const [url, fullReturnUrl] = await getLoginUrl(account, workspace, state)
+  console.log(url, fullReturnUrl)
   opn(url, { wait: false })
   return onAuth(account, workspace, state, fullReturnUrl)
 }

--- a/src/modules/auth/login.ts
+++ b/src/modules/auth/login.ts
@@ -18,14 +18,43 @@ import { promptConfirm } from '../prompts'
 const [cachedAccount, cachedLogin, cachedWorkspace] = [conf.getAccount(), conf.getLogin(), conf.getWorkspace()]
 const details = cachedAccount && `${chalk.green(cachedLogin)} @ ${chalk.green(cachedAccount)} / ${chalk.green(cachedWorkspace)}`
 
-const startUserAuth = (account: string, workspace: string): Bluebird<string[] | never> => {
-  const state = randomstring.generate()
-  const baseUrl = `https://${account}${clusterIdDomainInfix()}.${publicEndpoint()}`
+const oldLoginUrls = (workspace: string, state: string): [string, string] => {
   const returnUrl = `/_v/private/auth-server/v1/callback?workspace=${workspace}&state=${state}`
-  const returnUrlEncoded = encodeURIComponent(returnUrl)
-  const fullReturnUrl = baseUrl + returnUrl
-  const url = `${baseUrl}/_v/private/auth-server/v1/login/?workspace=${workspace}&ReturnUrl=${returnUrlEncoded}`
+  const url = `/_v/private/auth-server/v1/login/?workspace=${workspace}`
+  return [url, returnUrl]
+}
 
+const newLoginUrls = (workspace: string, state: string): [string, string] => {
+  const returnUrl = `/_v/private/auth-server/v1/callback?workspace=${workspace}&state=${state}`
+  const url = `/_v/segment/admin-login/v1/login/?workspace=${workspace}`
+  return [url, returnUrl]
+}
+
+const getLoginUrl = async (account: string, workspace: string, state: string): Promise<[string, string]> => {
+  const baseUrl = `https://${account}${clusterIdDomainInfix()}.${publicEndpoint()}`
+  let [url, returnUrl] = newLoginUrls(workspace, state)
+  try {
+    const response = await axios.get(`${baseUrl}${url}`)
+    console.log('it worked')
+    console.log(response)
+  } catch (e) {
+    console.log('got an error')
+    console.log(e)
+    const oldUrls = oldLoginUrls(workspace, state)
+    url = oldUrls[0]
+    returnUrl = oldUrls[1]
+  }
+  const fullReturnUrl = baseUrl + returnUrl
+  const returnUrlEncoded = encodeURIComponent(returnUrl)
+  return [
+    `${baseUrl}${url}&returnUrl=${returnUrlEncoded}`,
+    fullReturnUrl,
+  ]
+}
+
+const startUserAuth = async (account: string, workspace: string): Promise<string[] | never> => {
+  const state = randomstring.generate()
+  const [url, fullReturnUrl] = await getLoginUrl(account, workspace, state)
   opn(url, { wait: false })
   return onAuth(account, workspace, state, fullReturnUrl)
 }


### PR DESCRIPTION
Use the new admin-login app whenever for login whenever it is installed in the current workspace.

We check if it is installed by trying a request on its URL. I welcome suggestions on a better way of doing this.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
