### PR TITLE
Always convert formatted log to string before calling the replace method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Stringify `message` or `code` before calling the `replace` method.
 
 ## [2.65.1] - 2019-07-18
 ### Changed

--- a/src/sse.ts
+++ b/src/sse.ts
@@ -96,7 +96,7 @@ export const logAll = (context: Context, logLevel: string, id: string, senders?:
       return // Ignore logs without message or code.
     }
     const suffix = sender.startsWith(id) ? '' : ' ' + chalk.gray(sender)
-    const formatted = (message || code || '').replace(/\n\s*$/, '') + suffix
+    const formatted = String(message || code || '').replace(/\n\s*$/, '') + suffix
     if (previous !== formatted) {
       previous = formatted
       log.log(level, formatted)


### PR DESCRIPTION
This PR stringifies the `message` or `code` received from the logger before calling the `replace` method. 

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
