### PR TITLE
Refactor `vtex deprecate` and `vtex undeprecate`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Refactor
+- Refactor `vtex deprecate`, `vtex undeprecate`, `vtex publish`
 
 ## [2.81.2] - 2019-12-19
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.81.3] - 2019-12-23
 ### Refactor
 - Refactor `vtex deprecate`, `vtex undeprecate`, `vtex publish`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.81.2",
+  "version": "2.81.3",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/modules/apps/deprecate.ts
+++ b/src/modules/apps/deprecate.ts
@@ -1,15 +1,13 @@
 import * as Bluebird from 'bluebird'
 import chalk from 'chalk'
-import { head, prepend, tail } from 'ramda'
-
 import { createClients } from '../../clients'
 import { getAccount, getToken, getWorkspace } from '../../conf'
 import { UserCancelledError } from '../../errors'
+import { ManifestEditor, ManifestValidator } from '../../lib/manifest'
 import log from '../../logger'
-import { getManifest, validateApp } from '../../manifest'
 import switchAccount from '../auth/switch'
 import { promptConfirm } from '../prompts'
-import { parseLocator, toAppLocator } from './../../locator'
+import { parseLocator } from './../../locator'
 import { parseArgs, switchAccountMessage } from './utils'
 
 let originalAccount
@@ -56,40 +54,41 @@ const deprecateApp = async (app: string): Promise<void> => {
   return await registry.deprecateApp(`${vendor}.${name}`, version)
 }
 
