### PR TITLE
Ensure node version and log command and OS detail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Ensure `node` >= v10
+- Add debug logs on `node` version, OS basic info and command executed 
+
 ## [2.76.2] - 2019-10-01
 ### Changed
 - Use new rewriter API for redirects management.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.76.3] - 2019-10-02
+
 ### Added
 - Ensure `node` >= v10
 - Add debug logs on `node` version, OS basic info and command executed 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.76.2",
+  "version": "2.76.3",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -23,7 +23,10 @@ import { isVerbose, VERBOSE } from './utils'
 
 const nodeVersion = process.version.replace('v', '')
 if (!semver.satisfies(nodeVersion, pkg.engines.node)) {
-  console.error(chalk.bold('Incompatible with node < v10. Please upgrade node to major 10 or higher.'))
+  const minMajor = pkg.engines.node.replace('>=', '')
+  console.error(
+    chalk.bold(`Incompatible with node < v${minMajor}. Please upgrade node to major ${minMajor} or higher.`)
+  )
   process.exit(1)
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,7 +17,15 @@ import { CommandError, SSEConnectionError, UserCancelledError } from './errors'
 import log from './logger'
 import tree from './modules/tree'
 import notify from './update'
+import * as semver from 'semver'
+import * as os from 'os'
 import { isVerbose, VERBOSE } from './utils'
+
+const nodeVersion = process.version.replace('v', '')
+if (!semver.satisfies(nodeVersion, pkg.engines.node)) {
+  console.error(chalk.bold('Incompatible with node < v10. Please upgrade node to major 10 or higher.'))
+  process.exit(1)
+}
 
 axios.interceptors.request.use(config => {
   if (envCookies()) {
@@ -75,6 +83,8 @@ const main = async () => {
   conf.saveEnvironment(conf.Environment.Production) // Just to be backwards compatible with who used staging previously
 
   logToolbeltVersion()
+  log.debug('node %s - %s %s', process.version, os.platform(), os.release())
+  log.debug(args)
 
   await checkLogin(args)
 

--- a/src/typings/package.json.d.ts
+++ b/src/typings/package.json.d.ts
@@ -1,5 +1,9 @@
 declare module '*/package.json' {
   const name: string
   const version: string
-  export { name, version }
+  const engines: {
+    node: string
+  }
+
+  export { name, version, engines }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Now that node >= v10 is required some user errors reports are reaching us because the error is not clear at all. We though just adding `"engines": { "node": ">= 10" }` was sufficient, and in some cases are, but for some reason npm doesn't ensure node version for every install. Because of this a check was added and if node version is older than the defined on `package.json` `engines.node` a error log is showed.

Additionally, logs on the command run and OS basic information was added.
  
#### How should this be manually tested?
Install this toolbelt branch:
```
git clone git@github.com:vtex/toolbelt.git && cd toolbelt && \
git checkout feature/check-node-version && \
yarn && yarn global add file:$PWD
```

Run any `vtex` command with `node` < v10. A log `Incompatible with node < v10. Please upgrade node to major 10 or higher.` should appear and _immediately close_ the cli. If `node` > v10 it should not.

Run any command with `--verbose`. The first lines printed should print your node version, OS information and the command and args you asked to execute

#### Types of changes
- [X] Chore
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
