### PR TITLE
Use v8-compile-cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.81.2] - 2019-12-19
 ### Added
 - Use `v8-compile-cache` to slightly reduce commands startup
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Use `v8-compile-cache` to slightly reduce commands startup
 
 ## [2.81.1] - 2019-12-18
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.81.1",
+  "version": "2.81.2",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "tar": "~4.4.10",
     "unzip-stream": "~0.3.0",
     "update-notifier": "~3.0.1",
+    "v8-compile-cache": "^2.1.0",
     "winston": "~3.2.1",
     "winston-transport": "~4.3.0",
     "ws": "~7.2.0",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import 'any-promise/register/bluebird'
+import 'v8-compile-cache'
 import axios from 'axios'
 import * as Bluebird from 'bluebird'
 import chalk from 'chalk'

--- a/yarn.lock
+++ b/yarn.lock
@@ -7537,7 +7537,7 @@ uuid@^3.1.0, uuid@^3.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
   integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
 
-v8-compile-cache@^2.0.3:
+v8-compile-cache@^2.0.3, v8-compile-cache@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz#e14de37b31a6d194f5690d67efc4e7f6fc6ab30e"
   integrity sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==


### PR DESCRIPTION
#### What is the purpose of this pull request?
Using [v8-compile-cache](https://www.npmjs.com/package/v8-compile-cache) may improve toolbelt commands startup times.

#### Types of changes
- [X] Performance
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
