### PR TITLE
Switch accounts without opening browser when possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Store tokens of other accounts visited in order to change account without opening browser when possible
+
 ## [2.77.15] - 2019-11-07
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.78.0] - 2019-11-19
+
 ### Changed
 - Store tokens of other accounts visited in order to change account without opening browser when possible
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.77.15",
+  "version": "2.78.0",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/Token.ts
+++ b/src/Token.ts
@@ -1,0 +1,26 @@
+import { decode } from 'jsonwebtoken'
+
+export class Token {
+  public token: string | undefined
+  private decoded: string | Record<string, any>
+
+  constructor(token: string) {
+    this.token = token
+    if (this.token) {
+      this.decoded = decode(token)
+    } else this.decoded = null
+  }
+
+  get login() {
+    return this.decoded && this.decoded.sub
+  }
+
+  public isValid() {
+    return (
+      this.decoded &&
+      typeof this.decoded !== 'string' &&
+      this.decoded.exp &&
+      Number(this.decoded.exp) >= Date.now() / 1000
+    )
+  }
+}

--- a/src/conf.ts
+++ b/src/conf.ts
@@ -84,3 +84,11 @@ export const currentContext: Context = {
 export enum Region {
   Production = 'aws-us-east-1',
 }
+
+export const saveAccountToken = (account: string, token: string) => {
+  conf.set(`tokens.${account}`, token)
+}
+
+export const getTokens = () => {
+  return conf.get('tokens') || {}
+}

--- a/src/modules/auth/login.ts
+++ b/src/modules/auth/login.ts
@@ -80,10 +80,11 @@ const promptAccount = async promptPreviousAcc => {
   return account
 }
 
-const saveCredentials = (login: string, account: string, token: string, workspace: string): void => {
+export const saveCredentials = (login: string, account: string, token: string, workspace: string): void => {
   conf.saveLogin(login)
   conf.saveAccount(account)
   conf.saveToken(token)
+  conf.saveAccountToken(account, token)
   conf.saveWorkspace(workspace)
 }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
`vtex switch` needs to open the browser on every execution. Now used tokens are stored to later usage by `vtex switch`

#### How should this be manually tested?

Install this branch:
```
git clone https://github.com/vtex/toolbelt.git && \
cd toolbelt && \
git checkout feat/switch-without-opening-broser && \
yarn && yarn global add file:$PWD
```

Use `vtex --verbose switch` 

#### Screenshots or example usage

#### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
