### PR TITLE
Allow to pass "-" to switch to last used workspace/account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.65.0] - 2019-06-28
+
 ### Added
 
 - Support `-` to switch back to previous account or workspace.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support `-` to switch back to previous account or workspace.
+
 ## [2.64.3] - 2019-06-26
 ### Fixed
 - On `vtex update`, correctly show when there are no updates available.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.64.3",
+  "version": "2.65.0",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/conf.ts
+++ b/src/conf.ts
@@ -11,8 +11,14 @@ export enum Environment {
 export const saveAll = (config: any): void => {
   conf.all = config
 }
-export const saveAccount = (account: string): void =>
+export const saveAccount = (account: string): void => {
+  const lastUsedAccount = getAccount()
+  if(lastUsedAccount !== account) {
+    conf.set('lastUsedAccount', lastUsedAccount)
+    conf.delete('lastUsedWorkspace')
+  }
   conf.set('account', account)
+}
 
 export const saveLogin = (login: string): void =>
   conf.set('login', login)
@@ -20,8 +26,13 @@ export const saveLogin = (login: string): void =>
 export const saveToken = (token: string): void =>
   conf.set('token', token)
 
-export const saveWorkspace = (workspace = 'master') =>
+export const saveWorkspace = (workspace = 'master') => {
+  const lastUsedWorkspace = getWorkspace()
+  if(lastUsedWorkspace !== workspace) {
+    conf.set('lastUsedWorkspace', lastUsedWorkspace)
+  }
   conf.set('workspace', workspace)
+}
 
 export const saveEnvironment = (env: Environment) =>
   conf.set('env', env)
@@ -48,6 +59,12 @@ export const getStickyHost = (appName: string): {stickyHost: string; lastUpdated
 
 export const hasStickyHost = (appName: string): boolean =>
   conf.has(`apps.${appName}.sticky-host`)
+
+export const getLastUsedAccount = (): string =>
+  conf.get('lastUsedAccount')
+
+export const getLastUsedWorkspace = (): string =>
+  conf.get('lastUsedWorkspace')
 
 const envFromProcessEnv = {
   'prod': Environment.Production,

--- a/src/conf.ts
+++ b/src/conf.ts
@@ -13,9 +13,9 @@ export const saveAll = (config: any): void => {
 }
 export const saveAccount = (account: string): void => {
   const lastUsedAccount = getAccount()
-  if(lastUsedAccount !== account) {
-    conf.set('lastUsedAccount', lastUsedAccount)
-    conf.delete('lastUsedWorkspace')
+  if (lastUsedAccount !== account) {
+    conf.set('_lastUsedAccount', lastUsedAccount)
+    conf.delete('_lastUsedWorkspace')
   }
   conf.set('account', account)
 }
@@ -28,8 +28,8 @@ export const saveToken = (token: string): void =>
 
 export const saveWorkspace = (workspace = 'master') => {
   const lastUsedWorkspace = getWorkspace()
-  if(lastUsedWorkspace !== workspace) {
-    conf.set('lastUsedWorkspace', lastUsedWorkspace)
+  if (lastUsedWorkspace !== workspace) {
+    conf.set('_lastUsedWorkspace', lastUsedWorkspace)
   }
   conf.set('workspace', workspace)
 }
@@ -61,10 +61,10 @@ export const hasStickyHost = (appName: string): boolean =>
   conf.has(`apps.${appName}.sticky-host`)
 
 export const getLastUsedAccount = (): string =>
-  conf.get('lastUsedAccount')
+  conf.get('_lastUsedAccount')
 
 export const getLastUsedWorkspace = (): string =>
-  conf.get('lastUsedWorkspace')
+  conf.get('_lastUsedWorkspace')
 
 const envFromProcessEnv = {
   'prod': Environment.Production,

--- a/src/modules/auth/switch.ts
+++ b/src/modules/auth/switch.ts
@@ -27,8 +27,11 @@ const hasAccountSwitched = (account: string) => {
 }
 
 export default async (account: string, options) => {
-  if(account === '-') {
-    account = getLastUsedAccount() || account
+  if (account === '-') {
+    account = getLastUsedAccount()
+    if (account == null) {
+      throw new CommandError('No last used account was found')
+    }
   }
 
   const previousAccount = getAccount()

--- a/src/modules/auth/switch.ts
+++ b/src/modules/auth/switch.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk'
 
 import { split } from 'ramda'
-import { getAccount } from '../../conf'
+import { getAccount, getLastUsedAccount } from '../../conf'
 import { CommandError } from '../../errors'
 import log from '../../logger'
 import loginCmd from './login'
@@ -27,6 +27,10 @@ const hasAccountSwitched = (account: string) => {
 }
 
 export default async (account: string, options) => {
+  if(account === '-') {
+    account = getLastUsedAccount() || account
+  }
+
   const previousAccount = getAccount()
   // Enable users to type `vtex switch {account}/{workspace}` and switch
   // directly to a workspace without typing the `-w` option.

--- a/src/modules/workspace/use.ts
+++ b/src/modules/workspace/use.ts
@@ -3,7 +3,7 @@ import chalk from 'chalk'
 
 import { workspaces } from '../../clients'
 import { getAccount, saveWorkspace, getLastUsedWorkspace} from '../../conf'
-import { UserCancelledError } from '../../errors'
+import { UserCancelledError, CommandError } from '../../errors'
 import log from '../../logger'
 import { promptConfirm } from '../prompts'
 import createCmd from './create'
@@ -27,8 +27,11 @@ export default async (name: string, options?) => {
   let confirm
   const accountName = getAccount()
 
-  if(name === '-') {
-    name = getLastUsedWorkspace() || name
+  if (name === '-') {
+    name = getLastUsedWorkspace()
+    if (name == null) {
+      throw new CommandError('No last used workspace was found')
+    }
   }
 
   try {

--- a/src/modules/workspace/use.ts
+++ b/src/modules/workspace/use.ts
@@ -2,7 +2,7 @@ import * as Bluebird from 'bluebird'
 import chalk from 'chalk'
 
 import { workspaces } from '../../clients'
-import { getAccount, saveWorkspace } from '../../conf'
+import { getAccount, saveWorkspace, getLastUsedWorkspace} from '../../conf'
 import { UserCancelledError } from '../../errors'
 import log from '../../logger'
 import { promptConfirm } from '../prompts'
@@ -26,6 +26,11 @@ export default async (name: string, options?) => {
   let production = options ? (options.p || options.production) : null
   let confirm
   const accountName = getAccount()
+
+  if(name === '-') {
+    name = getLastUsedWorkspace() || name
+  }
+
   try {
     await workspaces.get(accountName, name)
   } catch (err) {
@@ -43,6 +48,7 @@ export default async (name: string, options?) => {
     }
   }
   await saveWorkspace(name)
+
   if (reset && !confirm) {
     await resetWks(name, {production})
   }


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->

Allow to use `vtex switch -` and `vtex use -` to switch account/workspace back to previous one used. Just like `git checkout -` or `cd -`. 

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->

Not exactly a problem, but it would be a nice to have.

#### How should this be manually tested?

```shell
vtex switch account1
vtex switch account2
vtex switch - # should switch to `account1`
vtex switch - # should switch to `account2`
vtex switch - # should switch to `account1`
```

```shell
vtex use workspace1
vtex use workspace2
vtex use - # should switch to `workspace1`
vtex use - # should switch to `workspace2`
vtex use - # should switch to `workspace1`
```

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
