### PR TITLE
Use major locator on app types urls when app is published

### DIFF
--- a/src/__tests__/modules/setup/setupTypings.test.ts
+++ b/src/__tests__/modules/setup/setupTypings.test.ts
@@ -42,9 +42,9 @@ describe('React type dependencies are correctly inserted', () => {
       name: 'mock',
       devDependencies: {
         someApp: '^1.0.0',
-        'vtex.admin': 'http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.admin@1.18.0/public/_types/react',
+        'vtex.admin': 'http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.admin@1.x/public/_types/react',
         'vtex.render-runtime':
-          'http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.render-runtime@8.1.0/public/_types/react',
+          'http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.render-runtime@8.x/public/_types/react',
       },
     })
     expect(runYarn).toBeCalledTimes(1)
@@ -71,9 +71,9 @@ describe('React type dependencies are correctly inserted', () => {
       name: 'mock',
       devDependencies: {
         someApp: '^1.0.0',
-        'vtex.admin': 'http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.admin@1.18.0/public/@types/vtex.admin',
+        'vtex.admin': 'http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.admin@1.x/public/@types/vtex.admin',
         'vtex.render-runtime':
-          'http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.render-runtime@8.1.0/public/@types/vtex.render-runtime',
+          'http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.render-runtime@8.x/public/@types/vtex.render-runtime',
       },
     })
     expect(runYarn).toBeCalledTimes(1)
@@ -103,7 +103,7 @@ describe('React type dependencies are correctly inserted', () => {
         'vtex.admin':
           'https://current-workspace--logged-account.public-endpoint/_v/private/typings/linked/v1/vtex.admin@1.18.0+build123/public/_types/react',
         'vtex.render-runtime':
-          'http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.render-runtime@8.1.0/public/_types/react',
+          'http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.render-runtime@8.x/public/_types/react',
       },
     })
     expect(runYarn).toBeCalledTimes(1)
@@ -133,7 +133,7 @@ describe('React type dependencies are correctly inserted', () => {
         'vtex.admin':
           'https://current-workspace--logged-account.public-endpoint/_v/private/typings/linked/v1/vtex.admin@1.18.0+build123/public/@types/vtex.admin',
         'vtex.render-runtime':
-          'http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.render-runtime@8.1.0/public/@types/vtex.render-runtime',
+          'http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.render-runtime@8.x/public/@types/vtex.render-runtime',
       },
     })
     expect(runYarn).toBeCalledTimes(1)
@@ -167,9 +167,9 @@ describe('React type dependencies are correctly inserted', () => {
       name: 'mock',
       devDependencies: {
         someApp: '^1.0.0',
-        'vtex.admin': 'http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.admin@1.15.0/public/@types/vtex.admin',
+        'vtex.admin': 'http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.admin@1.x/public/@types/vtex.admin',
         'vtex.render-runtime':
-          'http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.render-runtime@8.1.0/public/@types/vtex.render-runtime',
+          'http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.render-runtime@8.x/public/@types/vtex.render-runtime',
       },
     })
     expect(runYarn).toBeCalledTimes(1)

--- a/src/modules/setup/setupTypings.ts
+++ b/src/modules/setup/setupTypings.ts
@@ -12,10 +12,16 @@ import { checkIfTarGzIsEmpty, packageJsonEditor } from './utils'
 const getVendor = (appId: string) => appId.split('.')[0]
 const typingsURLRegex = /_v\/\w*\/typings/
 
+const appIdWithMajorRange = (appId: string) => {
+  const [appNameWithVendor, appVersion] = appId.split('@')
+  return `${appNameWithVendor}@${toMajorRange(appVersion)}`
+}
+
 const appTypingsURL = async (appName: string, appMajorLocator: string, ignoreLinked: boolean): Promise<string> => {
   const appId = ignoreLinked
     ? await appIdFromRegistry(appName, appMajorLocator)
     : await resolveAppId(appName, appMajorLocator)
+
   const vendor = getVendor(appId)
   const linked = isLinked({ version: appId, vendor, name: '', builders: {} })
 
@@ -25,7 +31,7 @@ const appTypingsURL = async (appName: string, appMajorLocator: string, ignoreLin
   const base =
     linked && !ignoreLinked
       ? `https://${getWorkspace()}--${getAccount()}.${publicEndpoint()}/_v/private/typings/linked/v1/${appId}/public`
-      : `http://vtex.vteximg.com.br/_v/public/typings/v1/${appId}/public`
+      : `http://vtex.vteximg.com.br/_v/public/typings/v1/${appIdWithMajorRange(appId)}/public`
 
   log.info(`Checking if ${chalk.bold(appId)} has new types format`)
   try {


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add:
```
"vtex.catalog-graphql": "http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.catalog-graphql@1.x/public/@types/vtex.catalog-graphql",
```
Instead of:
```
"vtex.catalog-graphql": "http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.catalog-graphql@1.25.0/public/@types/vtex.catalog-graphql",
```
The change is `vtex.catalog-graphql@1.25.0` -> `vtex.catalog-graphql@1.x`

#### How should this be manually tested?

Install this toolbelt branch:
```
git clone https://github.com/vtex/toolbelt.git && \
cd toolbelt && \
git checkout fix/use-major-locator-on-types-url && \
yarn && yarn global add file:$PWD
```
Clone or go to any project that has app dependencies and run:
```
vtex setup --ignore-linked
```
Check the types urls on `react/package.json` and/or `node/package.json`. 

#### Screenshots or example usage

#### Types of changes
- [X] Minor change (not bug fix, but i think it's not a feature)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
