### PR TITLE
Stop saving sticky-host locally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Stop saving sticky-host locally until issue with Builder-hub's `fork-ts-checker-webpack-plugin` issue is resolved.
 
 ## [2.65.0] - 2019-06-28
-
 ### Added
 
 - Support `-` to switch back to previous account or workspace.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.65.1] - 2019-07-18
 ### Changed
 - Stop saving sticky-host locally until issue with Builder-hub's `fork-ts-checker-webpack-plugin` issue is resolved.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.65.0",
+  "version": "2.65.1",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/host.ts
+++ b/src/host.ts
@@ -7,7 +7,7 @@ import { getStickyHost, hasStickyHost, saveStickyHost } from './conf'
 import { BuilderHubTimeoutError } from './errors'
 import log from './logger'
 
-const TTL_SAVED_HOST_HOURS = 6
+const TTL_SAVED_HOST_HOURS = 0
 
 const NOT_AVAILABLE = {
   hostname: undefined,


### PR DESCRIPTION
#### What is the purpose of this pull request?
This stops toolbelt from saving the sticky-host locally.

#### What problem is this solving?
The issue with the `fork-ts-checker-webpack-plugin` is making Builder-hub stall builds after the `Build accepted` message. This is worsened by the fact that toolbelt forces build requests to go to the same pod, so if the user ends up with a faulty pod, he won't be able to link until his sticky-host expires or the pod dies.

#### How should this be manually tested?
Use this toolbelt to link repeatedly and verify toolbelt gets a new sticky-host every time.

#### Screenshots or example usage

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