-const prepareDeprecate = async (appsList: string[]): Promise<void> => {
-  if (appsList.length === 0) {
-    await switchToPreviousAccount(originalAccount, originalWorkspace)
-    return
-  }
-
-  const app = await validateApp(head(appsList))
-  try {
+const prepareAndDeprecateApps = async (appsList: string[]): Promise<void> => {
+  for (const app of appsList) {
+    ManifestValidator.validateApp(app)
     log.debug('Starting to deprecate app:', app)
-    await deprecateApp(app)
-    log.info('Successfully deprecated', app)
-  } catch (e) {
-    if (e.response && e.response.status && e.response.status === 404) {
-      log.error(`Error deprecating ${app}. App not found`)
-    } else if (e.message && e.response.statusText) {
-      log.error(`Error deprecating ${app}. ${e.message}. ${e.response.statusText}`)
-      return await switchToPreviousAccount(originalAccount, originalWorkspace)
-    } else {
-      await switchToPreviousAccount(originalAccount, originalWorkspace)
-      throw e
+
+    try {
+      await deprecateApp(app)
+      log.info('Successfully deprecated', app)
+    } catch (e) {
+      if (e.response && e.response.status && e.response.status === 404) {
+        log.error(`Error deprecating ${app}. App not found`)
+      } else if (e.message && e.response.statusText) {
+        log.error(`Error deprecating ${app}. ${e.message}. ${e.response.statusText}`)
+        return await switchToPreviousAccount(originalAccount, originalWorkspace)
+      } else {
+        await switchToPreviousAccount(originalAccount, originalWorkspace)
+        throw e
+      }
     }
   }
-  await prepareDeprecate(tail(appsList))
+
+  await switchToPreviousAccount(originalAccount, originalWorkspace)
 }
 
 export default async (optionalApp: string, options) => {
   const preConfirm = options.y || options.yes
+
   originalAccount = getAccount()
   originalWorkspace = getWorkspace()
-  const appsList = prepend(optionalApp || toAppLocator(await getManifest()), parseArgs(options._))
+  const appsList = [optionalApp || (await ManifestEditor.getManifestEditor()).appLocator, ...parseArgs(options._)]
 
   if (!preConfirm && !(await promptDeprecate(appsList))) {
     throw new UserCancelledError()
   }
+
   log.debug('Deprecating app' + (appsList.length > 1 ? 's' : '') + `: ${appsList.join(', ')}`)
-  return prepareDeprecate(appsList)
+  return prepareAndDeprecateApps(appsList)
 }

--- a/src/modules/apps/publish.ts
+++ b/src/modules/apps/publish.ts
@@ -8,7 +8,7 @@ import { region } from '../../env'
 import { UserCancelledError } from '../../errors'
 import { toAppLocator } from '../../locator'
 import log from '../../logger'
-import { getAppRoot, getManifest } from '../../manifest'
+import { getAppRoot } from '../../manifest'
 import switchAccount from '../auth/switch'
 import { listenBuild } from '../build'
 import { promptConfirm } from '../prompts'
@@ -16,6 +16,7 @@ import { runYarnIfPathExists, switchToPreviousAccount } from '../utils'
 import { listLocalFiles } from './file'
 import { ProjectUploader } from './ProjectUploader'
 import { checkBuilderHubMessage, pathToFileObject, showBuilderHubMessage } from './utils'
+import { ManifestEditor } from '../../lib/manifest'
 
 const root = getAppRoot()
 const buildersToRunLocalYarn = ['node', 'react']
@@ -68,7 +69,7 @@ const publisher = (workspace: string = 'master') => {
   const publishApps = async (path: string, tag: string, force: boolean): Promise<void | never> => {
     const previousConf = conf.getAll() // Store previous configuration in memory
 
-    const manifest = await getManifest()
+    const manifest = await ManifestEditor.getManifestEditor()
     const account = conf.getAccount()
 
     const builderHubMessage = await checkBuilderHubMessage('publish')

--- a/src/modules/apps/undeprecate.ts
+++ b/src/modules/apps/undeprecate.ts
@@ -1,14 +1,13 @@
-import { createClients } from '../../clients'
 import * as Bluebird from 'bluebird'
 import chalk from 'chalk'
-import { head, prepend, tail } from 'ramda'
+import { createClients } from '../../clients'
 import { getAccount, getToken, getWorkspace } from '../../conf'
 import { UserCancelledError } from '../../errors'
+import { ManifestEditor, ManifestValidator } from '../../lib/manifest'
 import log from '../../logger'
-import { getManifest, validateApp } from '../../manifest'
 import switchAccount from '../auth/switch'
 import { promptConfirm } from '../prompts'
-import { parseLocator, toAppLocator } from './../../locator'
+import { parseLocator } from './../../locator'
 import { parseArgs, switchAccountMessage } from './utils'
 
 let originalAccount
@@ -58,36 +57,32 @@ const undeprecateApp = async (app: string): Promise<void> => {
 }
 
 const prepareUndeprecate = async (appsList: string[]): Promise<void> => {
-  if (appsList.length === 0) {
-    await switchToPreviousAccount(originalAccount, originalWorkspace)
-    return
-  }
-
-  const app = await validateApp(head(appsList))
-  try {
-    log.debug('Starting to undeprecate app:', app)
-    await undeprecateApp(app)
-    log.info('Successfully undeprecated', app)
-  } catch (e) {
-    if (e.response && e.response.status && e.response.status === 404) {
-      log.error(`Error undeprecating ${app}. App not found`)
-    } else if (e.message && e.response.statusText) {
-      log.error(`Error undeprecating ${app}. ${e.message}. ${e.response.statusText}`)
-      await switchToPreviousAccount(originalAccount, originalWorkspace)
-      return
-    } else {
-      await switchToPreviousAccount(originalAccount, originalWorkspace)
-      throw e
+  for (const app of appsList) {
+    ManifestValidator.validateApp(app)
+    try {
+      log.debug('Starting to undeprecate app:', app)
+      await undeprecateApp(app)
+      log.info('Successfully undeprecated', app)
+    } catch (e) {
+      if (e.response && e.response.status && e.response.status === 404) {
+        log.error(`Error undeprecating ${app}. App not found`)
+      } else if (e.message && e.response.statusText) {
+        log.error(`Error undeprecating ${app}. ${e.message}. ${e.response.statusText}`)
+        await switchToPreviousAccount(originalAccount, originalWorkspace)
+        return
+      } else {
+        await switchToPreviousAccount(originalAccount, originalWorkspace)
+        throw e
+      }
     }
   }
-  await prepareUndeprecate(tail(appsList))
 }
 
 export default async (optionalApp: string, options) => {
   const preConfirm = options.y || options.yes
   originalAccount = getAccount()
   originalWorkspace = getWorkspace()
-  const appsList = prepend(optionalApp || toAppLocator(await getManifest()), parseArgs(options._))
+  const appsList = [optionalApp || (await ManifestEditor.getManifestEditor()).appLocator, ...parseArgs(options._)]
 
   if (!preConfirm && !(await promptUndeprecate(appsList))) {
     throw new UserCancelledError()


### PR DESCRIPTION
#### What is the purpose of this pull request?
- Refactor `vtex deprecate` and `vtex undeprecate`
- Use `ManifestEditor` on `vtex publish`

#### How should this be manually tested?
Install this branch:
```
git clone https://github.com/vtex/toolbelt.git && \
cd toolbelt && \
git checkout refactor/deprecate-undeprecate-publish && \
yarn && yarn global add file:$PWD
```

Test these scenarios:
```
For `vtex deprecate` - `vtex undeprecate`:

// In the project
git clone https://github.com/vtex-apps/service-example.git && cd service-example
vtex-test deprecate
# check io-notifications
vtex-test undeprecate
# check io notifications

// Deprecate by name
vtex-test deprecate vtex.service-example@0.0.5
vtex-test undeprecate vtex.service-example@0.0.5

-------------------------------------------------------------------------------------------
For `vtex publish`:

git clone https://github.com/tiagonapoli/service-example.git && cd service-example
vtex-test publish
# check io-notifications
```

#### Types of changes
- [X] Chore
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
