### PR TITLE
Add header to send debug requests to the runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Add a header to send debug requests to the runtime instead of the app.
 
 ## [2.65.5] - 2019-08-06
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.65.6] - 2019-08-07
 ### Changed
 - Add a header to send debug requests to the runtime instead of the app.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.65.5",
+  "version": "2.65.6",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/modules/apps/debugger.ts
+++ b/src/modules/apps/debugger.ts
@@ -29,6 +29,7 @@ function webSocketTunnelHandler(host, path: string): (socket: net.Socket) => voi
     headers: {
       Authorization: getToken(),
       Host: host,
+      'X-Vtex-Runtime-Api': 'true',
     },
   }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
In order to keep the debug of Node apps working we need to make sure that debug requests are handled by the runtime.

#### What problem is this solving?
We want to remove the runtime from the default flow of requests, but it's needed in some situations, like debugging Node apps.

#### How should this be manually tested?
1. Configure the Toolbelt to use a cluster with a Router that can handle the new header (v3.1.14-beta.4, for instance)
2. Link the [Builder Hub](https://github.com/vtex/builder-hub/pull/662) that uses the runtime to start the app 
3. Link a Node app and go to `chrome://inspect` to make sure the debug tunnel is not open
4. Run this version of the Toolbelt so you can send the new `Runtime-Api` header
5. Link a Node app and go to `chrome://inspect` to make sure the debug tunnel is open

#### Screenshots or example usage

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
