### PR TITLE
Do not show unnecessary templates for users outside VTEX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `vtex init` does not show unnecessary templates for users outside VTEX.
 
 ## [2.65.3] - 2019-07-25
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.65.4] - 2019-08-06
 ### Added
 - `vtex init` does not show unnecessary templates for users outside VTEX.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.65.3",
+  "version": "2.65.4",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/modules/init/index.ts
+++ b/src/modules/init/index.ts
@@ -19,6 +19,7 @@ const VTEXInternalTemplates = [
   // Only show these templates for VTEX e-mail users.
   'graphql-example',
   'service-example',
+  'react-guide',
 ]
 
 const templates = {
@@ -30,6 +31,7 @@ const templates = {
   'render-guide': 'render-guide',
   'masterdata-graphql-guide': 'masterdata-graphql-guide',
   'support app': 'hello-support',
+  'react-guide': 'react-repo-template',
 }
 
 const titles = {
@@ -41,6 +43,7 @@ const titles = {
   'render-guide': 'Render Guide',
   'masterdata-graphql-guide': 'MasterData GraphQL Guide',
   'support app': 'Support App Example',
+  'react-guide': 'React App Template',
 }
 
 const descriptions = {
@@ -52,6 +55,7 @@ const descriptions = {
   'render-guide': 'VTEX IO Render Guide',
   'masterdata-graphql-guide': 'VTEX IO MasterData GraphQL Guide',
   'support app': 'Example of a support app',
+  'react-guide': 'Guide for react apps structure',
 }
 
 const getTemplates = () =>

--- a/src/modules/init/index.ts
+++ b/src/modules/init/index.ts
@@ -108,8 +108,6 @@ const promptDescription = async (repo: string) => {
 
 const promptTemplates = async (): Promise<string> => {
   const cancel = 'Cancel'
-  console.log('The templates are' + JSON.stringify(getTemplates()))
-  console.log('The login is ' + getLogin())
   const chosen = prop<string>('service', await enquirer.prompt({
     name: 'service',
     message: 'Choose where do you want to start from',


### PR DESCRIPTION
This PR makes the `vtex init` command not show some unnecessary (back end examples) templates for users that are not from VTEX. 

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
