### PR TITLE
Do not change app manifest when cloning with `vtex init`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.78.6] - 2019-12-04
 ### Refactor
 - Make `vtex init` never change the cloned app's manifest.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Refactor
+- Make `vtex init` never change the cloned app's manifest.
 
 ## [2.78.5] - 2019-12-04
 
@@ -21,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.78.2] - 2019-11-27
 
 ### Fixed
-- Use `vendor.appname@major.x` on `ABTester` and `Rewriter` clients constructors in order to use new `node-vtex-api` routing. 
+- Use `vendor.appname@major.x` on `ABTester` and `Rewriter` clients constructors in order to use new `node-vtex-api` routing.
 
 ## [2.78.1] - 2019-11-21
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.78.5",
+  "version": "2.78.6",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/modules/init/index.ts
+++ b/src/modules/init/index.ts
@@ -1,19 +1,13 @@
-import * as Bluebird from 'bluebird'
 import chalk from 'chalk'
 import * as enquirer from 'enquirer'
-import { outputJson, readJson } from 'fs-extra'
-import * as moment from 'moment'
-import { join } from 'path'
-import { keys, merge, prop, reject, test } from 'ramda'
+import { keys, prop, reject, test } from 'ramda'
 
-import { getAccount, getLogin } from '../../conf'
+import { getLogin } from '../../conf'
 import log from '../../logger'
-import { MANIFEST_FILE_NAME } from '../../manifest'
 import { promptConfirm } from '../prompts'
 
 import * as git from './git'
 
-const { mapSeries } = Bluebird
 
 const VTEXInternalTemplates = [
   // Only show these templates for VTEX e-mail users.
@@ -35,90 +29,10 @@ const templates = {
   'react-guide': 'react-app-template',
 }
 
-const titles = {
-  'graphql-example': 'GraphQL Example',
-  'admin-example': 'Admin Example',
-  'store-theme': 'Store Theme',
-  'delivery-theme': 'Delivery Store Theme',
-  'service-example': 'Node Service Example',
-  'render-guide': 'Render Guide',
-  'masterdata-graphql-guide': 'MasterData GraphQL Guide',
-  'support app': 'Support App Example',
-  'react-guide': 'React App Template',
-}
-
-const descriptions = {
-  'graphql-example': 'Example for building GraphQL Backend apps',
-  'admin-example': 'Example for building apps in Admin',
-  'store-theme': 'VTEX IO Store Theme',
-  'delivery-theme': 'VTEX IO Delivery Store Theme',
-  'service-example': `Example of @vtex/api's Service class`,
-  'render-guide': 'VTEX IO Render Guide',
-  'masterdata-graphql-guide': 'VTEX IO MasterData GraphQL Guide',
-  'support app': 'Example of a support app',
-  'react-guide': 'Guide for react apps structure',
-}
-
 const getTemplates = () =>
   // Return all templates if user's e-mail is `...@vtex...`.
   // Otherwise filter the VTEX internal templates.
   test(/\@vtex\./, getLogin()) ? keys(templates) : reject(x => VTEXInternalTemplates.indexOf(x) >= 0, keys(templates))
-
-const promptName = async (repo: string) => {
-  const message = 'The app name should only contain numbers, lowercase letters, underscores and hyphens.'
-  return prop(
-    'name',
-    await enquirer.prompt({
-      name: 'name',
-      message: "What's your VTEX app name?",
-      validate: s => /^[a-z0-9\-_]+$/.test(s) || message,
-      filter: s => s.trim(),
-      type: 'input',
-      initial: repo,
-    })
-  )
-}
-
-const promptVendor = async () => {
-  const message = 'The vendor should only contain numbers, lowercase letters, underscores and hyphens.'
-  return prop(
-    'vendor',
-    await enquirer.prompt({
-      name: 'vendor',
-      message: "What's your VTEX app vendor?",
-      validate: s => /^[a-z0-9\-_]+$/.test(s) || message,
-      filter: s => s.trim(),
-      type: 'input',
-      initial: getAccount(),
-    })
-  )
-}
-
-const promptTitle = async (repo: string) => {
-  return prop(
-    'title',
-    await enquirer.prompt({
-      name: 'title',
-      message: "What's your VTEX app title?",
-      filter: s => s.trim(),
-      type: 'input',
-      initial: titles[repo],
-    })
-  )
-}
-
-const promptDescription = async (repo: string) => {
-  return prop(
-    'description',
-    await enquirer.prompt({
-      name: 'description',
-      message: "What's your VTEX app description?",
-      filter: s => s.trim(),
-      type: 'input',
-      initial: descriptions[repo],
-    })
-  )
-}
 
 const promptTemplates = async (): Promise<string> => {
   const cancel = 'Cancel'
@@ -148,37 +62,14 @@ const promptContinue = async (repoName: string) => {
   }
 }
 
-const manifestFromPrompt = async (repo: string) => {
-  return mapSeries<any, string>([promptName, promptVendor, promptTitle, promptDescription], f => f(repo))
-}
-
-const createManifest = (name: string, vendor: string, title = '', description = ''): Partial<Manifest> => {
-  const [year, ...monthAndDay] = moment()
-    .format('YYYY-MM-DD')
-    .split('-')
-  return {
-    name,
-    vendor,
-    version: '0.1.0',
-    title,
-    description,
-    mustUpdateAt: `${Number(year) + 1}-${monthAndDay.join('-')}`,
-    registries: ['smartcheckout'],
-  }
-}
-
 export default async () => {
   log.debug('Prompting for app info')
   log.info('Hello! I will help you generate basic files and folders for your app.')
   try {
     const repo = templates[await promptTemplates()]
-    const manifestPath = join(process.cwd(), repo, MANIFEST_FILE_NAME)
     await promptContinue(repo)
     log.info(`Cloning https://vtex-apps/${repo}.git`)
-    const [, [name, vendor, title, description]]: any = await Bluebird.all([git.clone(repo), manifestFromPrompt(repo)])
-    const synthetic = createManifest(name, vendor, title, description)
-    const manifest: any = merge((await readJson(manifestPath)) || {}, synthetic)
-    await outputJson(manifestPath, manifest, { spaces: 2 })
+    await git.clone(repo)
     log.info(`Run ${chalk.bold.green(`cd ${repo}`)} and ${chalk.bold.green('vtex link')} to start developing!`)
   } catch (err) {
     log.error(err.message)

--- a/src/modules/init/index.ts
+++ b/src/modules/init/index.ts
@@ -8,7 +8,6 @@ import { promptConfirm } from '../prompts'
 
 import * as git from './git'
 
-
 const VTEXInternalTemplates = [
   // Only show these templates for VTEX e-mail users.
   'graphql-example',


### PR DESCRIPTION
This PR makes the `vtex init` command never modify the cloned app's manifest.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
