### PR TITLE
Add parameter force to skip SemVer ensure in app publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.70.0] - 2019-09-05
 - Parameter `-f` or `--force` in `vtex publish` to skip check for sem ver.
 
 ## [2.69.1] - 2019-09-04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Parameter `-f` or `--force` in `vtex publish` to skip check for sem ver.
 
 ## [2.69.1] - 2019-09-04
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.69.1",
+  "version": "2.70.0",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/modules/apps/publish.ts
+++ b/src/modules/apps/publish.ts
@@ -29,9 +29,13 @@ const buildersToRunLocalYarn = ['node', 'react']
 const automaticTag = (version: string): string => (version.indexOf('-') > 0 ? null : 'latest')
 
 const publisher = (workspace: string = 'master') => {
-
-  const publishApp = async (appRoot: string, appId: string, tag: string, force: boolean, builder): Promise<BuildResult> => {
-
+  const publishApp = async (
+    appRoot: string,
+    appId: string,
+    tag: string,
+    force: boolean,
+    builder
+  ): Promise<BuildResult> => {
     const paths = await listLocalFiles(appRoot)
     const retryOpts = {
       retries: 2,
@@ -74,7 +78,7 @@ const publisher = (workspace: string = 'master') => {
   }
 
   const publishApps = async (path: string, tag: string, force: boolean): Promise<void | never> => {
-    const previousConf = conf.getAll()  // Store previous configuration in memory
+    const previousConf = conf.getAll() // Store previous configuration in memory
 
     const manifest = await getManifest()
     const account = conf.getAccount()

--- a/src/modules/apps/publish.ts
+++ b/src/modules/apps/publish.ts
@@ -29,7 +29,9 @@ const buildersToRunLocalYarn = ['node', 'react']
 const automaticTag = (version: string): string => (version.indexOf('-') > 0 ? null : 'latest')
 
 const publisher = (workspace: string = 'master') => {
-  const publishApp = async (appRoot: string, appId: string, tag: string, builder): Promise<BuildResult> => {
+
+  const publishApp = async (appRoot: string, appId: string, tag: string, force: boolean, builder): Promise<BuildResult> => {
+
     const paths = await listLocalFiles(appRoot)
     const retryOpts = {
       retries: 2,
@@ -51,7 +53,7 @@ const publisher = (workspace: string = 'master') => {
         tag,
       }
       try {
-        return await builder.publishApp(appId, filesWithContent, publishOptions)
+        return await builder.publishApp(appId, filesWithContent, publishOptions, { skipSemVerEnsure: force })
       } catch (err) {
         const response = err.response
         const status = response.status
@@ -71,8 +73,8 @@ const publisher = (workspace: string = 'master') => {
     return await retry(publish, retryOpts)
   }
 
-  const publishApps = async (path: string, tag: string): Promise<void | never> => {
-    const previousConf = conf.getAll() // Store previous configuration in memory
+  const publishApps = async (path: string, tag: string, force: boolean): Promise<void | never> => {
+    const previousConf = conf.getAll()  // Store previous configuration in memory
 
     const manifest = await getManifest()
     const account = conf.getAccount()
@@ -108,7 +110,7 @@ const publisher = (workspace: string = 'master') => {
       const spinner = log.level === 'debug' ? oraMessage.info() : oraMessage.start()
       try {
         const senders = ['vtex.builder-hub', 'apps']
-        const { response } = await listenBuild(appId, () => publishApp(path, appId, pubTag, builder), {
+        const { response } = await listenBuild(appId, () => publishApp(path, appId, pubTag, force, builder), {
           waitCompletion: true,
           context,
           senders,
@@ -137,10 +139,11 @@ export default (path: string, options) => {
 
   path = path || root
   const workspace = options.w || options.workspace
+  const force = options.f || options.force
 
   // Always run yarn locally for some builders
   map(runYarnIfPathExists, buildersToRunLocalYarn)
 
   const { publishApps } = publisher(workspace)
-  return publishApps(path, options.tag)
+  return publishApps(path, options.tag, force)
 }

--- a/src/modules/tree.ts
+++ b/src/modules/tree.ts
@@ -248,6 +248,12 @@ export default {
         short: 'w',
         type: 'string',
       },
+      {
+        description: 'Publish app without checking if the sem ver is being respected',
+        long: 'force',
+        short: 'f',
+        type: 'boolean',
+      },
     ],
   },
   settings: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5039,7 +5039,7 @@ npm-packlist@^1.1.6:
     ignore-walk "^3.0.1"
     npm-bundled "^1.0.1"
 
-npm-run-all@^4.1.3:
+npm-run-all@^4.1.5:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/npm-run-all/-/npm-run-all-4.1.5.tgz#04476202a15ee0e2e214080861bff12a51d98fba"
   integrity sha512-Oo82gJDAVcaMdi3nuoKFavkIHBRVqQ1qvMb+9LHk/cF4P6B2m8aP04hGf7oL6wZ9BuGwX1onlLhpuoofSyoQDQ==


### PR DESCRIPTION
#### What is the purpose of this pull request?
A new feature to check that SemVer is being obeyed when publishing an app has been developed for the node builder in builder hub. This PR creates a parameter to skip this check and publish the app even if it violates SemVer.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
