### PR TITLE
Use `tenant-provisioner`'s `migrate` API to set account's editions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Use `tenant-provisioner`'s `migrate` API to set account's editions.
 
 ### Fixed
 - Remove CHANGELOG.md from list of ignored files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.77.12] - 2019-10-25
 ### Changed
 - Use `tenant-provisioner`'s `migrate` API to set account's editions.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.77.11",
+  "version": "2.77.12",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/clients/sponsor.ts
+++ b/src/clients/sponsor.ts
@@ -20,8 +20,15 @@ export class Sponsor extends IOClient {
 
   public getEdition = async () => this.http.get(this.routes.getEdition, { metric: 'get-edition' })
 
-  public setEdition = async (account: string, edition: string) =>
-    this.http.put(this.routes.setEdition(account), { edition }, { metric: 'set-edition' })
+  public setEdition = async (account: string, editionApp: string) => {
+    const [ edition, version ] = editionApp.split('@')
+    const [ sponsor, editionName ] = edition.split('.')
+    return this.http.post(
+      this.routes.setEdition(account),
+      { sponsor,  edition: editionName, version },
+      { metric: 'set-edition' }
+    )
+  }
 
   public runHouseKeeper = async () => this.http.post(this.routes.runHouseKeeper, {}, { metric: 'run-house-keeper' })
 
@@ -30,7 +37,7 @@ export class Sponsor extends IOClient {
       getSponsorAccount: `http://kube-router.${this.region}.vtex.io/_account/${this.account}`,
       getEdition: `http://apps.${this.region}.vtex.io/${this.account}/${this.workspace}/edition`,
       setEdition: (account: string) =>
-        `http://apps.${this.region}.vtex.io/${this.account}/master/childAccount/${account}/edition`,
+        `http://tenant-provisioner.vtex.${this.region}.vtex.io/${this.account}/master/tenants/${account}/migrate`,
       runHouseKeeper: `http://housekeeper.${this.region}.vtex.io/${this.account}/master/_housekeeping/perform`,
     }
   }

--- a/src/clients/sponsor.ts
+++ b/src/clients/sponsor.ts
@@ -25,7 +25,7 @@ export class Sponsor extends IOClient {
     const [ sponsor, editionName ] = edition.split('.')
     return this.http.post(
       this.routes.setEdition(account),
-      { sponsor,  edition: editionName, version },
+      { sponsor, edition: editionName, version },
       { metric: 'set-edition' }
     )
   }

--- a/src/clients/sponsor.ts
+++ b/src/clients/sponsor.ts
@@ -21,8 +21,8 @@ export class Sponsor extends IOClient {
   public getEdition = async () => this.http.get(this.routes.getEdition, { metric: 'get-edition' })
 
   public setEdition = async (account: string, editionApp: string) => {
-    const [ edition, version ] = editionApp.split('@')
-    const [ sponsor, editionName ] = edition.split('.')
+    const [edition, version] = editionApp.split('@')
+    const [sponsor, editionName] = edition.split('.')
     return this.http.post(
       this.routes.setEdition(account),
       { sponsor, edition: editionName, version },


### PR DESCRIPTION
This PR makes toolbelt use the specialized `tenant-provisioner` app to set account's editions.
