### PR TITLE
Fix clients constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Use `vendor.appname@major.x` on `ABTester` and `Rewriter` clients constructors in order to use new `node-vtex-api` routing. 
+
 ## [2.78.1] - 2019-11-21
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.78.2] - 2019-11-27
+
 ### Fixed
 - Use `vendor.appname@major.x` on `ABTester` and `Rewriter` clients constructors in order to use new `node-vtex-api` routing. 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.78.1",
+  "version": "2.78.2",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/clients/abTester.ts
+++ b/src/clients/abTester.ts
@@ -14,7 +14,7 @@ const routes = {
 
 export class ABTester extends AppClient {
   constructor(context: IOContext, options: InstanceOptions) {
-    super('vtex.ab-tester', context, options)
+    super('vtex.ab-tester@0.x', context, options)
   }
 
   // Abort AB Test in a workspace.

--- a/src/clients/rewriter.ts
+++ b/src/clients/rewriter.ts
@@ -40,7 +40,7 @@ export enum RedirectTypes {
 
 export class Rewriter extends AppGraphQLClient {
   constructor(context: IOContext, options: InstanceOptions) {
-    super('vtex.rewriter', context, {
+    super('vtex.rewriter@1.x', context, {
       ...options,
       headers: { 'cache-control': 'no-cache' },
       retries: 5,


### PR DESCRIPTION
#### What is the purpose of this pull request?
Use `vendor.appname@major.x` on `AppClients` constructors.

This will solve the message:
```
is using old routing for vtex.rewriter. Please change vendor.app to vendor.app@major in client
```

#### How should this be manually tested?

Install this branch:
```
git clone https://github.com/vtex/toolbelt.git && \
cd toolbelt && \
git checkout fix/old-routes && \
yarn && yarn global add file:$PWD
```
Try to link and check if the message is gone

#### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
