### PR TITLE
Improve redirect importing performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Increase timeout and retries in the `rewriter` client.
+- Sort the redirects list by the `from` prop before starting import.
 
 ## [2.77.0] - 2019-10-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.77.1] - 2019-10-02
 ### Changed
 - Increase timeout and retries in the `rewriter` client.
 - Sort the redirects list by the `from` prop before starting import.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.77.0",
+  "version": "2.77.1",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/clients/rewriter.ts
+++ b/src/clients/rewriter.ts
@@ -40,7 +40,12 @@ export enum RedirectTypes {
 
 export class Rewriter extends AppGraphQLClient {
   constructor(context: IOContext, options: InstanceOptions) {
-    super('vtex.rewriter', context, { ...options, headers: { 'cache-control': 'no-cache' }, retries: 5, timeout: 10000 })
+    super('vtex.rewriter', context, {
+      ...options,
+      headers: { 'cache-control': 'no-cache' },
+      retries: 5,
+      timeout: 10000,
+    })
   }
 
   public routesIndexFiles = (): Promise<RouteIndexFiles> =>

--- a/src/clients/rewriter.ts
+++ b/src/clients/rewriter.ts
@@ -40,7 +40,7 @@ export enum RedirectTypes {
 
 export class Rewriter extends AppGraphQLClient {
   constructor(context: IOContext, options: InstanceOptions) {
-    super('vtex.rewriter', context, { ...options, headers: { 'cache-control': 'no-cache' }, retries: 5, timeout: 15000 })
+    super('vtex.rewriter', context, { ...options, headers: { 'cache-control': 'no-cache' }, retries: 5, timeout: 10000 })
   }
 
   public routesIndexFiles = (): Promise<RouteIndexFiles> =>

--- a/src/clients/rewriter.ts
+++ b/src/clients/rewriter.ts
@@ -40,7 +40,7 @@ export enum RedirectTypes {
 
 export class Rewriter extends AppGraphQLClient {
   constructor(context: IOContext, options: InstanceOptions) {
-    super('vtex.rewriter', context, { ...options, headers: { 'cache-control': 'no-cache' } })
+    super('vtex.rewriter', context, { ...options, headers: { 'cache-control': 'no-cache' }, retries: 5, timeout: 15000 })
   }
 
   public routesIndexFiles = (): Promise<RouteIndexFiles> =>

--- a/src/modules/rewriter/utils.ts
+++ b/src/modules/rewriter/utils.ts
@@ -35,14 +35,21 @@ export const handleReadError = (path: string) => (error: any) => {
   process.exit()
 }
 
-const normalizePath = (path: string) => compose(replace(/\/+$/, ''), toLower, decodeURI)(path)
+const normalizePath = (path: string) =>
+  compose(
+    replace(/\/+$/, ''),
+    toLower,
+    decodeURI
+  )(path)
 
 const sortFunction = (redirect: Redirect) =>
-  `${createHash('md5').update(normalizePath(prop('from', redirect))).digest('hex')}`
+  `${createHash('md5')
+    .update(normalizePath(prop('from', redirect)))
+    .digest('hex')}`
 
 export const readCSV = async (path: string) => {
   try {
-    const result = await csv({ delimiter: ';', ignoreEmpty: true }).fromFile(path) as Redirect[]
+    const result = (await csv({ delimiter: ';', ignoreEmpty: true }).fromFile(path)) as Redirect[]
     return sortBy(sortFunction, result)
   } catch (e) {
     handleReadError(path)(e)

--- a/src/modules/rewriter/utils.ts
+++ b/src/modules/rewriter/utils.ts
@@ -1,11 +1,13 @@
 import * as Ajv from 'ajv'
+import { createHash } from 'crypto'
 import * as csv from 'csvtojson'
 import { writeJsonSync } from 'fs-extra'
 import * as jsonSplit from 'json-array-split'
 import * as ProgressBar from 'progress'
-import { keys, join, map, match, pluck } from 'ramda'
+import { compose, keys, join, map, match, pluck, prop, replace, sortBy, toLower } from 'ramda'
 
 import { getAccount, getWorkspace } from '../../conf'
+import { Redirect } from '../../clients/rewriter'
 import log from '../../logger'
 
 export const LAST_CHANGE_DATE = 'lastChangeDate'
@@ -33,9 +35,15 @@ export const handleReadError = (path: string) => (error: any) => {
   process.exit()
 }
 
+const normalizePath = (path: string) => compose(replace(/\/+$/, ''), toLower, decodeURI)(path)
+
+const sortFunction = (redirect: Redirect) =>
+  `${createHash('md5').update(normalizePath(prop('from', redirect))).digest('hex')}`
+
 export const readCSV = async (path: string) => {
   try {
-    return await csv({ delimiter: ';', ignoreEmpty: true }).fromFile(path)
+    const result = await csv({ delimiter: ';', ignoreEmpty: true }).fromFile(path) as Redirect[]
+    return sortBy(sortFunction, result)
   } catch (e) {
     handleReadError(path)(e)
   }


### PR DESCRIPTION
This PR improves the overall experience of the `vtex redirects import` command by sorting the list of `from` URLs before starting to import and by increasing timeout and number of retries of the `rewriter` client.