### PR TITLE
Fix vtex init for react-app-template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.77.4] - 2019-10-10
+
 ### Fixed
 
 - `vtex init` for `react-guide`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `vtex init` for `react-guide`
+
 ## [2.77.3] - 2019-10-09
 
 ### Fix

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.77.3",
+  "version": "2.77.4",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/modules/init/index.ts
+++ b/src/modules/init/index.ts
@@ -182,6 +182,6 @@ export default async () => {
     log.info(`Run ${chalk.bold.green(`cd ${repo}`)} and ${chalk.bold.green('vtex link')} to start developing!`)
   } catch (err) {
     log.error(err.message)
-    err.printStackTrace()
+    log.debug(err)
   }
 }

--- a/src/modules/init/index.ts
+++ b/src/modules/init/index.ts
@@ -32,7 +32,7 @@ const templates = {
   'render-guide': 'render-guide',
   'masterdata-graphql-guide': 'masterdata-graphql-guide',
   'support app': 'hello-support',
-  'react-guide': 'react-repo-template',
+  'react-guide': 'react-app-template',
 }
 
 const titles = {


### PR DESCRIPTION
#### What is the purpose of this pull request?
- Fix `vtex init` for `react-app-template`
- Remove `err.printStackTrace()`, which could be undefined

#### How should this be manually tested?

Clone and install globally this branch:
```
git clone git@github.com:vtex/toolbelt.git && \
cd toolbelt && \
git checkout fix/init-react && \
yarn && yarn global add file:$PWD
```
Run `vtex init` and select `react-guide`. 

#### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
