### PR TITLE
Fix error logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fix
+
+- Error logging using winston
+
 ## [2.74.1] - 2019-09-18
 
 ### Changed 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.74.2] - 2019-09-18
+
 ### Fix
 
 - Error logging using winston

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.74.1",
+  "version": "2.74.2",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -9,7 +9,7 @@ const VERBOSE = '--verbose'
 const isVerbose = process.argv.indexOf(VERBOSE) >= 0
 
 // The debug file is likely to be on ~/.config/configstore/vtex_debug.txt
-export const DEBUG_LOG_FILE_PATH = join(configDir, 'vtex_debug.txt')
+export const DEBUG_LOG_FILE_PATH = join(configDir, 'vtex_debug.json')
 
 const isObject = (a: any) => {
   return !!a && a.constructor === Object

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -24,9 +24,7 @@ const addArgs = format(info => {
 
 const messageFormatter = format.printf(info => {
   const { timestamp: timeString = '', sender = '', message, args = [] } = info
-  const formattedMsgWithArgs = util.formatWithOptions
-    ? util.formatWithOptions({ colors: true }, message, ...args)
-    : util.format(message, ...args)
+  const formattedMsgWithArgs = util.formatWithOptions({ colors: true }, message, ...args)
   const msg = `${chalk.gray(timeString)} - ${info.level}: ${formattedMsgWithArgs}  ${chalk.gray(sender)}`
   return msg
 })
@@ -68,7 +66,7 @@ const logger = createLogger({
   ],
 })
 
-const levels = ['debug', 'info', 'error']
+const levels = ['debug', 'info', 'error', 'warn', 'verbose', 'silly']
 levels.forEach(level => {
   logger[level] = (msg: any, ...remains: any[]) => {
     if (remains.length > 0 && isObject(remains[0]) && remains[0].message) {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -24,7 +24,9 @@ const addArgs = format(info => {
 
 const messageFormatter = format.printf(info => {
   const { timestamp: timeString = '', sender = '', message, args = [] } = info
-  const formattedMsgWithArgs = util.formatWithOptions({ colors: true }, message, ...args)
+  const formattedMsgWithArgs = util.formatWithOptions
+    ? util.formatWithOptions({ colors: true }, message, ...args)
+    : util.format(message, ...args)
   const msg = `${chalk.gray(timeString)} - ${info.level}: ${formattedMsgWithArgs}  ${chalk.gray(sender)}`
   return msg
 })


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix error logging

#### How should this be manually tested?
- Install this branch
```bash
git clone git@github.com:vtex/toolbelt.git && \
cd toolbelt && git checkout fix/error-logging && \
yarn && yarn global add file:$PWD
```
- Go to your global yarn `node_modules/vtex/lib`: 
```bash
cd ~/.config/yarn/global/node_modules/vtex/lib
```
- Run any log modifying the snippet: 
```bash
node -e "require('./logger').default.error(new Error('sample error'))"
```
Check the output and `vtex_debug.txt` as well: 
```
code ~/.config/configstore/
```

#### Screenshots or example usage

The logs:

```js
logger.info('Hello')
logger.info('msg1', 'msg2', new Error('Error 1'))
logger.info(new Error('Error 2'))
logger.error(new Error('Error 3'))
logger.debug('Test %s usage: %s %s %s', '123', '234')
logger.debug('a', 'b', 'c', { a: 54 }, 'd', 'e')
logger.debug({ a: 100, b: '123' })
logger.debug('weird winston behavior, adds next message:', { message: '123' }, { message: '234' }, { message: '345' })
logger.debug('Requesting login before command: %s', ['123', '456'].join(' '))
```

Will now render:

![Screenshot from 2019-09-17 17-16-23](https://user-images.githubusercontent.com/26463288/65076291-121d0600-d96f-11e9-96f8-280c3c6f54e6.png)

And will add to [vtex_debug.txt](https://github.com/vtex/toolbelt/files/3623266/vtex_debug1.txt)


#### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
