### PR TITLE
 Update versions of eslint related packages added by vtex setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.76.0] - 2019-09-20
 ### Changed
 
 - Update versions of eslint related packages added by `vtex setup`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+
+- Update versions of eslint related packages added by `vtex setup`
 
 ## [2.75.0] - 2019-09-20
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.75.0",
+  "version": "2.76.0",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/__tests__/modules/setup/setupESLint.test.ts
+++ b/src/__tests__/modules/setup/setupESLint.test.ts
@@ -26,7 +26,7 @@ beforeEach(() => {
 
 describe('Yarn is called correctly and .eslintrc is created', () => {
   const checkYarnCall = (builder: string) => {
-    const yarnInstallation = `${yarnPath} add eslint@^5.15.1 eslint-config-vtex@^10.1.0 eslint-config-vtex-react@^4.1.0 --dev`
+    const yarnInstallation = `${yarnPath} add eslint@^6.4.0 eslint-config-vtex@^11.0.0 eslint-config-vtex-react@^5.0.1 --dev`
     expect(execSync).toBeCalledWith(yarnInstallation, {
       cwd: path.resolve('app-root', builder),
       stdio: 'inherit',

--- a/src/modules/setup/setupESLint.ts
+++ b/src/modules/setup/setupESLint.ts
@@ -7,9 +7,9 @@ import { yarnPath } from '../utils'
 import { esLintrcEditor, packageJsonEditor } from './utils'
 
 const addToPackageJson = {
-  eslint: '^5.15.1',
-  'eslint-config-vtex': '^10.1.0',
-  'eslint-config-vtex-react': '^4.1.0',
+  eslint: '^6.4.0',
+  'eslint-config-vtex': '^11.0.0',
+  'eslint-config-vtex-react': '^5.0.1',
 }
 
 const addToEslintrc = {


### PR DESCRIPTION
#### What problem is this solving?
`eslint`, `eslint-config-vtex` and `eslint-config-vtex-react` have new versions 

#### How should this be manually tested?

Install this branch:
```
git clone git@github.com:vtex/toolbelt.git && \
cd toolbelt && git checkout feature/update-vtex-setup-packages && \
yarn && yarn global add file:$PWD
```
Go to any app, remove eslint, eslint-config-vtex and eslint-config-vtex-react from one or more of its builders package.json. Run `vtex setup`.
Check all package.json, they should have the updated version of the packages mentioned above 

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
