### PR TITLE
Initialize A/B test with new API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use app's root as `cwd` when running scripts during `vtex release`.
 
 ## [2.63.4] - 2019-06-04
+### Changed
+- Bump `axios` version.
 
 ## [2.63.3] - 2019-05-31
 ### Fixed
-- Fix `vtex init`
+- Fix `vtex init`.
 
 ## [2.63.2] - 2019-05-30
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Use yellow instead of red for `vtex update` table headers color
 
 ## [2.63.5] - 2019-06-04
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.63.6] - 2019-06-05
 ### Changed
 - Use yellow instead of red for `vtex update` table headers color
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.63.4] - 2019-06-04
+
 ## [2.63.3] - 2019-05-31
 ### Fixed
 - Fix `vtex init`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Use app's root as `cwd` when running scripts during `vtex release`
 
 ## [2.63.4] - 2019-06-04
 
@@ -13,8 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix `vtex init`
 
 ## [2.63.2] - 2019-05-30
+### Added
+- Add graphql example.
 
 ## [2.63.1] - 2019-05-30
+### Added
+- Add admin example.
 
 ## [2.63.0] - 2019-05-29
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.63.5] - 2019-06-04
 ### Fixed
 - Use app's root as `cwd` when running scripts during `vtex release`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed
-- Use app's root as `cwd` when running scripts during `vtex release`
+- Use app's root as `cwd` when running scripts during `vtex release`.
 
 ## [2.63.4] - 2019-06-04
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.63.3",
+  "version": "2.63.4",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.63.5",
+  "version": "2.63.6",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.63.4",
+  "version": "2.63.5",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/clients/abTester.ts
+++ b/src/clients/abTester.ts
@@ -3,7 +3,8 @@ import { AppClient, InstanceOptions, IOContext } from '@vtex/api'
 const routes = {
   Abort: (workspace: string) => `${routes.ABTester}/finish/${workspace}`,
   ABTester: '/_v/private/abtesting',
-  Initialize: (workspace: string, probability: number) => `${routes.ABTester}/initialize/${workspace}/${probability}`,
+  Initialize: (workspace: string) => `${routes.ABTester}/initialize/${workspace}`,
+  InitializeLegacy: (workspace: string, probability: number) => `${routes.ABTester}/initialize/${workspace}/${probability}`,
   Preview: (probability: number) => `${routes.ABTester}/time/${probability}`,
   Status: () => `${routes.ABTester}/status`,
 }
