### PR TITLE
Fix copy to clipboard on mac os

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fix copy to clipboard of `vtex local token` when it's executed on Mac OS.
+
 ## [2.77.13] - 2019-10-28
 ### Fixed
 - Error `Unhandled exception` when generating local token/workspace/account, due to nonexistent display.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.77.13",
+  "version": "2.77.14",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/modules/local/utils.ts
+++ b/src/modules/local/utils.ts
@@ -1,7 +1,7 @@
 import * as clipboardy from 'clipboardy'
 
 export const copyToClipboard = (str: string) => {
-  if (!process.env.DISPLAY) {
+  if (process.platform === 'linux' && !process.env.DISPLAY) {
     // skip, probably running on a server
     return
   }


### PR DESCRIPTION
#### What problem is this solving?
Make `vtex local token` great again when used on Mac OS.

#### How should this be manually tested?
Try to run `vtex local token` in different OS.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
