### PR TITLE
Update ESLint setup to match current recipe instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Update `vtex setup` ESLint configuration to match current recipe instructions.
 
 ## [2.77.5] - 2019-10-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.77.6] - 2019-10-15
 ### Changed
 - Update `vtex setup` ESLint configuration to match current recipe instructions.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.77.5",
+  "version": "2.77.6",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/__tests__/fixtures/manifests/index.ts
+++ b/src/__tests__/fixtures/manifests/index.ts
@@ -18,4 +18,36 @@ export const manifestSamples: Record<string, AppManifest> = {
     policies: [],
     $schema: 'https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema',
   },
+  'node4-app': {
+    vendor: 'vtex',
+    name: 'node-app',
+    version: '1.0.0',
+    title: 'CHANGE_ME',
+    description: 'CHANGE_ME',
+    builders: {
+      messages: '1.x',
+      node: '4.x',
+    },
+    dependencies: {
+      'vtex.admin': '1.x',
+    },
+    policies: [],
+    $schema: 'https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema',
+  },
+  'react3-app': {
+    vendor: 'vtex',
+    name: 'component-library',
+    version: '1.0.0',
+    title: 'CHANGE_ME',
+    description: 'CHANGE_ME',
+    builders: {
+      messages: '1.x',
+      react: '3.x',
+    },
+    dependencies: {
+      'vtex.store-graphql': '2.x',
+    },
+    policies: [],
+    $schema: 'https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema',
+  },
 }

--- a/src/__tests__/modules/setup/mocks.ts
+++ b/src/__tests__/modules/setup/mocks.ts
@@ -78,15 +78,26 @@ export const mockSetupUtils = () => {
       tsconfigEditor: { read: jest.fn(), write: jest.fn(), path: jest.fn() },
       packageJsonEditor: { read: jest.fn(), write: jest.fn(), path: jest.fn() },
       esLintrcEditor: { read: jest.fn(), write: jest.fn(), path: jest.fn() },
+      eslintIgnoreEditor: { read: jest.fn(), write: jest.fn(), path: jest.fn() },
+      prettierrcEditor: { read: jest.fn(), write: jest.fn(), path: jest.fn() },
     }
   })
 
-  const { tsconfigEditor, packageJsonEditor, esLintrcEditor, checkIfTarGzIsEmpty } = jest.requireMock(
-    '../../../modules/setup/utils'
-  ) as Record<string, { read: jest.Mock; write: jest.Mock; path: jest.Mock }> & { checkIfTarGzIsEmpty: jest.Mock }
+  const {
+    tsconfigEditor,
+    packageJsonEditor,
+    esLintrcEditor,
+    eslintIgnoreEditor,
+    prettierrcEditor,
+    checkIfTarGzIsEmpty,
+  } = jest.requireMock('../../../modules/setup/utils') as Record<
+    string,
+    { read: jest.Mock; write: jest.Mock; path: jest.Mock }
+  > & { checkIfTarGzIsEmpty: jest.Mock }
 
   const mockEditor = (editor: any, editorName: string) => {
     let dataByBuilder = {
+      root: {},
       node: {},
       react: {},
     }
@@ -94,8 +105,22 @@ export const mockSetupUtils = () => {
     editor.path.mockImplementation((builder: string) => `$path-${editorName}-${builder}`)
 
     const setDataByBuilder = (newData: any) => {
-      editor.read.mockImplementation((builder: string) => dataByBuilder[builder])
-      editor.write.mockImplementation((builder: string, newData: any) => (dataByBuilder[builder] = newData))
+      editor.read.mockImplementation((builder: string) => {
+        if (builder === '.') {
+          return dataByBuilder['root']
+        }
+
+        return dataByBuilder[builder]
+      })
+      editor.write.mockImplementation((builder: string, newData: any) => {
+        if (builder === '.') {
+          dataByBuilder['root'] = newData
+        } else {
+          dataByBuilder[builder] = newData
+        }
+
+        return newData
+      })
       dataByBuilder = newData
     }
 
@@ -113,6 +138,8 @@ export const mockSetupUtils = () => {
     packageJsonEditorMock: packageJsonEditor,
     setPackageJsonByBuilder,
     esLintrcEditorMock: esLintrcEditor,
+    eslintIgnoreEditorMock: eslintIgnoreEditor,
+    prettierrcEditorMock: prettierrcEditor,
     checkIfTarGzIsEmpty,
     setTarGzEmptyResponse,
   }

--- a/src/__tests__/modules/setup/setupESLint.test.ts
+++ b/src/__tests__/modules/setup/setupESLint.test.ts
@@ -98,4 +98,12 @@ describe('Yarn is called correctly and .eslintrc is created', () => {
       })
     )
   })
