### PR TITLE
Fix CTRL+C not terminating the process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.77.5] - 2019-10-11
+
 ## [2.77.4] - 2019-10-10
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.77.4",
+  "version": "2.77.5",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/modules/prompts.ts
+++ b/src/modules/prompts.ts
@@ -2,5 +2,11 @@ import * as Confirm from 'prompt-confirm'
 
 // Prompt definitions that are used in many modules of this project.
 
-export const promptConfirm = async (message: string, initial = true): Promise<boolean> =>
-  new Confirm({ message, default: initial }).run()
+export const promptConfirm = async (message: string, initial = true): Promise<boolean> => {
+  const initialMode = process.stdin.isRaw
+  const isStdinTTY = process.stdin.isTTY
+  if (isStdinTTY) process.stdin.setRawMode(true)
+  const ret = await new Confirm({ message, default: initial }).run()
+  if (isStdinTTY) process.stdin.setRawMode(initialMode)
+  return ret
+}


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix issue where CTRL+C couldn't terminate the process after prompting log in.

This happens because `process.stdin` is set to `rawMode` and is not reset. According to [node docs](https://nodejs.org/api/tty.html#tty_tty):
> When Node.js detects that it is being run with a text terminal ("TTY") attached, process.stdin will, by default, be initialized as an instance of tty.ReadStream and both process.stdout and process.stderr will, by default be instances of tty.WriteStream. The preferred method of determining whether Node.js is being run within a TTY context is to check that the value of the process.stdout.isTTY property is true

And:
> When in raw mode, input is always available character-by-character, not including modifiers. Additionally, all special processing of characters by the terminal is disabled, including echoing input characters. CTRL+C will no longer cause a SIGINT when in this mode.

Doing some tests it was noted that the only first run of `Confirm` from `prompt-confirm` was setting `process.stdin` to `rawMode`, but it wasn't resetting it back.

#### How should this be manually tested?
Install this toolbelt branch:
```
git clone git@github.com:vtex/toolbelt.git && \
cd toolbelt && \
git checkout fix/ctrl-c-not-exiting-process && \
yarn && yarn global add file:$PWD
```
Use `vtex login` and try to cancel it after answering `yes`. 

This will affect all confirm prompts, so other commands should be tested for anomalies

#### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
