### PR TITLE
Add masterdata-graphql-guide to vtex internal templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.65.5] - 2019-08-06
 ### Changed
 - Do not show `masterdata-graphql-guide` in `vtex init` for users outside VTEX.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Do not show `masterdata-graphql-guide` in `vtex init` for users outside VTEX.
+
 
 ## [2.65.4] - 2019-08-06
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.65.4",
+  "version": "2.65.5",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/modules/init/index.ts
+++ b/src/modules/init/index.ts
@@ -20,6 +20,7 @@ const VTEXInternalTemplates = [
   'graphql-example',
   'service-example',
   'react-guide',
+  'masterdata-graphql-guide',
 ]
 
 const templates = {


### PR DESCRIPTION
Do not show `masterdata-graphql-guide` in `vtex init` for users outside VTEX.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
