### PR TITLE
Ignore errors warming up the route map after create a workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Ignore errors warming up the route map after create a workspace
+
+## [2.77.14] - 2019-11-06
+### Fixed
 - Fix copy to clipboard of `vtex local token` when it's executed on Mac OS.
 
 ## [2.77.13] - 2019-10-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.77.15] - 2019-11-07
+
 ### Fixed
 - Ignore errors warming up the route map after create a workspace
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.77.14",
+  "version": "2.77.15",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/modules/setup/setupESLint.ts
+++ b/src/modules/setup/setupESLint.ts
@@ -122,6 +122,6 @@ export const setupESLint = (manifest: Manifest, buildersToAddAdditionalPackages:
   const buildersWithCustomLint = R.intersection(builders, R.keys(customEslintrc))
 
   buildersWithCustomLint.forEach(builder => {
-    setupCustomEsLintForBuilder(builder)
+    setupCustomEsLintForBuilder(builder as string)
   })
 }

--- a/src/modules/workspace/create.ts
+++ b/src/modules/workspace/create.ts
@@ -12,7 +12,7 @@ const warmUpRouteMap = async (workspace: string) => {
   try {
     const { builder } = createClients({ workspace: workspace })
     await builder.availability('vtex.builder-hub@0.x', null)
-    log.debug('Warmed up route map 2')
+    log.debug('Warmed up route map')
   } catch (err) {
     return
   }

--- a/src/modules/workspace/create.ts
+++ b/src/modules/workspace/create.ts
@@ -8,6 +8,16 @@ import log from '../../logger'
 
 const VALID_WORKSPACE = /^[a-z][a-z0-9]{0,126}[a-z0-9]$/
 
+const warmUpRouteMap = async (workspace: string) => {
+  try {
+    const { builder } = createClients({ workspace: workspace })
+    await builder.availability('vtex.builder-hub@0.x', null)
+    log.debug('Warmed up route map 2')
+  } catch (err) {
+    return
+  }
+}
+
 export default async (name: string, options: any) => {
   if (!VALID_WORKSPACE.test(name)) {
     throw new CommandError("Whoops! That's not a valid workspace name. Please use only lowercase letters and numbers.")
@@ -25,9 +35,7 @@ export default async (name: string, options: any) => {
       )}`
     )
     // First request on a brand new workspace takes very long because of route map generation, so we warm it up.
-    const { builder } = createClients({ workspace: name })
-    await builder.availability('vtex.builder-hub@0.x', null)
-    log.debug('Warmed up route map')
+    await warmUpRouteMap(name)
   } catch (err) {
     if (err.response && err.response.data.code === 'WorkspaceAlreadyExists') {
       log.error(err.response.data.message)


### PR DESCRIPTION
#### What is the purpose of this pull request?
When a new workspace is created using toolbelt, the CLI also warm up the route map performing a request to check the availability of builder-hub. This was implemented to decrease the chances of the user receives a timeout in the first requests which demands a route map generation in the workspace. But sometimes this timeout is received with the request to builder-hub, and actually we don't need to treat this error because the route map was warmed up anyway.

#### What problem is this solving?
Do not show errors when toolbelt tries warming up the route map of a new workspace, once the user doesn't know that it's happening and he/she can't do nothing in case of errors. 

#### How should this be manually tested?
- Uninstall builder-hub from some account
- Create a new workspace on this workspace
- The request to builder-hub will failed, but no error must be showed by the CLI.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
