### PR TITLE
Implement --reset option in vtex redirects import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.73.0] - 2019-09-10
+
 ## [2.72.0] - 2019-09-10
 
 ## [2.71.0] - 2019-09-05

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.72.0",
+  "version": "2.73.0",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/modules/rewriter/delete.ts
+++ b/src/modules/rewriter/delete.ts
@@ -34,16 +34,18 @@ const inputSchema = {
         type: 'string',
       },
     },
-    required: ["from"],
+    required: ['from'],
   },
 }
 
 const handleDelete = async (csvPath: string) => {
-  const fileHash = await readFile(csvPath).then(data =>
-    createHash('md5')
-      .update(`${account}_${workspace}_${data}`)
-      .digest('hex')
-  ).catch(handleReadError) as string
+  const fileHash = (await readFile(csvPath)
+    .then(data =>
+      createHash('md5')
+        .update(`${account}_${workspace}_${data}`)
+        .digest('hex')
+    )
+    .catch(handleReadError)) as string
   const metainfo = await readJson(METAINFO_FILE).catch(() => ({}))
   const deletesMetainfo = metainfo[DELETES] || {}
   let counter = deletesMetainfo[fileHash] ? deletesMetainfo[fileHash].counter : 0
@@ -94,7 +96,7 @@ export default async (csvPath: string) => {
     }
     log.error(`Retrying in ${RETRY_INTERVAL_S} seconds...`)
     log.info('Press CTRL+C to abort')
-    await sleep(RETRY_INTERVAL_S*1000)
+    await sleep(RETRY_INTERVAL_S * 1000)
     retryCount++
     await module.exports.default(csvPath)
   }

--- a/src/modules/rewriter/export.ts
+++ b/src/modules/rewriter/export.ts
@@ -90,7 +90,7 @@ export default async (csvPath: string) => {
     }
     log.error(`Retrying in ${RETRY_INTERVAL_S} seconds...`)
     log.info('Press CTRL+C to abort')
-    await sleep(RETRY_INTERVAL_S*1000)
+    await sleep(RETRY_INTERVAL_S * 1000)
     retryCount++
     await module.exports.default(csvPath)
   }

--- a/src/modules/rewriter/export.ts
+++ b/src/modules/rewriter/export.ts
@@ -17,6 +17,7 @@ import {
   progressBar,
   saveMetainfo,
   sleep,
+  RETRY_INTERVAL_S,
 } from './utils'
 
 const EXPORTS = 'exports'
@@ -87,9 +88,9 @@ export default async (csvPath: string) => {
     if (isVerbose) {
       log.error(e)
     }
-    log.error('Retrying in 10 seconds...')
+    log.error(`Retrying in ${RETRY_INTERVAL_S} seconds...`)
     log.info('Press CTRL+C to abort')
-    await sleep(10000)
+    await sleep(RETRY_INTERVAL_S*1000)
     retryCount++
     await module.exports.default(csvPath)
   }

--- a/src/modules/rewriter/import.ts
+++ b/src/modules/rewriter/import.ts
@@ -50,16 +50,18 @@ const inputSchema = {
       },
     },
     additionalProperties: false,
-    required: ["from", "to", "type"]
+    required: ['from', 'to', 'type'],
   },
 }
 
 const handleImport = async (csvPath: string) => {
-  const fileHash = await readFile(csvPath).then(data =>
-    createHash('md5')
-      .update(`${account}_${workspace}_${data}`)
-      .digest('hex')
-  ).catch(handleReadError) as string
+  const fileHash = (await readFile(csvPath)
+    .then(data =>
+      createHash('md5')
+        .update(`${account}_${workspace}_${data}`)
+        .digest('hex')
+    )
+    .catch(handleReadError)) as string
   const metainfo = await readJson(METAINFO_FILE).catch(() => ({}))
   const importMetainfo = metainfo[IMPORTS] || {}
   let counter = importMetainfo[fileHash] ? importMetainfo[fileHash].counter : 0
@@ -112,7 +114,7 @@ export default async (csvPath: string, options: any) => {
     }
     log.error(`Retrying in ${RETRY_INTERVAL_S} seconds...`)
     log.info('Press CTRL+C to abort')
-    await sleep(RETRY_INTERVAL_S*1000)
+    await sleep(RETRY_INTERVAL_S * 1000)
     retryCount++
     importedRoutes = await module.exports.default(csvPath)
   }
