### PR TITLE
Change color of vtex update table headers to yellow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Use yellow instead of red for `vtex update` table headers color
 
 ## [2.63.5] - 2019-06-04
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.63.6] - 2019-06-05
 ### Changed
 - Use yellow instead of red for `vtex update` table headers color
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.63.5",
+  "version": "2.63.6",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/modules/apps/update.ts
+++ b/src/modules/apps/update.ts
@@ -21,6 +21,11 @@ const promptUpdate = (): Bluebird<boolean> =>
 
 const sameVersion = ({ version, latest }: Manifest) => version === latest
 
+const tableHeaders = map(
+      str => chalk.bold.yellow(str),
+      ['App', 'Current', 'Latest']
+    )
+
 const extractAppLocator = pipe(prop('app'), parseLocator)
 
 const updateVersion = (app) => {
@@ -39,10 +44,7 @@ export default async () => {
   const updateableApps = reject(sameVersion, withLatest)
 
   const table = createTable(
-    { head: map(
-      str => chalk.bold.yellow(str),
-      ['App', 'Current', 'Latest']
-    ) }
+    { head: tableHeaders }
   )
   updateableApps.forEach(({ vendor, name, version, latest }) => {
     if (!latest) {

--- a/src/modules/apps/update.ts
+++ b/src/modules/apps/update.ts
@@ -43,9 +43,7 @@ export default async () => {
   }, installedApps))
   const updateableApps = reject(sameVersion, withLatest)
 
-  const table = createTable(
-    { head: tableHeaders }
-  )
+  const table = createTable({ head: tableHeaders })
   updateableApps.forEach(({ vendor, name, version, latest }) => {
     if (!latest) {
       log.debug(`Couldn't find latest version of ${vendor}.${name}`)

--- a/src/modules/apps/update.ts
+++ b/src/modules/apps/update.ts
@@ -38,7 +38,12 @@ export default async () => {
   }, installedApps))
   const updateableApps = reject(sameVersion, withLatest)
 
-  const table = createTable({ head: ['App', 'Current', 'Latest'] })
+  const table = createTable(
+    { head: map(
+      str => chalk.bold.yellow(str),
+      ['App', 'Current', 'Latest']
+    ) }
+  )
   updateableApps.forEach(({ vendor, name, version, latest }) => {
     if (!latest) {
       log.debug(`Couldn't find latest version of ${vendor}.${name}`)


### PR DESCRIPTION
When issuing `vtex update`, the confirmation table (containing the previous and new versions of installed apps) had red headers.

This PR changes the color of the headers to yellow.

![image](https://user-images.githubusercontent.com/20361388/58903223-395f0880-86db-11e9-9b56-c6bccd16e2e0.png)


#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
