### PR TITLE
Fix base package.json overriding custom one in setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix `vtex setup` overriding the app's existing `package.json`.
 
 ## [2.77.9] - 2019-10-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.77.10] - 2019-10-21
 ### Fixed
 - Fix `vtex setup` overriding the app's existing `package.json`.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.77.9",
+  "version": "2.77.10",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/__tests__/modules/setup/setupESLint.test.ts
+++ b/src/__tests__/modules/setup/setupESLint.test.ts
@@ -107,7 +107,7 @@ describe('Yarn is called correctly and .eslintrc is created', () => {
     expect(esLintrcEditorMock.write).toHaveBeenCalledTimes(1)
   })
 
-  it("shouldn't crash when no package.json exists in app root", async () => {
+  it('should not crash when no package.json exists in app root', async () => {
     const builders = ['node']
 
     packageJsonEditorMock.read.mockImplementationOnce(() => {
@@ -122,5 +122,28 @@ describe('Yarn is called correctly and .eslintrc is created', () => {
     await setupESLint(manifestSamples['node4-app'], builders)
 
     expect(packageJsonEditorMock.write).toHaveBeenCalledTimes(1)
+  })
+
+  it('should not replace custom package.json scripts', async () => {
+    const builders = ['node']
+
+    const pkg = {
+      scripts: {
+        lint: 'tsc --noEmit && eslint --ext ts,tsx .',
+      },
+    }
+
+    setPackageJsonByBuilder({ root: pkg })
+
+    await setupESLint(manifestSamples['node4-app'], builders)
+
+    expect(packageJsonEditorMock.write).toHaveBeenCalledWith(
+      '.',
+      expect.objectContaining({
+        scripts: {
+          lint: pkg.scripts.lint,
+        },
+      })
+    )
   })
 })

--- a/src/modules/setup/setupESLint.ts
+++ b/src/modules/setup/setupESLint.ts
@@ -81,7 +81,7 @@ const createESLintSetup = (appName: string, lintPackages: string[]) => {
       }
     }
 
-    packageJsonEditor.write('.', R.mergeDeepRight(originalRootPackageJson, basePackageJson(appName)))
+    packageJsonEditor.write('.', R.mergeDeepRight(basePackageJson(appName), originalRootPackageJson))
     eslintIgnoreEditor.write('.', eslintIgnore)
     prettierrcEditor.write('.', basePrettierRc)
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
Modifies the merge of `package.json` in the ESLint setup to not override custom set options.

#### What problem is this solving?
The `package.json` existing in the root of the app was always being overwritten with the base options, but it should be preserved.

#### How should this be manually tested?
Build the toolbelt and run `vtex setup` in any IO app, with a custom root `package.json`. The options in the existing file should be preserved.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
