### PR TITLE
Make vtex update show runtimes updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `vtex update` correctly shows available updates for runtimes.
 
 ## [2.65.2] - 2019-07-19
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.65.3] - 2019-07-25
 ### Fixed
 - `vtex update` correctly shows available updates for runtimes.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.65.2",
+  "version": "2.65.3",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,12 +12,13 @@ import { reject, without } from 'ramda'
 import { isFunction } from 'ramda-adjunct'
 import * as pkg from '../package.json'
 import { getToken } from './conf'
+import * as conf from './conf'
 import { envCookies } from './env'
 import { CommandError, SSEConnectionError, UserCancelledError } from './errors'
 import log from './logger'
 import tree from './modules/tree'
 import notify from './update'
-import * as conf from './conf'
+import { isVerbose, VERBOSE } from './utils'
 
 axios.interceptors.request.use(config => {
   if (envCookies()) {
@@ -37,8 +38,6 @@ const loginCmd = tree.login
 let loginPending = false
 
 // Setup logging
-const VERBOSE = '--verbose'
-const isVerbose = process.argv.indexOf(VERBOSE) >= 0
 if (isVerbose) {
   log.level = 'debug'
   ;(log.default.transports.console as any).timestamp = () =>

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,2 @@
+export const VERBOSE = '--verbose'
+export const isVerbose = process.argv.indexOf(VERBOSE) >= 0


### PR DESCRIPTION
This PR fixes the `vtex update` command by making it show available `runtimes` updates.

Moreover, the `vtex update` command will now list available `infra` and `runtimes` updates only when run with the `--verbose` option. Otherwise it will only show that there are availble `infra` and/or `runtimes` updates without listing them.

### Examples:

![image](https://user-images.githubusercontent.com/20361388/61833337-5c3faa80-ae4a-11e9-9199-ace0b0b5f7b9.png)


![image](https://user-images.githubusercontent.com/20361388/61833294-3dd9af00-ae4a-11e9-9220-917b6edd0d61.png)

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
