### PR TITLE
Fix error when running on TTY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.77.13] - 2019-10-28
 ### Fixed
 - Error `Unhandled exception` when generating local token/workspace/account, due to nonexistent display.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Error `Unhandled exception` when generating local token/workspace/account, due to nonexistent display.
 
 ## [2.77.12] - 2019-10-25
 ### Changed

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "clear-module": "^3.0.0",
     "cli-table": "^0.3.1",
     "cli-table2": "^0.2.0",
-    "clipboardy": "^1.1.4",
+    "clipboardy": "^2.1.0",
     "configstore": "^4.0.0",
     "csvtojson": "^2.0.10",
     "debounce": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.77.12",
+  "version": "2.77.13",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/modules/local/account.ts
+++ b/src/modules/local/account.ts
@@ -1,8 +1,8 @@
-import * as clipboardy from 'clipboardy'
+import { copyToClipboard } from './utils'
 import { getAccount } from '../../conf'
 
 export default () => {
   const account = getAccount()
-  clipboardy.writeSync(account)
+  copyToClipboard(account)
   return console.log(account)
 }

--- a/src/modules/local/token.ts
+++ b/src/modules/local/token.ts
@@ -1,8 +1,8 @@
-import * as clipboardy from 'clipboardy'
+import { copyToClipboard } from './utils'
 import { getToken } from '../../conf'
 
 export default () => {
   const token = getToken()
-  clipboardy.writeSync(token)
+  copyToClipboard(token)
   return console.log(token)
 }

--- a/src/modules/local/utils.ts
+++ b/src/modules/local/utils.ts
@@ -1,9 +1,9 @@
 import * as clipboardy from 'clipboardy'
 
 export const copyToClipboard = (str: string) => {
-  try {
-    clipboardy.writeSync(str)
-  } catch (_) {
-    // ignores, probably running on a server
+  if (!process.env.DISPLAY) {
+    // skip, probably running on a server
+    return
   }
+  clipboardy.writeSync(str)
 }

--- a/src/modules/local/utils.ts
+++ b/src/modules/local/utils.ts
@@ -1,0 +1,9 @@
+import * as clipboardy from 'clipboardy'
+
+export const copyToClipboard = (str: string) => {
+  try {
+    clipboardy.writeSync(str)
+  } catch (_) {
+    // ignores, probably running on a server
+  }
+}

--- a/src/modules/local/workspace.ts
+++ b/src/modules/local/workspace.ts
@@ -1,8 +1,8 @@
-import * as clipboardy from 'clipboardy'
+import { copyToClipboard } from './utils'
 import { getWorkspace } from '../../conf'
 
 export default () => {
   const workspace = getWorkspace()
-  clipboardy.writeSync(workspace)
+  copyToClipboard(workspace)
   return console.log(workspace)
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1287,7 +1287,7 @@ aproba@^1.0.3:
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
   integrity sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==
 
-arch@^2.1.0:
+arch@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/arch/-/arch-2.1.1.tgz#8f5c2731aa35a30929221bb0640eed65175ec84e"
   integrity sha512-BLM56aPo9vLLFVa8+/+pJLnrZ7QGGTVHWsCwieAWT9o9K8UeGaQbzZbGoabWLOo2ksBCztoXdqBZBplqLDDCSg==
@@ -1968,13 +1968,13 @@ cli-width@^2.0.0:
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.0.tgz#ff19ede8a9a5e579324147b0c11f0fbcbabed639"
   integrity sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=
 
-clipboardy@^1.1.4:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/clipboardy/-/clipboardy-1.2.3.tgz#0526361bf78724c1f20be248d428e365433c07ef"
-  integrity sha512-2WNImOvCRe6r63Gk9pShfkwXsVtKCroMAevIbiae021mS850UkWPbevxsBz3tnvjZIEGvlwaqCPsw+4ulzNgJA==
+clipboardy@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/clipboardy/-/clipboardy-2.1.0.tgz#0123a0c8fac92f256dc56335e0bb8be97a4909a5"
+  integrity sha512-2pzOUxWcLlXWtn+Jd6js3o12TysNOOVes/aQfg+MT/35vrxWzedHlLwyoJpXjsFKWm95BTNEcMGD9+a7mKzZkQ==
   dependencies:
-    arch "^2.1.0"
-    execa "^0.8.0"
+    arch "^2.1.1"
+    execa "^1.0.0"
 
 cliui@^4.0.0:
   version "4.1.0"
@@ -2750,19 +2750,6 @@ execa@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/execa/-/execa-0.7.0.tgz#944becd34cc41ee32a63a9faf27ad5a65fc59777"
   integrity sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=
-  dependencies:
-    cross-spawn "^5.0.1"
-    get-stream "^3.0.0"
-    is-stream "^1.1.0"
-    npm-run-path "^2.0.0"
-    p-finally "^1.0.0"
-    signal-exit "^3.0.0"
-    strip-eof "^1.0.0"
-
-execa@^0.8.0:
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/execa/-/execa-0.8.0.tgz#d8d76bbc1b55217ed190fd6dd49d3c774ecfc8da"
-  integrity sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=
   dependencies:
     cross-spawn "^5.0.1"
     get-stream "^3.0.0"


### PR DESCRIPTION
#### What is the purpose of this pull request?
Skip the "copy to clipboard" function on systems that don't support it.

#### What problem is this solving?
When running the `clipboardy.writeSync` function on systems that don't have a display attached (e.g. WSL, or when running on TTY) or a X.Org server running, the function throws an error because it uses `xsel` under the hood.

#### How should this be manually tested?
Run the `vtex local token` command on a TTY. No error should be thrown and the token should be displayed as normal.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
