### PR TITLE
Fix `vtex init`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix `vtex init`
 
 ## [2.63.2] - 2019-05-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.63.3] - 2019-05-31
 ### Fixed
 - Fix `vtex init`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.63.2",
+  "version": "2.63.3",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/modules/init/index.ts
+++ b/src/modules/init/index.ts
@@ -4,7 +4,7 @@ import * as enquirer from 'enquirer'
 import { outputJson, readJson } from 'fs-extra'
 import * as moment from 'moment'
 import { join } from 'path'
-import { keys, prop } from 'ramda'
+import { keys, merge, prop } from 'ramda'
 
 import { getAccount } from '../../conf'
 import log from '../../logger'
@@ -126,7 +126,7 @@ const manifestFromPrompt = async (repo: string) => {
   ], f => f(repo))
 }
 
-const createManifest = (name: string, vendor: string, title = '', description = ''): Manifest => {
+const createManifest = (name: string, vendor: string, title = '', description = ''): Partial<Manifest> => {
   const [year, ...monthAndDay] = moment().format('YYYY-MM-DD').split('-')
   return {
     name,
@@ -136,7 +136,6 @@ const createManifest = (name: string, vendor: string, title = '', description = 
     description,
     mustUpdateAt: `${Number(year) + 1}-${monthAndDay.join('-')}`,
     registries: ['smartcheckout'],
-    builders: {},
   }
 }
 
@@ -153,7 +152,7 @@ export default async () => {
       manifestFromPrompt(repo),
     ])
     const synthetic = createManifest(name, vendor, title, description)
-    const manifest: any = Object.assign(await readJson(manifestPath) || {}, synthetic)
+    const manifest: any = merge(await readJson(manifestPath) || {}, synthetic)
     await outputJson(manifestPath, manifest, { spaces: 2 })
     log.info(`Run ${chalk.bold.green(`cd ${repo}`)} and ${chalk.bold.green('vtex link')} to start developing!`)
   } catch (err) {


### PR DESCRIPTION
The `builders` prop in the `manifest.json` file of the cloned app was always being set to `{}` with `vtex init`.

This PR fixes the issue.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