@@ -122,9 +124,11 @@ export default async (csvPath: string, options: any) => {
       const fileName = `.vtex_redirects_to_delete_${Date.now().toString()}.csv`
       const filePath = `./${fileName}`
       log.info('Deleting old redirects...')
-      log.info(`In case this step fails, run 'vtex redirects delete ${resolve(fileName)}' to finish deleting old redirects.`)
+      log.info(
+        `In case this step fails, run 'vtex redirects delete ${resolve(fileName)}' to finish deleting old redirects.`
+      )
       const json2csvParser = new Parser({ fields: ['from'], delimiter: ';', quote: '' })
-      const csv = json2csvParser.parse(map((route) => ({from: route}), routesToDelete))
+      const csv = json2csvParser.parse(map(route => ({ from: route }), routesToDelete))
       await writeFile(filePath, csv)
       await deleteRedirects(filePath)
       await remove(filePath)

--- a/src/modules/rewriter/import.ts
+++ b/src/modules/rewriter/import.ts
@@ -1,12 +1,16 @@
 import { createHash } from 'crypto'
-import { readFile, readJson } from 'fs-extra'
-import { length } from 'ramda'
+import { readFile, readJson, remove } from 'fs-extra'
+import { difference, isEmpty, length, map, pluck } from 'ramda'
 import { createInterface } from 'readline'
+import { Parser } from 'json2csv'
+import { writeFile } from 'fs-extra'
+import { resolve } from 'path'
 
 import { rewriter } from '../../clients'
 import { RedirectInput } from '../../clients/rewriter'
 import log from '../../logger'
 import { isVerbose } from '../../utils'
+import { default as deleteRedirects } from './delete'
 import {
   accountAndWorkspace,
   deleteMetainfo,
@@ -19,6 +23,8 @@ import {
   sleep,
   splitJsonArray,
   validateInput,
+  handleReadError,
+  RETRY_INTERVAL_S,
 } from './utils'
 
 const IMPORTS = 'imports'
@@ -43,6 +49,8 @@ const inputSchema = {
         enum: ['PERMANENT', 'TEMPORARY'],
       },
     },
+    additionalProperties: false,
+    required: ["from", "to", "type"]
   },
 }
 
@@ -51,7 +59,7 @@ const handleImport = async (csvPath: string) => {
     createHash('md5')
       .update(`${account}_${workspace}_${data}`)
       .digest('hex')
-  )
+  ).catch(handleReadError) as string
   const metainfo = await readJson(METAINFO_FILE).catch(() => ({}))
   const importMetainfo = metainfo[IMPORTS] || {}
   let counter = importMetainfo[fileHash] ? importMetainfo[fileHash].counter : 0
@@ -83,15 +91,17 @@ const handleImport = async (csvPath: string) => {
   log.info('\nFinished!\n')
   listener.close()
   deleteMetainfo(metainfo, IMPORTS, fileHash)
+  return pluck('from', routes)
 }
 
 let retryCount = 0