@@ -18,8 +19,12 @@ export class ABTester extends AppClient {
     this.http.post(routes.Abort(workspace), {}, { metric: 'abtester-finish' })
 
   // Start AB Test in a workspace with a given probability.
-  public start = async (workspace: string, probability: number) =>
-    this.http.post(routes.Initialize(workspace, probability), {}, { metric: 'abtester-start' })
+  public startLegacy = async (workspace: string, probability: number) =>
+    this.http.post(routes.InitializeLegacy(workspace, probability), {}, { metric: 'abtester-start' })
+
+  // Start AB Test in a workspace.
+  public start = async (workspace: string) =>
+    this.http.post(routes.Initialize(workspace), {}, { metric: 'abtester-start' })
 
   // Get estimated AB Test duration.
   public preview = async (significanceLevel: number): Promise<number> =>

--- a/src/modules/apps/update.ts
+++ b/src/modules/apps/update.ts
@@ -21,6 +21,11 @@ const promptUpdate = (): Bluebird<boolean> =>
 
 const sameVersion = ({ version, latest }: Manifest) => version === latest
 
+const tableHeaders = map(
+      str => chalk.bold.yellow(str),
+      ['App', 'Current', 'Latest']
+    )
+
 const extractAppLocator = pipe(prop('app'), parseLocator)
 
 const updateVersion = (app) => {
@@ -39,10 +44,7 @@ export default async () => {
   const updateableApps = reject(sameVersion, withLatest)
 
   const table = createTable(
-    { head: map(
-      str => chalk.bold.yellow(str),
-      ['App', 'Current', 'Latest']
-    ) }
+    { head: tableHeaders }
   )
   updateableApps.forEach(({ vendor, name, version, latest }) => {
     if (!latest) {

--- a/src/modules/apps/update.ts
+++ b/src/modules/apps/update.ts
@@ -43,9 +43,7 @@ export default async () => {
   }, installedApps))
   const updateableApps = reject(sameVersion, withLatest)
 
-  const table = createTable(
-    { head: tableHeaders }
-  )
+  const table = createTable({ head: tableHeaders })
   updateableApps.forEach(({ vendor, name, version, latest }) => {
     if (!latest) {
       log.debug(`Couldn't find latest version of ${vendor}.${name}`)

--- a/src/modules/apps/update.ts
+++ b/src/modules/apps/update.ts
@@ -38,7 +38,12 @@ export default async () => {
   }, installedApps))
   const updateableApps = reject(sameVersion, withLatest)
 
-  const table = createTable({ head: ['App', 'Current', 'Latest'] })
+  const table = createTable(
+    { head: map(
+      str => chalk.bold.yellow(str),
+      ['App', 'Current', 'Latest']
+    ) }
+  )
   updateableApps.forEach(({ vendor, name, version, latest }) => {
     if (!latest) {
       log.debug(`Couldn't find latest version of ${vendor}.${name}`)

--- a/src/modules/release/utils.ts
+++ b/src/modules/release/utils.ts
@@ -72,7 +72,7 @@ const runCommand = (
 ) => {
   let output
   try {
-    output = execSync(cmd, {stdio: hideOutput ? 'pipe' : 'inherit'})
+    output = execSync(cmd, {stdio: hideOutput ? 'pipe' : 'inherit', cwd: root})
     if (!hideSuccessMessage) {
       log.info(successMessage + chalk.blue(` >  ${cmd}`))
     }

--- a/src/modules/workspace/abtest/start.ts
+++ b/src/modules/workspace/abtest/start.ts
@@ -1,6 +1,7 @@
 import chalk from 'chalk'
 import * as enquirer from 'enquirer'
-import { compose, fromPairs, keys, map, mapObjIndexed, prop, values, zip } from 'ramda'
+import { compose, fromPairs, keys, map, mapObjIndexed, prop, values, zip } from 'ramda';
+import * as semver from 'semver'
 
 import { UserCancelledError } from '../../../errors'
 import log from '../../../logger'
@@ -33,10 +34,10 @@ const promptSignificanceLevel = async () => {
     choices: values(
       mapObjIndexed(
         (value, key) => (
-           {
-             message:`${key} (~ ${formatDays(value as number)})`,
-             value: key,
-        }
+          {
+            message: `${key} (~ ${formatDays(value as number)})`,
+            value: key,
+          }
         ))(significanceTimePreviewMap)
     ),
   }).then(prop('level'))
@@ -47,7 +48,7 @@ const promptContinue = async (workspace: string, significanceLevel: string) => {
     `You are about to start an A/B test between workspaces \
 ${chalk.green('master')} and ${chalk.green(workspace)} with \
 ${chalk.red(significanceLevel)} significance level. Proceed?`,
-  false
+    false
   )
   if (!proceed) {
     throw new UserCancelledError()
@@ -56,14 +57,23 @@ ${chalk.red(significanceLevel)} significance level. Proceed?`,
 
 
 export default async () => {
-  await checkIfABTesterIsInstalled()
+  const abTesterManifest = await checkIfABTesterIsInstalled()
   const workspace = await promptProductionWorkspace('Choose production workspace to start A/B test:')
+
+  if (semver.satisfies(abTesterManifest.version, '>=0.10.0')) {
+    log.info(`Setting workspace ${chalk.green(workspace)} to A/B test`)
+    await abtester.start(workspace)
+    log.info(`Workspace ${chalk.green(workspace)} in A/B test`)
+    log.info(`You can stop the test using ${chalk.blue('vtex workspace abtest finish')}`)
+    return
+  }
+
   const significanceLevel = await promptSignificanceLevel()
   await promptContinue(workspace, significanceLevel)
   const significanceLevelValue = SIGNIFICANCE_LEVELS[significanceLevel]
   log.info(`Setting workspace ${chalk.green(workspace)} to A/B test with \
       ${significanceLevel} significance level`)
-  await abtester.start(workspace, significanceLevelValue)
+  await abtester.startLegacy(workspace, significanceLevelValue)
   log.info(`Workspace ${chalk.green(workspace)} in A/B test`)
   log.info(
     `You can stop the test using ${chalk.blue('vtex workspace abtest finish')}`

--- a/src/modules/workspace/abtest/utils.ts
+++ b/src/modules/workspace/abtest/utils.ts
@@ -1,4 +1,4 @@
-import { Apps } from '@vtex/api'
+import { AppManifest, Apps } from '@vtex/api'
 import chalk from 'chalk'
 import * as enquirer from 'enquirer'
 import * as numbro from 'numbro'
@@ -62,9 +62,9 @@ export const formatDuration = (durationInMinutes: number) => {
   return `${days} days, ${hours} hours and ${minutes} minutes`
 }
 
-export const checkIfABTesterIsInstalled = async () => {
+export const checkIfABTesterIsInstalled = async (): Promise<AppManifest> => {
   try {
-    await apps.getApp('vtex.ab-tester@x')
+    return await apps.getApp('vtex.ab-tester@x')
   } catch (e) {
     if (e.response.data.code === 'app_not_found') {
       throw new CommandError(`The app ${chalk.yellow('vtex.ab-tester')} is \

--- a/yarn.lock
+++ b/yarn.lock
@@ -1251,12 +1251,12 @@ axios-retry@^3.1.2:
     is-retry-allowed "^1.1.0"
 
 axios@^0.18.0:
-  version "0.18.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.18.0.tgz#32d53e4851efdc0a11993b6cd000789d70c05102"
-  integrity sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=
+  version "0.18.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.18.1.tgz#ff3f0de2e7b5d180e757ad98000f1081b87bcea3"
+  integrity sha512-0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==
   dependencies:
-    follow-redirects "^1.3.0"
-    is-buffer "^1.1.5"
+    follow-redirects "1.5.10"
+    is-buffer "^2.0.2"
 
 babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
   version "6.26.0"
@@ -2450,6 +2450,13 @@ debug-log@^1.0.1:
   resolved "https://registry.yarnpkg.com/debug-log/-/debug-log-1.0.1.tgz#2307632d4c04382b8df8a32f70b895046d52745f"
   integrity sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=
 
+debug@=3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
+  dependencies:
+    ms "2.0.0"
+
 debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.6, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -2457,7 +2464,7 @@ debug@^2.1.2, debug@^2.2.0, debug@^2.3.3, debug@^2.6.6, debug@^2.6.8, debug@^2.6
   dependencies:
     ms "2.0.0"
 
-debug@^3.0.1, debug@^3.1.0, debug@^3.2.6:
+debug@^3.0.1, debug@^3.1.0:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
@@ -3001,12 +3008,12 @@ fn-name@^2.0.0:
   resolved "https://registry.yarnpkg.com/fn-name/-/fn-name-2.0.1.tgz#5214d7537a4d06a4a301c0cc262feb84188002e7"
   integrity sha1-UhTXU3pNBqSjAcDMJi/rhBiAAuc=
 
-follow-redirects@^1.3.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.7.0.tgz#489ebc198dc0e7f64167bd23b03c4c19b5784c76"
-  integrity sha512-m/pZQy4Gj287eNy94nivy5wchN3Kp+Q5WgUPNy5lJSZ3sgkVKSYV/ZChMAQVIgx1SqfZ2zBZtPA2YlXIWxxJOQ==
+follow-redirects@1.5.10:
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
+  integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
   dependencies:
-    debug "^3.2.6"
+    debug "=3.1.0"
 
 for-in@^0.1.3:
   version "0.1.8"
@@ -3717,6 +3724,11 @@ is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
+
+is-buffer@^2.0.2:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.3.tgz#4ecf3fcf749cbd1e472689e109ac66261a25e725"
+  integrity sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==
 
 is-builtin-module@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
#### What is the purpose of this pull request?
Initialize A/B test adapted to the new API, which doesn't need anymore to tell the confidence level.

#### What problem is this solving?
Now `ab-tester` declares a new route to initialize a test which doesn't require a value o confidence level. This PR aims to initialize the test with this new format but also maintain support for old version of `ab-tester`.

#### How should this be manually tested?
Try to initialize a A/B test with IO CLI and verify if works well.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
