### PR TITLE
Feature/candidate release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - New command to validate a published app
 
+### Fixed
+- Use vtex/api on undeprecate request instead of axios 
+
 ## [2.78.6] - 2019-12-04
 ### Refactor
 - Make `vtex init` never change the cloned app's manifest.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.79.0] - 2019-12-06
+
 ### Added
 - New command to validate a published app
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- New command to validate a published app
+
 ## [2.78.6] - 2019-12-04
 ### Refactor
 - Make `vtex init` never change the cloned app's manifest.

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "url": "https://github.com/vtex/toolbelt/issues"
   },
   "dependencies": {
-    "@vtex/api": "^3.65.1",
+    "@vtex/api": "^3.67.1",
     "ajv": "^6.10.2",
     "any-promise": "^1.3.0",
     "async-retry": "^1.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.78.6",
+  "version": "2.79.0",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/modules/apps/validate.ts
+++ b/src/modules/apps/validate.ts
@@ -53,7 +53,7 @@ const prepareValidate = async (app, originalAccount, originalWorkspace: string):
     log.info('Successfully validated', app)
   } catch (e) {
     if (e.response && e.response.status && e.response.status === 404) {
-      log.error(`Error validating ${app}. App not found`)
+      log.error(`Error validating ${app}. App not found or already validated`)
     } else if (e.message && e.response.statusText) {
       log.error(`Error validating ${app}. ${e.message}. ${e.response.statusText}`)
       return await switchToPreviousAccount(originalAccount, originalWorkspace)

--- a/src/modules/apps/validate.ts
+++ b/src/modules/apps/validate.ts
@@ -1,0 +1,85 @@
+import * as Bluebird from 'bluebird'
+import chalk from 'chalk'
+
+import { createClients } from '../../clients'
+import { getAccount, getToken, getWorkspace } from '../../conf'
+import { UserCancelledError } from '../../errors'
+import log from '../../logger'
+import { getManifest, validateApp } from '../../manifest'
+import switchAccount from '../auth/switch'
+import { promptConfirm } from '../prompts'
+import { parseLocator, toAppLocator } from './../../locator'
+import { switchAccountMessage } from './utils'
+
+let originalAccount
+let originalWorkspace
+
+const switchToVendorMessage = (vendor: string): string => {
+  return `You are trying to validate this app in an account that differs from the indicated vendor. Do you want to valite in account ${chalk.blue(
+    vendor
+  )}?`
+}
+
+const promptValidate = (app: string): Bluebird<boolean> =>
+  promptConfirm(
+    `Are you sure you want to validate app ${app}`
+  )
+
+const switchToPreviousAccount = async (previousAccount: string, previousWorkspace: string) => {
+  const currentAccount = getAccount()
+  if (previousAccount !== currentAccount) {
+    const canSwitchToPrevious = await promptConfirm(switchAccountMessage(previousAccount, currentAccount))
+    if (canSwitchToPrevious) {
+      return await switchAccount(previousAccount, { workspace: previousWorkspace })
+    }
+  }
+  return
+}
+
+const validateRelease = async (app: string): Promise<void> => {
+  const { vendor, name, version } = parseLocator(app)
+  const account = getAccount()
+  if (vendor !== account) {
+    const canSwitchToVendor = await promptConfirm(switchToVendorMessage(vendor))
+    if (!canSwitchToVendor) {
+      throw new UserCancelledError()
+    }
+    await switchAccount(vendor, {})
+  }
+  const context = { account: vendor, workspace: 'master', authToken: getToken() }
+  const { registry } = createClients(context)
+  return await registry.validateApp(`${vendor}.${name}`, version)
+}
+
+const prepareValidate = async (app: string): Promise<void> => {
+  app = await validateApp(app)
+  try {
+    log.debug('Starting to validate app:', app)
+    await validateRelease(app)
+    log.info('Successfully validated', app)
+  } catch (e) {
+    if (e.response && e.response.status && e.response.status === 404) {
+      log.error(`Error validating ${app}. App not found`)
+    } else if (e.message && e.response.statusText) {
+      log.error(`Error validating ${app}. ${e.message}. ${e.response.statusText}`)
+      return await switchToPreviousAccount(originalAccount, originalWorkspace)
+    } else {
+      await switchToPreviousAccount(originalAccount, originalWorkspace)
+      throw e
+    }
+  }
+  await switchToPreviousAccount(originalAccount, originalWorkspace)
+}
+
+export default async (optionalApp: string, options) => {
+  const preConfirm = options.y || options.yes
+  originalAccount = getAccount()
+  originalWorkspace = getWorkspace()
+  const app = optionalApp || toAppLocator(await getManifest())
+
+  if (!preConfirm && !(await promptValidate(app))) {
+    throw new UserCancelledError()
+  }
+  log.debug(`Validating app ${app}`)
+  return prepareValidate(app)
+}

--- a/src/modules/apps/validate.ts
+++ b/src/modules/apps/validate.ts
@@ -11,19 +11,13 @@ import { promptConfirm } from '../prompts'
 import { parseLocator, toAppLocator } from './../../locator'
 import { switchAccountMessage } from './utils'
 
-let originalAccount
-let originalWorkspace
-
 const switchToVendorMessage = (vendor: string): string => {
   return `You are trying to validate this app in an account that differs from the indicated vendor. Do you want to valite in account ${chalk.blue(
     vendor
   )}?`
 }
 
-const promptValidate = (app: string): Bluebird<boolean> =>
-  promptConfirm(
-    `Are you sure you want to validate app ${app}`
-  )
+const promptValidate = (app: string): Bluebird<boolean> => promptConfirm(`Are you sure you want to validate app ${app}`)
 
 const switchToPreviousAccount = async (previousAccount: string, previousWorkspace: string) => {
   const currentAccount = getAccount()
@@ -51,7 +45,7 @@ const validateRelease = async (app: string): Promise<void> => {
   return await registry.validateApp(`${vendor}.${name}`, version)
 }
 
-const prepareValidate = async (app: string): Promise<void> => {
+const prepareValidate = async (app, originalAccount, originalWorkspace: string): Promise<void> => {
   app = await validateApp(app)
   try {
     log.debug('Starting to validate app:', app)
@@ -73,13 +67,13 @@ const prepareValidate = async (app: string): Promise<void> => {
 
 export default async (optionalApp: string, options) => {
   const preConfirm = options.y || options.yes
-  originalAccount = getAccount()
-  originalWorkspace = getWorkspace()
+  const originalAccount = getAccount()
+  const originalWorkspace = getWorkspace()
   const app = optionalApp || toAppLocator(await getManifest())
 
   if (!preConfirm && !(await promptValidate(app))) {
     throw new UserCancelledError()
   }
   log.debug(`Validating app ${app}`)
-  return prepareValidate(app)
+  return prepareValidate(app, originalAccount, originalWorkspace)
 }

--- a/src/modules/tree.ts
+++ b/src/modules/tree.ts
@@ -29,6 +29,11 @@ export default {
       },
     ],
   },
+  validate: {
+    description: 'Validate a release of an app',
+    handler: './apps/validate',
+    optionalArgs: 'app',
+  },
   deprecate: {
     description: 'Deprecate app(s)',
     handler: './apps/deprecate',

--- a/yarn.lock
+++ b/yarn.lock
@@ -729,10 +729,10 @@
     lodash.unescape "4.0.1"
     semver "5.5.0"
 
-"@vtex/api@^3.65.1":
-  version "3.65.1"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-3.65.1.tgz#7d9afc996f5c282626d8b0fac19a8bf48889e899"
-  integrity sha512-myyq0Y82vXOr6BUfkv3E6PBdJgvJI6Zw0X4lG0aWausgIjPBpznmoov+kaNBZRw+ng8bmkKDi/qM6ok5L03Mfg==
+"@vtex/api@^3.67.1":
+  version "3.67.1"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-3.67.1.tgz#3b91bf33d3fe970e887e5563106304c57fd4e20f"
+  integrity sha512-7oNOCZ5ClhhdFj/hO4IisLHOtJwjg9WFbr8KXeYayD5HU6P8jgbjLyB68cMbrigPxfr2AOBHD358Ql+9GcWaSQ==
   dependencies:
     "@types/koa" "^2.0.48"
     "@types/koa-compose" "^3.2.3"
@@ -6515,7 +6515,7 @@ static-extend@^0.1.1, static-extend@^0.1.2:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-stats-lite@vtex/node-stats-lite#dist:
+"stats-lite@github:vtex/node-stats-lite#dist":
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
#### What is the purpose of this pull request?
Create new command to validate an app. When we update the builder-hub to use the new publish API the apps won't be updated automatically anymore, even if they are stable version. The published apps will be in a "probation state", which means they can be used to run AB test using their stable versions. If the app is ready to automatically deployed in every account which it's installed (using HK), so the follow command should be executed: `vtex validate <app>@<version>`.

Related PR: https://github.com/vtex/node-vtex-api/pull/282

#### How should this be manually tested?
- Link node-vtex-api with toolbelt;
- On builder-hub: move the `vtex/api` do `dependencies` on node/package.json and also link the node-vtex-api on it;
- Install some app on master and publish a new version using toolbelt and builder-hub above: `vtex publish -w <workspace>`;
- Run `vtex update` on master. The app should *not* be available to update;
- Run `vtex validate <app>@<version>`.
- Run `vtex update` again. Now the app should be updated. 

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
