### PR TITLE
Fix redirects export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- The command `vtex redirects export` no longer exports duplicate entries.
 
 ## [2.80.0] - 2019-12-16
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.80.1] - 2019-12-16
 ### Fixed
 - The command `vtex redirects export` no longer exports duplicate entries.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.80.0",
+  "version": "2.80.1",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/modules/rewriter/export.ts
+++ b/src/modules/rewriter/export.ts
@@ -28,7 +28,7 @@ const FIELDS = ['from', 'to', 'type', 'endDate']
 
 const generateListOfRanges = (indexLength: number) =>
   map(
-    (n: number) => [n * MAX_ENTRIES_PER_REQUEST, Math.min((n + 1) * MAX_ENTRIES_PER_REQUEST, indexLength)],
+    (n: number) => [n * MAX_ENTRIES_PER_REQUEST, Math.min((n + 1) * MAX_ENTRIES_PER_REQUEST - 1, indexLength)],
     range(0, Math.ceil(indexLength / MAX_ENTRIES_PER_REQUEST))
   )
 
@@ -50,6 +50,7 @@ const handleExport = async (csvPath: string) => {
   const metainfo = await readJson(METAINFO_FILE).catch(() => ({}))
   const exportMetainfo = metainfo[EXPORTS] || {}
   const listOfRanges = generateListOfRanges(numberOfFiles)
+console.log(`listOfRanges: ${JSON.stringify(listOfRanges)}`)
   let counter = exportMetainfo[indexHash] ? exportMetainfo[indexHash].counter : 0
   let listOfRoutes = exportMetainfo[indexHash] ? exportMetainfo[indexHash].data : []
 

--- a/src/modules/rewriter/export.ts
+++ b/src/modules/rewriter/export.ts
@@ -50,7 +50,6 @@ const handleExport = async (csvPath: string) => {
   const metainfo = await readJson(METAINFO_FILE).catch(() => ({}))
   const exportMetainfo = metainfo[EXPORTS] || {}
   const listOfRanges = generateListOfRanges(numberOfFiles)
-console.log(`listOfRanges: ${JSON.stringify(listOfRanges)}`)
   let counter = exportMetainfo[indexHash] ? exportMetainfo[indexHash].counter : 0
   let listOfRoutes = exportMetainfo[indexHash] ? exportMetainfo[indexHash].data : []
 


### PR DESCRIPTION
The ranges of redirect batches to be exported were being wrongly generated, which caused duplicated entries in the exported file. This PR fixes it.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
