### PR TITLE
Feature/reset account confirmation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Display account name on workspace reset prompt
 
 ## [2.63.8] - 2019-06-17
 

--- a/src/modules/workspace/reset.ts
+++ b/src/modules/workspace/reset.ts
@@ -6,9 +6,9 @@ import { UserCancelledError } from '../../errors'
 import log from '../../logger'
 import { promptConfirm } from '../prompts'
 
-const promptWorkspaceReset = (name: string): Bluebird<void> =>
+const promptWorkspaceReset = (name: string, account: string): Bluebird<void> =>
   promptConfirm(
-    `Are you sure you want to reset workspace ${chalk.green(name)}?`
+    `Are you sure you want to reset workspace ${chalk.green(name)} on account ${chalk.blue(account)}?`
   ).then(answer => {
     if (!answer) {
       throw new UserCancelledError()
@@ -24,7 +24,7 @@ export default async (name: string, options) => {
   log.debug('Resetting workspace', workspace)
 
   if (!preConfirm) {
-    await promptWorkspaceReset(workspace)
+    await promptWorkspaceReset(workspace, account)
   }
 
   try {


### PR DESCRIPTION
#### What is the purpose of this pull request?
Displays account name on workspace reset prompt.
<img width="677" alt="Screen Shot 2019-06-06 at 14 42 41" src="https://user-images.githubusercontent.com/5691711/59054403-ff703c80-8869-11e9-983f-e8f58694b21a.png">


#### What problem is this solving?
<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
