### PR TITLE
Allow setting initial edition of accounts :evil-parrot:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.78.4] - 2019-12-03
+
 ## [2.78.3] - 2019-12-02
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.78.3",
+  "version": "2.78.4",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/modules/sponsor/setEdition.ts
+++ b/src/modules/sponsor/setEdition.ts
@@ -33,8 +33,6 @@ export default async (edition: string) => {
   }
   const sponsorClientForSponsorAccount = new Sponsor(getIOContext(), IOClientOptions)
   await sponsorClientForSponsorAccount.setEdition(previousAccount, edition)
-  log.info(
-    `Successfully set new edition in account ${chalk.blue(previousAccount)}.`
-  )
+  log.info(`Successfully set new edition in account ${chalk.blue(previousAccount)}.`)
   await switchToPreviousAccount(previousConf)
 }

--- a/src/modules/sponsor/setEdition.ts
+++ b/src/modules/sponsor/setEdition.ts
@@ -34,9 +34,7 @@ export default async (edition: string) => {
   const sponsorClientForSponsorAccount = new Sponsor(getIOContext(), IOClientOptions)
   await sponsorClientForSponsorAccount.setEdition(previousAccount, edition)
   log.info(
-    `Successfully set new edition in account ${chalk.blue(
-      previousAccount
-    )}. You stil need to wait for the house keeper to update this account.`
+    `Successfully set new edition in account ${chalk.blue(previousAccount)}.`
   )
   await switchToPreviousAccount(previousConf)
 }

--- a/src/modules/sponsor/setEdition.ts
+++ b/src/modules/sponsor/setEdition.ts
@@ -10,9 +10,9 @@ import { switchToPreviousAccount } from '../utils'
 import { getIOContext, IOClientOptions } from '../utils'
 
 const promptSwitchToAccount = async (account: string, initial: boolean) => {
-  const reason = initial ?
-    `Initial edition can only be set by ${chalk.blue(account)} account` :
-    `Only current account sponsor (${chalk.blue(account)}') can change its edition`
+  const reason = initial
+    ? `Initial edition can only be set by ${chalk.blue(account)} account`
+    : `Only current account sponsor (${chalk.blue(account)}) can change its edition`
   const proceed = await promptConfirm(`${reason}. Do you want to switch to account ${chalk.blue(account)}?`)
   if (!proceed) {
     throw new UserCancelledError()

--- a/src/modules/sponsor/setEdition.ts
+++ b/src/modules/sponsor/setEdition.ts
@@ -9,12 +9,15 @@ import { promptConfirm } from '../prompts'
 import { switchToPreviousAccount } from '../utils'
 import { getIOContext, IOClientOptions } from '../utils'
 
-const promptChangeToSponsorAccount = async (sponsorAccount: string) => {
-  const proceed = await promptConfirm(`Do you wish to log into the sponsor account ${sponsorAccount}?`)
+const promptSwitchToAccount = async (account: string, initial: boolean) => {
+  const reason = initial ?
+    `Initial edition can only be set by ${chalk.blue(account)} account` :
+    `Only current account sponsor (${chalk.blue(account)}') can change its edition`
+  const proceed = await promptConfirm(`${reason}. Do you want to switch to account ${chalk.blue(account)}?`)
   if (!proceed) {
     throw new UserCancelledError()
   }
-  await switchAccount(sponsorAccount, {})
+  await switchAccount(account, {})
 }
 
 export default async (edition: string) => {
@@ -24,10 +27,9 @@ export default async (edition: string) => {
   const data = await sponsorClient.getSponsorAccount()
   const sponsorAccount = R.prop('sponsorAccount', data)
   if (!sponsorAccount) {
-    throw new Error(`No sponsor account found for account ${chalk.blue(previousAccount)}`)
-  }
-  if (previousAccount !== sponsorAccount) {
-    await promptChangeToSponsorAccount(sponsorAccount)
+    await promptSwitchToAccount('vtex', true)
+  } else if (previousAccount !== sponsorAccount) {
+    await promptSwitchToAccount(sponsorAccount, false)
   }
   const sponsorClientForSponsorAccount = new Sponsor(getIOContext(), IOClientOptions)
   await sponsorClientForSponsorAccount.setEdition(previousAccount, edition)

--- a/yarn.lock
+++ b/yarn.lock
@@ -6515,7 +6515,7 @@ static-extend@^0.1.1, static-extend@^0.1.2:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-"stats-lite@github:vtex/node-stats-lite#dist":
+stats-lite@vtex/node-stats-lite#dist:
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix `edition set` command to allow setting the initial edition of an account.

That request must be performed from `vtex` root spnsor, so the change is
to stop giving an error when the account has no sponsor and calling from the
`vtex` account instead.

#### What problem is this solving?
Not allowing to set initial edition of an account from toolbelt.

#### How should this be manually tested?
 - Find an account without any edition (e.g. any `vtexgameX` where `X` not in `[42-45]`)
 - Ensure that with `vtex edition` which should return a 404
 - Try setting edition `vtex edition set <edition>` (e.g. `vtex.edition@0.x`)
 - Should change to `vtex` account and set edition successfully
 
#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/1613383/70002142-e8bb5180-153d-11ea-8773-b31acae92cbe.png)

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
