### PR TITLE
Initialize A/B test with new API

### DIFF
--- a/src/clients/abTester.ts
+++ b/src/clients/abTester.ts
@@ -3,7 +3,8 @@ import { AppClient, InstanceOptions, IOContext } from '@vtex/api'
 const routes = {
   Abort: (workspace: string) => `${routes.ABTester}/finish/${workspace}`,
   ABTester: '/_v/private/abtesting',
-  Initialize: (workspace: string, probability: number) => `${routes.ABTester}/initialize/${workspace}/${probability}`,
+  Initialize: (workspace: string) => `${routes.ABTester}/initialize/${workspace}`,
+  InitializeLegacy: (workspace: string, probability: number) => `${routes.ABTester}/initialize/${workspace}/${probability}`,
   Preview: (probability: number) => `${routes.ABTester}/time/${probability}`,
   Status: () => `${routes.ABTester}/status`,
 }
@@ -18,8 +19,12 @@ export class ABTester extends AppClient {
     this.http.post(routes.Abort(workspace), {}, { metric: 'abtester-finish' })
 
   // Start AB Test in a workspace with a given probability.
-  public start = async (workspace: string, probability: number) =>
-    this.http.post(routes.Initialize(workspace, probability), {}, { metric: 'abtester-start' })
+  public startLegacy = async (workspace: string, probability: number) =>
+    this.http.post(routes.InitializeLegacy(workspace, probability), {}, { metric: 'abtester-start' })
+
+  // Start AB Test in a workspace.
+  public start = async (workspace: string) =>
+    this.http.post(routes.Initialize(workspace), {}, { metric: 'abtester-start' })
 
   // Get estimated AB Test duration.
   public preview = async (significanceLevel: number): Promise<number> =>

--- a/src/modules/workspace/abtest/finish.ts
+++ b/src/modules/workspace/abtest/finish.ts
@@ -9,7 +9,7 @@ import { promptConfirm } from '../../prompts'
 import { default as abTestStatus } from './status'
 import {
   abtester,
-  checkIfABTesterIsInstalled,
+  installedABTester,
 } from './utils'
 
 const [account] = [getAccount()]
@@ -39,7 +39,7 @@ const promptWorkspaceToFinishABTest = async () =>
     .then(prop('workspace'))
 
 export default async () => {
-  await checkIfABTesterIsInstalled()
+  await installedABTester()
   const workspace = await promptWorkspaceToFinishABTest()
   await promptContinue(workspace)
   log.info('Finishing A/B tests')

--- a/src/modules/workspace/abtest/start.ts
+++ b/src/modules/workspace/abtest/start.ts
@@ -60,22 +60,28 @@ export default async () => {
   const abTesterManifest = await installedABTester()
   const workspace = await promptProductionWorkspace('Choose production workspace to start A/B test:')
 
-  if (semver.satisfies(abTesterManifest.version, '>=0.10.0')) {
-    log.info(`Setting workspace ${chalk.green(workspace)} to A/B test`)
-    await abtester.start(workspace)
-    log.info(`Workspace ${chalk.green(workspace)} in A/B test`)
-    log.info(`You can stop the test using ${chalk.blue('vtex workspace abtest finish')}`)
-    return
-  }
+  try {
+    if (semver.satisfies(abTesterManifest.version, '>=0.10.0')) {
+      log.info(`Setting workspace ${chalk.green(workspace)} to A/B test`)
+      await abtester.start(workspace)
+      log.info(`Workspace ${chalk.green(workspace)} in A/B test`)
+      log.info(`You can stop the test using ${chalk.blue('vtex workspace abtest finish')}`)
+      return
+    }
 
-  const significanceLevel = await promptSignificanceLevel()
-  await promptContinue(workspace, significanceLevel)
-  const significanceLevelValue = SIGNIFICANCE_LEVELS[significanceLevel]
-  log.info(`Setting workspace ${chalk.green(workspace)} to A/B test with \
-      ${significanceLevel} significance level`)
-  await abtester.startLegacy(workspace, significanceLevelValue)
-  log.info(`Workspace ${chalk.green(workspace)} in A/B test`)
-  log.info(
-    `You can stop the test using ${chalk.blue('vtex workspace abtest finish')}`
-  )
+    const significanceLevel = await promptSignificanceLevel()
+    await promptContinue(workspace, significanceLevel)
+    const significanceLevelValue = SIGNIFICANCE_LEVELS[significanceLevel]
+    log.info(`Setting workspace ${chalk.green(workspace)} to A/B test with \
+        ${significanceLevel} significance level`)
+    await abtester.startLegacy(workspace, significanceLevelValue)
+    log.info(`Workspace ${chalk.green(workspace)} in A/B test`)
+    log.info(
+      `You can stop the test using ${chalk.blue('vtex workspace abtest finish')}`
+    )
+  } catch(err) {
+    if (err.message === 'Workspace not found') {
+      console.log(`Test not initialized due to workspace ${workspace} not found by ab-tester.`)
+    }
+  }
 }

--- a/src/modules/workspace/abtest/start.ts
+++ b/src/modules/workspace/abtest/start.ts
@@ -1,13 +1,14 @@
 import chalk from 'chalk'
 import * as enquirer from 'enquirer'
 import { compose, fromPairs, keys, map, mapObjIndexed, prop, values, zip } from 'ramda'
+import * as semver from 'semver'
 
 import { UserCancelledError } from '../../../errors'
 import log from '../../../logger'
 import { promptConfirm } from '../../prompts'
 import {
   abtester,
-  checkIfABTesterIsInstalled,
+  installedABTester,
   formatDays,
   promptProductionWorkspace,
   SIGNIFICANCE_LEVELS,
@@ -33,10 +34,10 @@ const promptSignificanceLevel = async () => {
     choices: values(
       mapObjIndexed(
         (value, key) => (
-           {
-             message:`${key} (~ ${formatDays(value as number)})`,
-             value: key,
-        }
+          {
+            message: `${key} (~ ${formatDays(value as number)})`,
+            value: key,
+          }
         ))(significanceTimePreviewMap)
     ),
   }).then(prop('level'))
@@ -47,7 +48,7 @@ const promptContinue = async (workspace: string, significanceLevel: string) => {
     `You are about to start an A/B test between workspaces \
 ${chalk.green('master')} and ${chalk.green(workspace)} with \
 ${chalk.red(significanceLevel)} significance level. Proceed?`,
-  false
+    false
   )
   if (!proceed) {
     throw new UserCancelledError()
@@ -56,14 +57,23 @@ ${chalk.red(significanceLevel)} significance level. Proceed?`,
 
 
 export default async () => {
-  await checkIfABTesterIsInstalled()
+  const abTesterManifest = await installedABTester()
   const workspace = await promptProductionWorkspace('Choose production workspace to start A/B test:')
+
+  if (semver.satisfies(abTesterManifest.version, '>=0.10.0')) {
+    log.info(`Setting workspace ${chalk.green(workspace)} to A/B test`)
+    await abtester.start(workspace)
+    log.info(`Workspace ${chalk.green(workspace)} in A/B test`)
+    log.info(`You can stop the test using ${chalk.blue('vtex workspace abtest finish')}`)
+    return
+  }
+
   const significanceLevel = await promptSignificanceLevel()
   await promptContinue(workspace, significanceLevel)
   const significanceLevelValue = SIGNIFICANCE_LEVELS[significanceLevel]
   log.info(`Setting workspace ${chalk.green(workspace)} to A/B test with \
       ${significanceLevel} significance level`)
-  await abtester.start(workspace, significanceLevelValue)
+  await abtester.startLegacy(workspace, significanceLevelValue)
   log.info(`Workspace ${chalk.green(workspace)} in A/B test`)
   log.info(
     `You can stop the test using ${chalk.blue('vtex workspace abtest finish')}`

--- a/src/modules/workspace/abtest/status.ts
+++ b/src/modules/workspace/abtest/status.ts
@@ -8,7 +8,7 @@ import log from '../../../logger'
 import { createTable } from '../../../table'
 import {
   abtester,
-  checkIfABTesterIsInstalled,
+  installedABTester,
   formatDuration,
 } from './utils'
 
@@ -78,7 +78,7 @@ const printResultsTable = (testInfo: ABTestStatus) => {
 }
 
 export default async () => {
-  await checkIfABTesterIsInstalled()
+  await installedABTester()
   let abTestInfo = []
   abTestInfo = await abtester.status()
   if (!abTestInfo || abTestInfo.length === 0) {

--- a/src/modules/workspace/abtest/utils.ts
+++ b/src/modules/workspace/abtest/utils.ts
@@ -1,4 +1,4 @@
-import { Apps } from '@vtex/api'
+import { AppManifest, Apps } from '@vtex/api'
 import chalk from 'chalk'
 import * as enquirer from 'enquirer'
 import * as numbro from 'numbro'
@@ -62,9 +62,9 @@ export const formatDuration = (durationInMinutes: number) => {
   return `${days} days, ${hours} hours and ${minutes} minutes`
 }
 
-export const checkIfABTesterIsInstalled = async () => {
+export const installedABTester = async (): Promise<AppManifest> => {
   try {
-    await apps.getApp('vtex.ab-tester@x')
+    return await apps.getApp('vtex.ab-tester@x')
   } catch (e) {
     if (e.response.data.code === 'app_not_found') {
       throw new CommandError(`The app ${chalk.yellow('vtex.ab-tester')} is \


### PR DESCRIPTION
#### What is the purpose of this pull request?
Initialize A/B test adapted to the new API, which doesn't need anymore to tell the confidence level.

#### What problem is this solving?
Now `ab-tester` declares a new route to initialize a test which doesn't require a value o confidence level. This PR aims to initialize the test with this new format but also maintain support for old version of `ab-tester`.

#### How should this be manually tested?
Try to initialize a A/B test with IO CLI and verify if works well.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
