### PR TITLE
Add/eslint files support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ yarn-error.log
 .DS_Store
 scripts/errors.json
 package-lock.json
+.nyc_output

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.66.1] - 2019-08-15
 - Use jest as testing framework
+- Stop ignoring eslint configuration files.
 
 ## [2.66.0] - 2019-08-07
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.66.3] - 2019-08-19
+
 ### Changed
 - Stop ignoring eslint configuration files.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Stop ignoring eslint configuration files.
+
 ## [2.66.2] - 2019-08-15
 
 ## [2.66.1] - 2019-08-15
 - Use jest as testing framework
-- Stop ignoring eslint configuration files.
 
 ## [2.66.0] - 2019-08-07
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.66.2",
+  "version": "2.66.3",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/modules/apps/file.ts
+++ b/src/modules/apps/file.ts
@@ -14,7 +14,6 @@ type AnyFunction = (...args: any[]) => any
 const defaultIgnored = [
   '.DS_Store',
   'README.md',
-  '.eslintrc',
   '.gitignore',
   'CHANGELOG.md',
   'package.json',
@@ -113,7 +112,6 @@ export async function getLinkedFiles(linkConfig: LinkConfig): Promise<BatchStrea
   const ignore = [
     '.DS_Store',
     'README.md',
-    '.eslintrc',
     '.gitignore',
     'CHANGELOG.md',
     'node_modules/**',
@@ -157,7 +155,7 @@ export const getIgnoredPaths = (root: string): string[] => {
 
 export const listLocalFiles = (root: string, folder?: string): Promise<string[]> =>
   Promise.resolve(
-    glob(['manifest.json', 'policies.json', `${safeFolder(folder)}`], {
+    glob(['manifest.json', 'policies.json', 'node/.*', 'react/.*', `${safeFolder(folder)}`], {
       cwd: root,
       follow: true,
       ignore: getIgnoredPaths(root),


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
Make the toolbelt send the eslint config files to builder hub

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
The builder hub needs this files to run eslint with the apps configs.

#### How should this be manually tested?
Link a node or a react app that contains a `.eslintrc` with `--verbose` and check if the file `node/.eslintrc` or `react/.eslintrc` shows up on the list of sent files

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
