### PR TITLE
Remove request to builder-hub when a new workspace is created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.66.1] - 2019-08-15
 - Use jest as testing framework
 
 ## [2.66.0] - 2019-08-07

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.66.0",
+  "version": "2.66.1",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/modules/workspace/create.ts
+++ b/src/modules/workspace/create.ts
@@ -1,7 +1,6 @@
 import chalk from 'chalk'
 
 import { workspaces } from '../../clients'
-import { createClients } from '../../clients'
 import { getAccount } from '../../conf'
 import { CommandError } from '../../errors'
 import log from '../../logger'
@@ -20,10 +19,6 @@ export default async (name: string, options: any) => {
   try {
     await workspaces.create(getAccount(), name, production)
     log.info(`Workspace ${chalk.green(name)} created ${chalk.green('successfully')} with ${chalk.green(`production=${production}`)}`)
-    // First request on a brand new workspace takes very long because of route map generation, so we warm it up.
-    const { builder } = createClients({ workspace: name })
-    await builder.availability('vtex.builder-hub@0.x', null)
-    log.debug('Warmed up route map')
   } catch (err) {
     if (err.response && err.response.data.code === 'WorkspaceAlreadyExists') {
       log.error(err.response.data.message)


### PR DESCRIPTION
#### What is the purpose of this pull request?
After creating a new workspace, toolbelt always calls the the availability endpoint of build-hub to work the route map generation and cache it on router. The problem is: the endpoint which has been used to warm it up is private, and route map are only built to public endpoints.

#### What problem is this solving?
Remove unnecessary code. Once this code never warmed up the route map build and we there aren't "tickets" about timeout on the first request, we don't need sending a request to builder-hub anymore.

#### How should this be manually tested?
- Create a new workspace
- Open the account admin on it (you should not receive a timeout)

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
