### PR TITLE
Remove changelog from ignored published files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Remove CHANGELOG.md from lint of ignored files
+
 ## [2.77.10] - 2019-10-21
 ### Fixed
 - Fix `vtex setup` overriding the app's existing `package.json`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- Remove CHANGELOG.md from lint of ignored files
+- Remove CHANGELOG.md from list of ignored files
 
 ## [2.77.10] - 2019-10-21
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.77.10",
+  "version": "2.77.11",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/modules/apps/file.ts
+++ b/src/modules/apps/file.ts
@@ -15,7 +15,6 @@ const defaultIgnored = [
   '.DS_Store',
   'README.md',
   '.gitignore',
-  'CHANGELOG.md',
   'package.json',
   'node_modules/**',
   '**/node_modules/**',


### PR DESCRIPTION
#### What is the purpose of this pull request?
We need sending the CHANGELOG.md when the app is published in order to show it in the notifications channel (and in our admin of releases in the future). 

#### How should this be manually tested?
- Publish em app with CHANGELOG
- Check the files published with the app: `GET http://apps.aws-us-east-1.vtex.io/<vendor>/master/registry/<app_name>/x/files`

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
