### PR TITLE
Use `ignore-engines` flag when running `yarn`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.65.2] - 2019-07-19
 ### Fixed
 - Add `ignore-engines` flag when running `yarn`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Add `ignore-engines` flag when running `yarn`.
 
 ## [2.65.1] - 2019-07-18
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.65.1",
+  "version": "2.65.2",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/modules/utils.ts
+++ b/src/modules/utils.ts
@@ -121,8 +121,8 @@ export const runYarn = (relativePath: string, force: boolean) => {
   log.info(`Running yarn in ${chalk.green(relativePath)}`)
   const root = getAppRoot()
   const command = force ?
-    `${yarnPath} --force --non-interactive` :
-    `${yarnPath} --non-interactive`
+    `${yarnPath} --force --non-interactive --ignore-engines` :
+    `${yarnPath} --non-interactive --ignore-engines`
   execSync(
     command,
     {stdio: 'inherit', cwd: resolvePath(root, relativePath)}


### PR DESCRIPTION
Since the local code will be built with `vtex.builder-hub`, it makes no sense to have `yarn` checking if the dependencies in a project's `package.json` are compatible with the local version of `node`.


#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
