### PR TITLE
Fix redirects import when called with the `reset` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `vtex redirects import --reset` when the redirects index is empty in `vtex.rewriter`.
 
 ## [2.77.6] - 2019-10-15
 ### Changed
@@ -41,7 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Ensure `node` >= v10
-- Add debug logs on `node` version, OS basic info and command executed 
+- Add debug logs on `node` version, OS basic info and command executed
 
 ## [2.76.2] - 2019-10-01
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.77.7] - 2019-10-16
 ### Fixed
 - `vtex redirects import --reset` when the redirects index is empty in `vtex.rewriter`.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.77.6",
+  "version": "2.77.7",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/modules/rewriter/import.ts
+++ b/src/modules/rewriter/import.ts
@@ -102,7 +102,7 @@ export default async (csvPath: string, options: any) => {
   let indexedRoutes
   if (reset) {
     const indexFiles = await rewriter.routesIndexFiles().then(prop('routeIndexFiles'))
-    const indexFileNames = pluck('fileName', indexFiles)
+    const indexFileNames = pluck('fileName', indexFiles) || []
     indexedRoutes = await Promise.mapSeries(indexFileNames, rewriter.routesIndex).then(
       compose<any, any, any>(
         pluck('id'),


### PR DESCRIPTION
This PR fixes the command `vtex redirects import` when it is called with the `reset` option and the redirects index in `vtex.rewriter` is empty.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
