### PR TITLE
Filter out __VTEX_IO_LOGS except on verbose mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Filter out artificial JSON logs that are meant to be logged to splunk, except in verbose mode
 
 ## [2.65.6] - 2019-08-07
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.66.0] - 2019-08-07
 ### Changed
 - Filter out artificial JSON logs that are meant to be logged to splunk, except in verbose mode
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.65.6",
+  "version": "2.66.0",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",


### PR DESCRIPTION
#### What is the purpose of this pull request?
Filter out artificial JSON objects that are meant to be logged to splunk, except in verbose mode

https://vtex.slack.com/archives/CK9QZV5JN/p1565206489045000

#### What problem is this solving?

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
