### PR TITLE
Update A/B Test Status

### DIFF
--- a/src/modules/workspace/abtest/start.ts
+++ b/src/modules/workspace/abtest/start.ts
@@ -43,18 +43,22 @@ const promptSignificanceLevel = async () => {
   }).then(prop('level'))
 }
 
-const promptContinue = async (workspace: string, significanceLevel: string) => {
-  const proceed = await promptConfirm(
+const promptContinue = async (workspace: string, significanceLevel?: string) => {
+  const proceed = significanceLevel ? await promptConfirm(
     `You are about to start an A/B test between workspaces \
 ${chalk.green('master')} and ${chalk.green(workspace)} with \
 ${chalk.red(significanceLevel)} significance level. Proceed?`,
+    false
+  ) :
+  await promptConfirm(
+    `You are about to start an A/B test between workspaces \
+${chalk.green('master')} and ${chalk.green(workspace)}. Proceed?`,
     false
   )
   if (!proceed) {
     throw new UserCancelledError()
   }
 }
-
 
 export default async () => {
   const abTesterManifest = await installedABTester()
@@ -64,6 +68,7 @@ export default async () => {
     if (semver.satisfies(abTesterManifest.version, '>=0.10.0')) {
       log.info(`Setting workspace ${chalk.green(workspace)} to A/B test`)
       await abtester.start(workspace)
+      await promptContinue(workspace)
       log.info(`Workspace ${chalk.green(workspace)} in A/B test`)
       log.info(`You can stop the test using ${chalk.blue('vtex workspace abtest finish')}`)
       return

--- a/src/modules/workspace/abtest/status.ts
+++ b/src/modules/workspace/abtest/status.ts
@@ -27,6 +27,7 @@ interface ABTestStatus {
   ConversionA: number
   ConversionB: number
   ProbabilityAlternativeBeatMaster: number
+  PValue: number
 }
 
 const formatPercent = (n: number) => numbro(n).format('0.000%')

--- a/src/modules/workspace/abtest/status.ts
+++ b/src/modules/workspace/abtest/status.ts
@@ -25,7 +25,9 @@ interface ABTestStatus {
   ExpectedLossChoosingA: number
   ExpectedLossChoosingB: number
   ConversionA: number
+  ConversionALast24Hours: number
   ConversionB: number
+  ConversionBLast24Hours: number
   ProbabilityAlternativeBeatMaster: number
   PValue: number
 }
@@ -49,8 +51,11 @@ const printResultsTable = (testInfo: ABTestStatus) => {
     ExpectedLossChoosingA,
     ExpectedLossChoosingB,
     ConversionA,
+    ConversionALast24Hours,
     ConversionB,
+    ConversionBLast24Hours,
     ProbabilityAlternativeBeatMaster,
+    PValue,
   } = testInfo
   console.log(chalk.bold(`VTEX AB Test: ${chalk.blue(`${WorkspaceA} (A)`)} vs ${chalk.blue(`${WorkspaceB} (B)`)}\n`))
   if (R.any(R.isNil)([ExpectedLossChoosingA, ExpectedLossChoosingB, ProbabilityAlternativeBeatMaster])) {
@@ -58,23 +63,34 @@ const printResultsTable = (testInfo: ABTestStatus) => {
 
   }
 
+  const rawDataTable = createTable()
+  rawDataTable.push(bold(['', chalk.blue(WorkspaceA), chalk.blue(WorkspaceB)]))
+  rawDataTable.push(bold(['Conversion', formatPercent(ConversionA), formatPercent(ConversionB)]))
+  rawDataTable.push(bold(['Conversion (last 24h)',
+      formatPercent(ConversionALast24Hours), formatPercent(ConversionBLast24Hours)]))
+  rawDataTable.push(bold(['N. of Sessions', formatInteger(WorkspaceASessions), formatInteger(WorkspaceBSessions)]))
+  rawDataTable.push(bold(['N. of Sessions (last 24h)',
+      formatInteger(WorkspaceASessionsLast24Hours), formatInteger(WorkspaceBSessionsLast24Hours)]))
+
   const comparisonTable = createTable()
   comparisonTable.push(bold(['', chalk.blue(WorkspaceA), chalk.blue(WorkspaceB)]))
-  comparisonTable.push(bold(['Conversion', formatPercent(ConversionA), formatPercent(ConversionB)]))
   comparisonTable.push(bold(['Expected Loss', formatPercent(ExpectedLossChoosingA), formatPercent(ExpectedLossChoosingB)]))
-  comparisonTable.push(bold(['N. of Sessions', formatInteger(WorkspaceASessions), formatInteger(WorkspaceBSessions)]))
-  comparisonTable.push(bold(['N. of Sessions (last 24h)',
-      formatInteger(WorkspaceASessionsLast24Hours), formatInteger(WorkspaceBSessionsLast24Hours)]))
+
+  const probabilitiesTable = createTable()
+  probabilitiesTable.push(bold(['Event', 'Condition', 'Probability']))
+  probabilitiesTable.push(bold(['B beats A', 'None', formatPercent(ProbabilityAlternativeBeatMaster)]))
+  probabilitiesTable.push(bold(['Data as extreme as the observed', `Workspaces being equal (both to ${chalk.blue(WorkspaceA)}).`, formatPercent(PValue)]))
 
   const resultsTable = createTable()
   resultsTable.push(bold([`Start Date`, `${moment(ABTestBeginning).format('DD-MMM-YYYY HH:mm')} (UTC)`]))
   const nowUTC = moment.utc()
   const runningTime = nowUTC.diff(moment.utc(ABTestBeginning), 'minutes')
   resultsTable.push(bold([`Running Time`, formatDuration(runningTime)]))
-  resultsTable.push(bold([`Probability B beats A`, formatPercent(ProbabilityAlternativeBeatMaster)]))
   resultsTable.push(bold([chalk.bold.green(`Winner`), chalk.bold.green(Winner)]))
 
-  console.log(`Comparative:\n${comparisonTable.toString()}\n`)
+  console.log(`Raw Data:\n${rawDataTable.toString()}\n`)
+  console.log(`Comparison of losses in case of chosing wrong workspace:\n${rawDataTable.toString()}\n`)
+  console.log(`Probabilities:\n${probabilitiesTable.toString()}\n`)
   console.log(`Results:\n${resultsTable.toString()}\n`)
 }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
First, add the new A/B Test's info `pValue` to the response of A/B Test status and add a missing information, the values of conversion rates when we only looked to the data retrieved in the last 24 hours. Also, we should change a bit the way we show these informations trying to make it clearer and easy to understand.

#### What problem is this solving?
We need to return a more descriptive information about an A/B Test.

#### How should this be manually tested?
Initialize an A/B Test and check if the status of the test changed as described.

#### Types of changes
- [x] Little improvement (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
