### PR TITLE
Add message regarding publish changes when trying to publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add message regarding publish process changes when trying to publish
 
 ## [2.81.3] - 2019-12-23
 ### Refactor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.81.4] - 2019-12-23
 ### Added
 - Add message regarding publish process changes when trying to publish
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.81.3",
+  "version": "2.81.4",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/modules/apps/publish.ts
+++ b/src/modules/apps/publish.ts
@@ -121,8 +121,18 @@ const publisher = (workspace: string = 'master') => {
   return { publishApp, publishApps }
 }
 
-export default (path: string, options) => {
+export default async (path: string, options) => {
   log.debug(`Starting to publish app in ${conf.getEnvironment()}`)
+
+  const response = await promptConfirm(
+    chalk.yellow.bold(
+      `Starting January 2, 2020, the 'vtex publish' command will change its behavior and more steps will be added to the publishing process. Read more about this change here: https://vtex.io/docs/releases/2019-week-47-48-49-50-51/publish-command. Acknowledged?`
+    ),
+    false
+  )
+  if (!response) {
+    process.exit(1)
+  }
 
   path = path || root
   const workspace = options.w || options.workspace
@@ -132,5 +142,5 @@ export default (path: string, options) => {
   map(runYarnIfPathExists, buildersToRunLocalYarn)
 
   const { publishApps } = publisher(workspace)
-  return publishApps(path, options.tag, force)
+  await publishApps(path, options.tag, force)
 }


### PR DESCRIPTION
Changes on publish will start to take efect on January, 2. This has to be communicated to the user.

To test:
```
git clone https://github.com/vtex/toolbelt.git && \
cd toolbelt && \
git checkout chore/publish-changes-message && \
yarn && yarn global add file:$PWD
```
Try to publish an app

#### Screenshots or example usage
![Screenshot from 2019-12-23 15-33-55](https://user-images.githubusercontent.com/26463288/71374487-a95eae80-2599-11ea-9b55-daaa5a8e8eac.png)


#### Types of changes
- [X] Chore
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
