### PR TITLE
Temporarily use console.log to print errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Correctly print error objects when the `--verbose` flag is set.
 
 ## [2.73.0] - 2019-09-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.73.1] - 2019-09-11
 ### Fixed
 - Correctly print error objects when the `--verbose` flag is set.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.73.0",
+  "version": "2.73.1",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -143,7 +143,9 @@ const onError = e => {
         if (e.config && e.config.url && e.config.method) {
           log.error(`${e.config.method} ${e.config.url}`)
         }
-        log.debug(e)
+        if (isVerbose) {
+          console.log(e)
+        }
     }
   } else {
     switch (e.name) {
@@ -168,7 +170,9 @@ const onError = e => {
         log.error('Unhandled exception')
         log.error('Please report the issue in https://github.com/vtex/toolbelt/issues')
         log.error(reject(isFunction, e))
-        log.debug(e)
+        if (isVerbose) {
+          console.log(e)
+        }
     }
   }
   process.exit(1)

--- a/src/modules/rewriter/delete.ts
+++ b/src/modules/rewriter/delete.ts
@@ -92,7 +92,7 @@ export default async (csvPath: string) => {
       throw e
     }
     if (isVerbose) {
-      log.error(e)
+      console.log(e)
     }
     log.error(`Retrying in ${RETRY_INTERVAL_S} seconds...`)
     log.info('Press CTRL+C to abort')

--- a/src/modules/rewriter/export.ts
+++ b/src/modules/rewriter/export.ts
@@ -86,7 +86,7 @@ export default async (csvPath: string) => {
       throw e
     }
     if (isVerbose) {
-      log.error(e)
+      console.log(e)
     }
     log.error(`Retrying in ${RETRY_INTERVAL_S} seconds...`)
     log.info('Press CTRL+C to abort')

--- a/src/modules/rewriter/import.ts
+++ b/src/modules/rewriter/import.ts
@@ -110,7 +110,7 @@ export default async (csvPath: string, options: any) => {
       throw e
     }
     if (isVerbose) {
-      log.error(e)
+      console.log(e)
     }
     log.error(`Retrying in ${RETRY_INTERVAL_S} seconds...`)
     log.info('Press CTRL+C to abort')


### PR DESCRIPTION
Since this project upgraded the version of the `winston` dependency, the logging of error objects have stopped working. This PR makes the project use `console.log` to show error objects when the `--verbose` flag is set.


#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
