### PR TITLE
Wrap yarn path in double quotes to avoid errors with spaces in path name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Use double quotes around the resolved `yarn` path so `vtex link` works correctly on Windows platforms.
 
 ## [2.61.1] - 2019-05-27
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.60.2] - 2019-05-28
 ### Fixed
 - Use double quotes around the resolved `yarn` path so `vtex link` works correctly on Windows platforms.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.61.1",
+  "version": "2.60.1-beta.0",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.60.1",
+  "version": "2.60.2",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.60.1-beta.0",
+  "version": "2.60.1",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/modules/utils.ts
+++ b/src/modules/utils.ts
@@ -21,7 +21,7 @@ const allEvents: BuildEvent[] = ['start', 'success', 'fail', 'timeout', 'logs']
 
 const flowEvents: BuildEvent[] = ['start', 'success', 'fail']
 
-export const yarnPath = `'${require.resolve('yarn/bin/yarn')}'`
+export const yarnPath = `"${require.resolve('yarn/bin/yarn')}"`
 
 const onBuildEvent = (ctx: Context, timeout: number, appOrKey: string, callback: (type: BuildEvent, message?: Message) => void) => {
   const [subject] = appOrKey.split('@')

--- a/src/modules/utils.ts
+++ b/src/modules/utils.ts
@@ -21,7 +21,7 @@ const allEvents: BuildEvent[] = ['start', 'success', 'fail', 'timeout', 'logs']
 
 const flowEvents: BuildEvent[] = ['start', 'success', 'fail']
 
-export const yarnPath = require.resolve('yarn/bin/yarn')
+export const yarnPath = `'${require.resolve('yarn/bin/yarn')}'`
 
 const onBuildEvent = (ctx: Context, timeout: number, appOrKey: string, callback: (type: BuildEvent, message?: Message) => void) => {
   const [subject] = appOrKey.split('@')


### PR DESCRIPTION
This PR adds double quotes around the resolved `yarn` path so calling `yarn` also works in Windows platforms.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