+
+  it('should not install react custom config on node-only app', async () => {
+    const builders = ['node']
+
+    await setupESLint(manifestSamples['node4-app'], builders)
+
+    expect(esLintrcEditorMock.write).toHaveBeenCalledTimes(1)
+  })
 })

--- a/src/__tests__/modules/setup/setupESLint.test.ts
+++ b/src/__tests__/modules/setup/setupESLint.test.ts
@@ -3,7 +3,7 @@ import { yarnPath } from '../../../modules/utils'
 import { manifestSamples } from '../../fixtures/manifests'
 import { mockSetupUtils } from './mocks'
 
-const { setPackageJsonByBuilder, esLintrcEditorMock } = mockSetupUtils()
+const { setPackageJsonByBuilder, esLintrcEditorMock, packageJsonEditorMock } = mockSetupUtils()
 jest.mock('child-process-es6-promise', () => {
   return {
     execSync: jest.fn(),
@@ -105,5 +105,22 @@ describe('Yarn is called correctly and .eslintrc is created', () => {
     await setupESLint(manifestSamples['node4-app'], builders)
 
     expect(esLintrcEditorMock.write).toHaveBeenCalledTimes(1)
+  })
+
+  it("shouldn't crash when no package.json exists in app root", async () => {
+    const builders = ['node']
+
+    packageJsonEditorMock.read.mockImplementationOnce(() => {
+      const err = new Error('File not found')
+
+      // @ts-ignore
+      err.code = 'ENOENT'
+
+      throw err
+    })
+
+    await setupESLint(manifestSamples['node4-app'], builders)
+
+    expect(packageJsonEditorMock.write).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/modules/setup/index.ts
+++ b/src/modules/setup/index.ts
@@ -9,7 +9,7 @@ const buildersToAddTypes = ['react', 'node']
 export default async (opts: { i?: boolean; 'ignore-linked': boolean }) => {
   const ignoreLinked = opts.i || opts['ignore-linked']
   const manifest = await getManifest()
-  await setupESLint(manifest, buildersToAddAdditionalPackages)
+  setupESLint(manifest, buildersToAddAdditionalPackages)
   await setupTSConfig(manifest)
   await setupTypings(manifest, ignoreLinked, buildersToAddTypes)
 }

--- a/src/modules/setup/setupESLint.ts
+++ b/src/modules/setup/setupESLint.ts
@@ -4,15 +4,50 @@ import * as R from 'ramda'
 import log from '../../logger'
 import { getAppRoot } from '../../manifest'
 import { yarnPath } from '../utils'
-import { esLintrcEditor, packageJsonEditor } from './utils'
+import { esLintrcEditor, packageJsonEditor, eslintIgnoreEditor, prettierrcEditor } from './utils'
 
-const addToPackageJson = {
+const basePackageJson = (appName: string) => ({
+  name: appName,
+  private: true,
+  license: 'UNLICENSED',
+  scripts: {
+    lint: 'eslint --ext js,jsx,ts,tsx .',
+  },
+})
+
+const eslintIgnore = `
+node_modules
+`.trim()
+
+const basePrettierRc = {
+  semi: false,
+  singleQuote: true,
+  trailingComma: 'es5',
+  eslintIntegration: true,
+}
+
+const lintDeps = {
   eslint: '^6.4.0',
   'eslint-config-vtex': '^11.0.0',
   'eslint-config-vtex-react': '^5.0.1',
+  '@types/node': '^12.7.12',
+  prettier: '^1.18.2',
+  typescript: '^3.5.3',
 }
 
-const addToEslintrc = {
+const baseEslintrc = {
+  extends: 'vtex',
+  root: true,
+  env: {
+    node: true,
+    es6: true,
+    jest: true,
+  },
+}
+
+// eslint-disable-next-line
+// @ts-ignore
+const customEslintrc = {
   react: {
     extends: 'vtex-react',
     env: {
@@ -21,42 +56,62 @@ const addToEslintrc = {
       jest: true,
     },
   },
-  node: {
-    extends: 'vtex',
-    env: {
-      node: true,
-      es6: true,
-      jest: true,
-    },
-  },
 }
 
-const yarnAddESLint = (relativePath: string) => {
-  log.info(`Adding lint configs in ${relativePath}`)
-  const lintDeps = R.join(' ', R.values(R.mapObjIndexed((version, name) => `${name}@${version}`, addToPackageJson)))
-  execSync(`${yarnPath} add ${lintDeps} --dev`, {
+const yarnAddESLint = () => {
+  log.info('Adding lint configs in app root')
+  const lintPackages = R.join(' ', R.values(R.mapObjIndexed((version, name) => `${name}@${version}`, lintDeps)))
+  execSync(`${yarnPath} add ${lintPackages} --dev`, {
     stdio: 'inherit',
-    cwd: resolvePath(getAppRoot(), `${relativePath}`),
+    cwd: resolvePath(getAppRoot()),
   })
 }
 
-const createESLintSetup = async (lintDeps: string[], builder: string) => {
+const createESLintSetup = (appName: string, lintPackages: string[]) => {
   try {
-    const devDependencies = R.prop('devDependencies', packageJsonEditor.read(builder)) || {}
-    if (R.difference(lintDeps, R.intersection(lintDeps, R.keys(devDependencies))).length !== 0) {
-      yarnAddESLint(builder)
+    const originalRootPackageJson = packageJsonEditor.read('.')
+
+    packageJsonEditor.write('.', R.mergeDeepRight(originalRootPackageJson, basePackageJson(appName)))
+    eslintIgnoreEditor.write('.', eslintIgnore)
+    prettierrcEditor.write('.', basePrettierRc)
+
+    const devDependencies = R.prop('devDependencies', originalRootPackageJson) || {}
+
+    if (R.difference(lintPackages, R.intersection(lintPackages, R.keys(devDependencies))).length !== 0) {
+      yarnAddESLint()
     }
-    log.info(`Configuring ${builder} .eslint`)
-    esLintrcEditor.write(builder, addToEslintrc[builder])
+
+    log.info('Configuring app .eslintrc.json')
+    esLintrcEditor.write('.', baseEslintrc)
   } catch (e) {
     log.error(e)
   }
 }
 
-export const setupESLint = async (manifest: Manifest, buildersToAddAdditionalPackages: string[]) => {
+const setupCustomEsLintForBuilder = (builder: string) => {
+  const customConfig = customEslintrc[builder]
+
+  try {
+    log.info(`Setting up ${builder}'s ESLint config`)
+    esLintrcEditor.write(builder, customConfig)
+  } catch (err) {
+    log.error(err)
+  }
+}
+
+export const setupESLint = (manifest: Manifest, buildersToAddAdditionalPackages: string[]) => {
   const builders = R.keys(R.prop('builders', manifest) || {})
   const filteredBuilders = R.intersection(builders, buildersToAddAdditionalPackages)
-  const lintDeps = R.keys(addToPackageJson)
 
-  return Promise.all(R.map(R.curry(createESLintSetup)(lintDeps), filteredBuilders))
+  const lintPackages = R.keys(lintDeps)
+
+  if (filteredBuilders.length > 0) {
+    createESLintSetup(manifest.name, lintPackages)
+  }
+
+  const buildersWithCustomLint = R.keys(customEslintrc)
+
+  buildersWithCustomLint.forEach(builder => {
+    setupCustomEsLintForBuilder(builder)
+  })
 }

--- a/src/modules/setup/setupESLint.ts
+++ b/src/modules/setup/setupESLint.ts
@@ -1,6 +1,7 @@
 import { execSync } from 'child-process-es6-promise'
-import { resolve as resolvePath } from 'path'
+import { resolve as resolvePath, dirname } from 'path'
 import * as R from 'ramda'
+
 import log from '../../logger'
 import { getAppRoot } from '../../manifest'
 import { yarnPath } from '../utils'
@@ -67,7 +68,18 @@ const yarnAddESLint = () => {
 
 const createESLintSetup = (appName: string, lintPackages: string[]) => {
   try {
-    const originalRootPackageJson = packageJsonEditor.read('.')
+    let originalRootPackageJson = {}
+
+    try {
+      originalRootPackageJson = packageJsonEditor.read('.')
+    } catch (err) {
+      if (err.code === 'ENOENT') {
+        log.info(`No package.json found in ${dirname(packageJsonEditor.path('.'))}. Creating one.`)
+      } else {
+        log.error(err)
+        return
+      }
+    }
 
     packageJsonEditor.write('.', R.mergeDeepRight(originalRootPackageJson, basePackageJson(appName)))
     eslintIgnoreEditor.write('.', eslintIgnore)

--- a/src/modules/setup/setupESLint.ts
+++ b/src/modules/setup/setupESLint.ts
@@ -45,8 +45,6 @@ const baseEslintrc = {
   },
 }
 
-// eslint-disable-next-line
-// @ts-ignore
 const customEslintrc = {
   react: {
     extends: 'vtex-react',

--- a/src/modules/setup/setupESLint.ts
+++ b/src/modules/setup/setupESLint.ts
@@ -107,7 +107,7 @@ export const setupESLint = (manifest: Manifest, buildersToAddAdditionalPackages:
     createESLintSetup(manifest.name, lintPackages)
   }
 
-  const buildersWithCustomLint = R.keys(customEslintrc)
+  const buildersWithCustomLint = R.intersection(builders, R.keys(customEslintrc))
 
   buildersWithCustomLint.forEach(builder => {
     setupCustomEsLintForBuilder(builder)

--- a/src/modules/setup/utils.ts
+++ b/src/modules/setup/utils.ts
@@ -1,5 +1,5 @@
 import axios from 'axios'
-import { outputJsonSync, readJsonSync } from 'fs-extra'
+import { outputJsonSync, readJsonSync, readFileSync, outputFileSync } from 'fs-extra'
 import * as path from 'path'
 import { pipeline } from 'stream'
 import * as tar from 'tar'
@@ -33,23 +33,31 @@ const paths: Record<Files, (builder: string) => string> = {
 }
 
 class FileReaderWriter {
-  constructor(private file: Files) {}
+  constructor(private file: Files, private isJSON = true) {}
 
   public path = (builder: string) => {
     return paths[this.file](builder)
   }
 
   public read = (builder: string) => {
-    return readJsonSync(this.path(builder))
+    if (this.isJSON) {
+      return readJsonSync(this.path(builder))
+    }
+
+    return readFileSync(this.path(builder))
   }
 
   public write = (builder: string, data: any) => {
-    return outputJsonSync(this.path(builder), data, { spaces: 2 })
+    if (this.isJSON) {
+      return outputJsonSync(this.path(builder), data, { spaces: 2 })
+    }
+
+    return outputFileSync(this.path(builder), data)
   }
 }
 
 export const packageJsonEditor = new FileReaderWriter('packageJson')
 export const esLintrcEditor = new FileReaderWriter('esLintrc')
 export const tsconfigEditor = new FileReaderWriter('tsconfig')
-export const eslintIgnoreEditor = new FileReaderWriter('eslintIgnore')
+export const eslintIgnoreEditor = new FileReaderWriter('eslintIgnore', false)
 export const prettierrcEditor = new FileReaderWriter('prettierrc')

--- a/src/modules/setup/utils.ts
+++ b/src/modules/setup/utils.ts
@@ -22,12 +22,14 @@ export const checkIfTarGzIsEmpty = (url: string) => {
   })
 }
 
-type Files = 'tsconfig' | 'esLintrc' | 'packageJson'
+type Files = 'tsconfig' | 'esLintrc' | 'packageJson' | 'eslintIgnore' | 'prettierrc'
 
 const paths: Record<Files, (builder: string) => string> = {
   tsconfig: (builder: string) => path.join(getAppRoot(), builder, 'tsconfig.json'),
-  esLintrc: (builder: string) => path.join(getAppRoot(), builder, '.eslintrc'),
+  esLintrc: (builder: string) => path.join(getAppRoot(), builder, '.eslintrc.json'),
   packageJson: (builder: string) => path.join(getAppRoot(), builder, 'package.json'),
+  eslintIgnore: (builder: string) => path.join(getAppRoot(), builder, '.eslintignore'),
+  prettierrc: (builder: string) => path.join(getAppRoot(), builder, '.prettierrc'),
 }
 
 class FileReaderWriter {
@@ -49,3 +51,5 @@ class FileReaderWriter {
 export const packageJsonEditor = new FileReaderWriter('packageJson')
 export const esLintrcEditor = new FileReaderWriter('esLintrc')
 export const tsconfigEditor = new FileReaderWriter('tsconfig')
+export const eslintIgnoreEditor = new FileReaderWriter('eslintIgnore')
+export const prettierrcEditor = new FileReaderWriter('prettierrc')


### PR DESCRIPTION
#### What is the purpose of this pull request?
Updates the `vtex setup` command to match the current [recipe](https://docs.google.com/document/d/1ePi5Mn3pe1dOorKrMtC-MclBDiIDimVzf0Uj61W8lA4/edit) instructions. This creates a `package.json` at the root of the app (alongside the `manifest.json`) with all ESLint dependencies.

#### What problem is this solving?
Since ESLint newest major, they've changed how the package imports some dependencies (such as shared configs), making them break if you load your eslint plugin other than the folder that it is installed. For example, if you have you eslint and dependencies installed in a `node` folder, and you open the repo in the root, some ESLint plugins may not work properly, because they are installed in a child directory, not the one that the editor plugin is running.

#### How should this be manually tested?
Build the toolbelt and run `vtex setup` in any IO app. It should generate a `.eslintrc.json`, `package.json` and some other files in the same folder as your `manifest.json`. If you have a react app, it should also add a `.eslintrc.json` in the `react` folder.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
