### PR TITLE
Fix/prob table

### DIFF
--- a/src/modules/workspace/abtest/status.ts
+++ b/src/modules/workspace/abtest/status.ts
@@ -79,7 +79,9 @@ const printResultsTable = (testInfo: ABTestStatus) => {
   const probabilitiesTable = createTable()
   probabilitiesTable.push(bold(['Event', 'Condition', 'Probability']))
   probabilitiesTable.push(bold(['B beats A', 'None', formatPercent(ProbabilityAlternativeBeatMaster)]))
-  probabilitiesTable.push(bold(['Data as extreme as the observed', `Workspaces being equal (both to ${chalk.blue(WorkspaceA)}).`, formatPercent(PValue)]))
+
+  // While we're not confident in this calculation, we shouldn't show it to our users
+  // probabilitiesTable.push(bold(['Data as extreme as the observed', `Workspaces being equal (both to ${chalk.blue(WorkspaceA)}).`, formatPercent(PValue)]))
 
   const resultsTable = createTable()
   resultsTable.push(bold([`Start Date`, `${moment(ABTestBeginning).format('DD-MMM-YYYY HH:mm')} (UTC)`]))

--- a/src/modules/workspace/abtest/status.ts
+++ b/src/modules/workspace/abtest/status.ts
@@ -55,7 +55,7 @@ const printResultsTable = (testInfo: ABTestStatus) => {
     ConversionB,
     ConversionBLast24Hours,
     ProbabilityAlternativeBeatMaster,
-    PValue,
+    // PValue,
   } = testInfo
   console.log(chalk.bold(`VTEX AB Test: ${chalk.blue(`${WorkspaceA} (A)`)} vs ${chalk.blue(`${WorkspaceB} (B)`)}\n`))
   if (R.any(R.isNil)([ExpectedLossChoosingA, ExpectedLossChoosingB, ProbabilityAlternativeBeatMaster])) {


### PR DESCRIPTION
#### What is the purpose of this pull request?
Don't show in A/B Test status the p-value calculated while we're not confident in its calculation.

#### How should this be manually tested?
In a workspace with an A/B Test being performed, execute the command `vtex workspace abtest status` and verify if the field "Data as extreme as the observed" don't appear anymore.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