-export default async (csvPath: string) => {
+export default async (csvPath: string, options: any) => {
   // First check if the redirects index exists
-  await ensureIndexCreation()
+  const index = await ensureIndexCreation()
+  const indexedRoutes = pluck('id', index)
+  let importedRoutes
   try {
-    await handleImport(csvPath)
-    process.exit()
+    importedRoutes = await handleImport(csvPath)
   } catch (e) {
     log.error('\nError handling import')
     if (retryCount >= MAX_RETRIES) {
@@ -100,10 +110,25 @@ export default async (csvPath: string) => {
     if (isVerbose) {
       log.error(e)
     }
-    log.error('Retrying in 10 seconds...')
+    log.error(`Retrying in ${RETRY_INTERVAL_S} seconds...`)
     log.info('Press CTRL+C to abort')
-    await sleep(10000)
+    await sleep(RETRY_INTERVAL_S*1000)
     retryCount++
-    await module.exports.default(csvPath)
+    importedRoutes = await module.exports.default(csvPath)
   }
+  if (options.r || options.reset) {
+    const routesToDelete = difference(indexedRoutes || [], importedRoutes || [])
+    if (routesToDelete && !isEmpty(routesToDelete)) {
+      const fileName = `.vtex_redirects_to_delete_${Date.now().toString()}.csv`
+      const filePath = `./${fileName}`
+      log.info('Deleting old redirects...')
+      log.info(`In case this step fails, run 'vtex redirects delete ${resolve(fileName)}' to finish deleting old redirects.`)
+      const json2csvParser = new Parser({ fields: ['from'], delimiter: ';', quote: '' })
+      const csv = json2csvParser.parse(map((route) => ({from: route}), routesToDelete))
+      await writeFile(filePath, csv)
+      await deleteRedirects(filePath)
+      await remove(filePath)
+    }
+  }
+  return importedRoutes
 }

--- a/src/modules/rewriter/utils.ts
+++ b/src/modules/rewriter/utils.ts
@@ -19,13 +19,12 @@ export const progressString = (message: string) => `${message} [:bar] :current/:
 
 export const sleep = milliseconds => new Promise(resolve => setTimeout(resolve, milliseconds))
 
-export const handleReadError = (path: string) =>
-  (error: any) => {
-    console.log(JSON.stringify(error))
-    log.error(`Error reading file: ${path}`)
-    log.error(`${error.message}`)
-    process.exit()
-  }
+export const handleReadError = (path: string) => (error: any) => {
+  console.log(JSON.stringify(error))
+  log.error(`Error reading file: ${path}`)
+  log.error(`${error.message}`)
+  process.exit()
+}
 
 export const readCSV = async (path: string) => {
   try {

--- a/src/modules/rewriter/utils.ts
+++ b/src/modules/rewriter/utils.ts
@@ -12,13 +12,28 @@ import log from '../../logger'
 export const MAX_ENTRIES_PER_REQUEST = 10
 export const METAINFO_FILE = '.vtex_redirects_metainfo.json'
 export const MAX_RETRIES = 10
+export const RETRY_INTERVAL_S = 5
 export const accountAndWorkspace = [getAccount(), getWorkspace()]
 
 export const progressString = (message: string) => `${message} [:bar] :current/:total :percent`
 
 export const sleep = milliseconds => new Promise(resolve => setTimeout(resolve, milliseconds))
 
-export const readCSV = async (path: string) => await csv({ delimiter: ';', ignoreEmpty: true }).fromFile(path)
+export const handleReadError = (path: string) =>
+  (error: any) => {
+    console.log(JSON.stringify(error))
+    log.error(`Error reading file: ${path}`)
+    log.error(`${error.message}`)
+    process.exit()
+  }
+
+export const readCSV = async (path: string) => {
+  try {
+    return await csv({ delimiter: ';', ignoreEmpty: true }).fromFile(path)
+  } catch (e) {
+    handleReadError(path)(e)
+  }
+}
 
 export const splitJsonArray = (data: any) => jsonSplit(data, MAX_ENTRIES_PER_REQUEST)
 
@@ -76,4 +91,5 @@ export const ensureIndexCreation = async () => {
     console.error('Error getting redirects index. Please try again in some seconds..')
     process.exit()
   }
+  return index
 }

--- a/src/modules/tree.ts
+++ b/src/modules/tree.ts
@@ -447,6 +447,14 @@ export default {
       description: 'Import redirects for the current account and workspace',
       handler: './rewriter/import',
       requiredArgs: 'csvPath',
+      options: [
+        {
+          description: 'Remove all previous redirects',
+          long: 'reset',
+          short: 'r',
+          type: 'boolean',
+        },
+      ],
     },
     export: {
       description: 'Export all redirects in the current account and workspace',


### PR DESCRIPTION
This PR implements the `--reset` option in the `vtex redirects import` command, along with fixes to both file existence and CSV format validations.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
