### PR TITLE
Correctly check if `vtex.admin-login` is installed in current account/workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.61.1] - 2019-05-27
 ### Fixed
 - Check if the returned data is really from the `vtex.admin-login` app when testing if it is installed in the current account/workspace
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Check if the returned data is really from the `vtex.admin-login` app when testing if it is installed in the current account/workspace
 
 ## [2.61.0] - 2019-05-27
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.61.0",
+  "version": "2.61.1",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/modules/auth/login.ts
+++ b/src/modules/auth/login.ts
@@ -34,7 +34,10 @@ const getLoginUrl = async (account: string, workspace: string, state: string): P
   const baseUrl = `https://${account}${clusterIdDomainInfix()}.${publicEndpoint()}`
   let [url, returnUrl] = newLoginUrls(workspace, state)
   try {
-    await axios.get(`${baseUrl}${url}`)
+    const response = await axios.get(`${baseUrl}${url}`)
+    if (!response.data.match(/vtex\.admin-login/)) {
+      throw new Error('Unexpected response from admin-login')
+    }
   } catch (e) {
     const oldUrls = oldLoginUrls(workspace, state)
     url = oldUrls[0]


### PR DESCRIPTION
This PR adds the following condition when checking if `vtex.admin-login` is installed in the current account/workspace:

- checks if the data returned by the request to `vtex.admin-login` contains the appId "vtex.admin-login", which should indicate that it is actually the app's response, and not a generic "not found" page generated by the website.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
