### PR TITLE
Add a parameter to skip route conflict check in app installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 - Use jest as testing framework
 
+## [2.67.0] - 2019-08-21
+### Added
+- Parameter `-f` or `--force` in `vtex install` to skip check for route conflicts.
+
 ## [2.66.0] - 2019-08-07
 ### Changed
 - Filter out artificial JSON logs that are meant to be logged to splunk, except in verbose mode

--- a/src/clients/billingClient.ts
+++ b/src/clients/billingClient.ts
@@ -8,9 +8,9 @@ export default class Billing {
     this.http = HttpClient.forWorkspace('billing.vtex', ioContext, opts)
   }
 
-  public installApp = async (appName: string, termsOfUseAccepted: boolean): Promise<InstallResponse> => {
+  public installApp = async (appName: string, termsOfUseAccepted: boolean, force: boolean): Promise<InstallResponse> => {
     const graphQLQuery = `mutation InstallApps{
-      install(appName:"${appName}", termsOfUseAccepted:${termsOfUseAccepted}) {
+      install(appName:"${appName}", termsOfUseAccepted:${termsOfUseAccepted}, force:${force}) {
         code
         billingOptions
       }

--- a/src/modules/tree.ts
+++ b/src/modules/tree.ts
@@ -110,6 +110,14 @@ export default {
     alias: 'i',
     description: 'Install an app (defaults to the app in the current directory)',
     handler: './apps/install',
+    options: [
+      {
+        description: 'Install app without checking for route conflicts',
+        long: 'force',
+        short: 'f',
+        type: 'boolean',
+      },
+    ],
     optionalArgs: 'app',
   },
   setup: {


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add a parameter force in the cli for the app installation feature that will skip the check for route conflict. Therefore it will be possible to install an app even if it has route conflicts with app already installed in the workspace.

#### How should this be manually tested?
Trying to install an app that has route conflict with another app already installed in the workspace. Without the parameter force it should return an error and the app should not be installed. With the parameter force the app should be installed normally.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
