### PR TITLE
Notify IO when link connection is closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.78.3] - 2019-12-02
+
 ### Added
 - Use `onUnsubscribe` event feature to notify users about links closing connection.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Use `onUnsubscribe` event feature to notify users about links closing connection.
+
 ## [2.78.2] - 2019-11-27
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.78.2",
+  "version": "2.78.3",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/sse.ts
+++ b/src/sse.ts
@@ -96,7 +96,7 @@ export const onEvent = (
 ): Unlisten => {
   const source = `${endpoint('colossus')}/${ctx.account}/${
     ctx.workspace
-  }/events?sender=${sender}${parseKeyToQueryParameter(keys)}`
+  }/events?onUnsubscribe=link_interrupted&sender=${sender}${parseKeyToQueryParameter(keys)}`
   const es = createEventSource(source)
   es.onopen = onOpen('event')
   es.onmessage = compose(


### PR DESCRIPTION
#### What is the purpose of this pull request?
Use the colossus feature which allows us sends an event when the link connection is closed.
https://github.com/vtex/colossus/pull/287

#### What problem is this solving?
Now we can notify the users when the "link experience" is not turned on anymore sending an event, which can be catch by an app and shows some kind of notification on browser.

#### How should this be manually tested?
- Install colossus@0.36.0-beta
- Use this toolbelt to link some app
- Close the terminal or just turn off the link
- Check on splunk: `index=colossus account=<account> workspace=<workspace> key=link_interrupted`

You can also link an app which is expected to receives a `link_interrupted` event from colossus.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
