### PR TITLE
Scope pinned dependencies by builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ node_modules/
 coverage/
 npm-debug.log
 .tern-project
-lib/
+/lib/
 temp/
 yarn-error.log
 .DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Short circuit bad toolbelt version error when linking
 
+### Changed
+- Add dependencies pinned by builder-hub scoped by builder
+
 ## [2.84.1] - 2020-01-13
 ### Fixed
 - Post publish message now notifies about `vtex deploy` instead of `vtex validate`

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,6 +3,6 @@ module.exports = {
   transform: {
     '^.+\\.tsx?$': 'ts-jest',
   },
-  testRegex: '(/__tests__/.*(test|spec)).tsx?$',
+  testRegex: '(.*(test|spec)).tsx?$',
   testEnvironment: 'node',
 }

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   },
   "dependencies": {
     "@vtex/api": "3.67.1",
+    "@yarnpkg/lockfile": "^1.1.0",
     "ajv": "~6.10.2",
     "any-promise": "~1.3.0",
     "archiver": "^3.1.1",
@@ -110,6 +111,7 @@
     "@types/ramda": "types/npm-ramda#dist",
     "@types/semver-diff": "2.1.1",
     "@types/tar": "4.0.3",
+    "@types/yarnpkg__lockfile": "^1.1.3",
     "eslint": "^6.7.2",
     "eslint-config-vtex": "^11.2.0",
     "jest": "24.9.0",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "ramda-adjunct": "~2.23.0",
     "randomstring": "~1.1.5",
     "request": "~2.88.0",
-    "semver": "~5.3.0",
+    "semver": "~7.1.1",
     "semver-diff": "~2.1.0",
     "tar": "~4.4.10",
     "unzip-stream": "~0.3.0",

--- a/src/lib/packageJson/index.test.ts
+++ b/src/lib/packageJson/index.test.ts
@@ -26,6 +26,7 @@ beforeEach(() => {
 describe('Version comparison', () => {
   const versionComparison = [
     [{ yarnResolved: '1.2.3', required: '1.2.3', found: '1.2.3', satisfies: true }],
+    [{ yarnResolved: '1.2.3', required: '1.2.3', found: '1.2.3', satisfies: true }],
     [{ yarnResolved: '1.2.4', required: '1.2.3', found: '1.2.4', satisfies: false }],
     [{ yarnResolved: '1.2.3', required: '^1.0.0', found: '^1.0.0', satisfies: true }],
     [{ yarnResolved: '1.1.1', required: '^1.0.0', found: '1.1.1', satisfies: true }],
@@ -42,10 +43,14 @@ describe('Version comparison', () => {
     [{ yarnResolved: '1.0.1', required: '^1.1.0', found: '~1.0.0', satisfies: false }],
     [{ yarnResolved: '1.0.5', required: '^1.1.0', found: '^1.0.0', satisfies: false }],
     [{ yarnResolved: '1.2.3', required: '^1.1.0', found: '^1.0.0', satisfies: true }],
+    [{ yarnResolved: undefined, required: '1.2.3', found: '1.2.3', satisfies: true }],
+    [{ yarnResolved: undefined, required: '1.2.4', found: '1.2.3', satisfies: false }],
+    [{ yarnResolved: undefined, required: '^1.1.0', found: '1.0.0', satisfies: false }],
+    [{ yarnResolved: undefined, required: '^1.1.0', found: 'invalid', satisfies: false }],
   ]
 
-  test.each(versionComparison)('versionSatisfies: %p', ({ required, found, yarnResolved, satisfies }) => {
-    expect(PackageJson.versionSatisfiesWithUserPriority(required, found, yarnResolved)).toBe(satisfies)
+  test.each(versionComparison)('%# versionSatisfies: %p', ({ required, found, yarnResolved, satisfies }) => {
+    expect(PackageJson.versionSatisfiesWithYarnPriority(required, found, yarnResolved)).toBe(satisfies)
   })
 })
 

--- a/src/lib/packageJson/index.test.ts
+++ b/src/lib/packageJson/index.test.ts
@@ -25,27 +25,27 @@ beforeEach(() => {
 
 describe('Version comparison', () => {
   const versionComparison = [
-    [{ required: '1.2.3', found: '1.2.4', satisfies: false }],
-    [{ required: '1.2.3', found: '1.2.3', satisfies: true }],
-
-    [{ required: '^1.0.0', found: '^1.0.0', satisfies: true }],
-    [{ required: '^1.0.0', found: '1.1.1', satisfies: true }],
-    [{ required: '^1.0.0', found: '^1.1.1', satisfies: true }],
-    [{ required: '^1.0.0', found: '~1.1.1', satisfies: true }],
-    [{ required: '^1.0.0', found: '1.x', satisfies: true }],
-
-    [{ required: '^1.0.0', found: '2.1.1', satisfies: false }],
-    [{ required: '^1.0.0', found: '^2.1.1', satisfies: false }],
-    [{ required: '^1.0.0', found: '~2.1.1', satisfies: false }],
-    [{ required: '^1.0.0', found: '2.x', satisfies: false }],
-
-    [{ required: '^1.1.0', found: '1.x', satisfies: false }],
-    [{ required: '^1.1.0', found: '~1.0.0', satisfies: false }],
-    [{ required: '^1.1.0', found: '^1.0.0', satisfies: false }],
+    [{ yarnResolved: '1.2.3', required: '1.2.3', found: '1.2.3', satisfies: true }],
+    [{ yarnResolved: '1.2.4', required: '1.2.3', found: '1.2.4', satisfies: false }],
+    [{ yarnResolved: '1.2.3', required: '^1.0.0', found: '^1.0.0', satisfies: true }],
+    [{ yarnResolved: '1.1.1', required: '^1.0.0', found: '1.1.1', satisfies: true }],
+    [{ yarnResolved: '1.2.3', required: '^1.0.0', found: '^1.1.1', satisfies: true }],
+    [{ yarnResolved: '1.1.2', required: '^1.0.0', found: '~1.1.1', satisfies: true }],
+    [{ yarnResolved: '1.2.3', required: '^1.0.0', found: '1.x', satisfies: true }],
+    [{ yarnResolved: '2.1.1', required: '^1.0.0', found: '2.1.1', satisfies: false }],
+    [{ yarnResolved: '2.2.2', required: '^1.0.0', found: '^2.1.1', satisfies: false }],
+    [{ yarnResolved: '2.1.2', required: '^1.0.0', found: '~2.1.1', satisfies: false }],
+    [{ yarnResolved: '2.3.4', required: '^1.0.0', found: '2.x', satisfies: false }],
+    [{ yarnResolved: '1.0.0', required: '^1.1.0', found: '1.x', satisfies: false }],
+    [{ yarnResolved: '1.2.3', required: '^1.1.0', found: '1.x', satisfies: true }],
+    [{ yarnResolved: '1.2.3', required: '^1.1.0', found: '~1.0.0', satisfies: true }],
+    [{ yarnResolved: '1.0.1', required: '^1.1.0', found: '~1.0.0', satisfies: false }],
+    [{ yarnResolved: '1.0.5', required: '^1.1.0', found: '^1.0.0', satisfies: false }],
+    [{ yarnResolved: '1.2.3', required: '^1.1.0', found: '^1.0.0', satisfies: true }],
   ]
 
-  test.each(versionComparison)('versionSatisfies: %s', ({ required, found, satisfies }) => {
-    expect(PackageJson.versionSatisfiesWithUserPriority(required, found)).toBe(satisfies)
+  test.each(versionComparison)('versionSatisfies: %p', ({ required, found, yarnResolved, satisfies }) => {
+    expect(PackageJson.versionSatisfiesWithUserPriority(required, found, yarnResolved)).toBe(satisfies)
   })
 })
 

--- a/src/lib/packageJson/index.test.ts
+++ b/src/lib/packageJson/index.test.ts
@@ -1,0 +1,119 @@
+import { clone } from 'ramda'
+import { PackageJson, PackageJsonInterface } from './index'
+
+jest.mock('fs-extra', () => {
+  return {
+    pathExists: jest.fn(),
+    readJson: jest.fn(),
+    writeJson: jest.fn(),
+    writeJsonSync: jest.fn(),
+  }
+})
+
+const { readJson } = jest.requireMock('fs-extra') as Record<string, jest.Mock>
+
+const setupPackageJson = async (content: any) => {
+  const pkg = new PackageJson('mockPath')
+  readJson.mockResolvedValue(clone(content))
+  await pkg.init()
+  return pkg
+}
+
+beforeEach(() => {
+  readJson.mockClear()
+})
+
+describe('Version comparison', () => {
+  const versionComparison = [
+    [{ required: '1.2.3', found: '1.2.4', satisfies: false }],
+    [{ required: '1.2.3', found: '1.2.3', satisfies: true }],
+
+    [{ required: '^1.0.0', found: '^1.0.0', satisfies: true }],
+    [{ required: '^1.0.0', found: '1.1.1', satisfies: true }],
+    [{ required: '^1.0.0', found: '^1.1.1', satisfies: true }],
+    [{ required: '^1.0.0', found: '~1.1.1', satisfies: true }],
+    [{ required: '^1.0.0', found: '1.x', satisfies: true }],
+
+    [{ required: '^1.0.0', found: '2.1.1', satisfies: false }],
+    [{ required: '^1.0.0', found: '^2.1.1', satisfies: false }],
+    [{ required: '^1.0.0', found: '~2.1.1', satisfies: false }],
+    [{ required: '^1.0.0', found: '2.x', satisfies: false }],
+
+    [{ required: '^1.1.0', found: '1.x', satisfies: false }],
+    [{ required: '^1.1.0', found: '~1.0.0', satisfies: false }],
+    [{ required: '^1.1.0', found: '^1.0.0', satisfies: false }],
+  ]
+
+  test.each(versionComparison)('versionSatisfies: %s', ({ required, found, satisfies }) => {
+    expect(PackageJson.versionSatisfiesWithUserPriority(required, found)).toBe(satisfies)
+  })
+})
+
+describe('PackageJson manipulation', () => {
+  const pkgMocks: Array<[PackageJsonInterface]> = [
+    [{}],
+    [{ name: 'somePackage' }],
+    [{ dependencies: { axios: '1.2.3' } }],
+    [{ dependencies: { axios: '1.2.2' } }],
+    [{ devDependencies: { axios: '1.2.3' } }],
+    [{ devDependencies: { axios: '1.2.2' } }],
+    [{ dependencies: { axios: '1.2.3' }, devDependencies: { '@types/axios': '1.2.4' } }],
+    [{ dependencies: { axios: '1.2.2' }, devDependencies: { '@types/axios': '1.2.4' } }],
+    [{ name: 'somePackage', dependencies: { axios: '1.2.3' }, devDependencies: { '@types/axios': '1.2.4' } }],
+    [{ name: 'somePackage', dependencies: { axios: '1.2.2' }, devDependencies: { '@types/axios': '1.2.4' } }],
+    [{ name: 'somePackage', dependencies: {}, devDependencies: { '@types/axios': '1.2.4' } }],
+    [{ name: 'somePackage', devDependencies: { '@types/axios': '1.2.4' } }],
+  ]
+
+  test('package.json opened is the specifiend in the constructor', async () => {
+    const mockObj = { mock: '123' }
+    const pkg = new PackageJson('mockPath')
+    readJson.mockResolvedValue(mockObj)
+    await pkg.init()
+    expect(readJson).toBeCalledTimes(1)
+    expect(readJson).toBeCalledWith('mockPath')
+    expect(pkg.content).toEqual(mockObj)
+  })
+
+  describe.each(pkgMocks)('PackageJson editing features - Sample %#', (pkgMock: PackageJsonInterface) => {
+    test(`Add someDep: 'http://pkg.com.br' dependency`, async () => {
+      const pkg = await setupPackageJson(pkgMock)
+      const dep = { someDep: 'http://pkg.com.br' }
+      pkg.addDependency('someDep', dep.someDep, 'dependencies')
+      expect(pkg.content).toEqual({ ...pkgMock, dependencies: { ...pkgMock.dependencies, ...dep } })
+    })
+
+    test(`Add someDep: 'http://pkg.com.br' devDependency`, async () => {
+      const pkg = await setupPackageJson(pkgMock)
+      const dep = { someDep: 'http://pkg.com.br' }
+      pkg.addDependency('someDep', dep.someDep, 'devDependencies')
+      expect(pkg.content).toEqual({ ...pkgMock, devDependencies: { ...pkgMock.devDependencies, ...dep } })
+    })
+
+    test('Force dependency version', async () => {
+      const before = clone(pkgMock)
+      const pkg = await setupPackageJson(pkgMock)
+      pkg.maybeChangeDepVersionByDepType('axios', '1.2.3', 'dependencies')
+      if (before?.dependencies?.axios) {
+        expect(pkg.content.dependencies.axios).toEqual('1.2.3')
+        delete before.dependencies.axios
+        delete pkg.content.dependencies.axios
+      }
+
+      expect(pkg.content).toEqual(before)
+    })
+
+    test('Force devDependency version', async () => {
+      const before = clone(pkgMock)
+      const pkg = await setupPackageJson(pkgMock)
+      pkg.maybeChangeDepVersionByDepType('axios', '1.2.3', 'devDependencies')
+      if (before?.devDependencies?.axios) {
+        expect(pkg.content.devDependencies.axios).toEqual('1.2.3')
+        delete before.devDependencies.axios
+        delete pkg.content.devDependencies.axios
+      }
+
+      expect(pkg.content).toEqual(before)
+    })
+  })
+})

--- a/src/lib/packageJson/index.ts
+++ b/src/lib/packageJson/index.ts
@@ -1,0 +1,106 @@
+import { pathExists, readJson, writeJson, writeJsonSync } from 'fs-extra'
+import { resolve } from 'path'
+import * as semver from 'semver'
+
+export interface PackageJsonInterface {
+  name?: string
+  version?: string
+  dependencies?: Record<string, string>
+  devDependencies?: Record<string, string>
+}
+
+export class PackageJson {
+  static versionSatisfiesWithUserPriority(versionRequired: string, versionFound: string) {
+    if (!semver.valid(versionFound) && !semver.validRange(versionFound)) {
+      return false
+    }
+
+    if (semver.validRange(versionRequired)) {
+      if (semver.validRange(versionFound)) {
+        const minFoundVersion = semver.minVersion(versionFound)
+        return semver.satisfies(minFoundVersion, versionRequired)
+      } else {
+        return semver.satisfies(versionFound, versionRequired)
+      }
+    } else {
+      return versionRequired !== versionFound
+    }
+  }
+
+  static async getBuilderPackageJsonIfExists(
+    appRoot: string,
+    builder: string,
+    notifyIfDoesntExist: boolean,
+    notifier?: any
+  ): Promise<PackageJson | null> {
+    const path = resolve(appRoot, builder, 'package.json')
+    if (!(await pathExists(path))) {
+      if (notifyIfDoesntExist) {
+        notifier.warn(`Folder ${builder} doesn't have a package.json`)
+      }
+
+      return null
+    }
+
+    const pkg = new PackageJson(path, notifier)
+    await pkg.init()
+    return pkg
+  }
+
+  content: PackageJsonInterface
+  constructor(public packageJsonPath: string, private notifier?: any) {}
+
+  public async init() {
+    this.content = await readJson(this.packageJsonPath)
+  }
+
+  get name() {
+    return this.content.name ?? ''
+  }
+
+  get version() {
+    return this.content.version ?? ''
+  }
+
+  get dependencies() {
+    return this.content.dependencies ?? {}
+  }
+
+  get devDependencies() {
+    return this.content.devDependencies ?? {}
+  }
+
+  public flushChanges() {
+    return writeJson(this.packageJsonPath, this.content, { spaces: 2 })
+  }
+
+  public flushChangesSync() {
+    return writeJsonSync(this.packageJsonPath, this.content, { spaces: 2 })
+  }
+
+  public changeDepVersionIfUnsatisfied(depName: string, depVersion: string) {
+    this.maybeChangeDepVersionByDepType(depName, depVersion, 'dependencies')
+    this.maybeChangeDepVersionByDepType(depName, depVersion, 'devDependencies')
+  }
+
+  public maybeChangeDepVersionByDepType(
+    depName: string,
+    depVersion: string,
+    depType: 'dependencies' | 'devDependencies'
+  ) {
+    if (
+      this.content[depType]?.[depName] != null &&
+      !PackageJson.versionSatisfiesWithUserPriority(depVersion, this.content[depType][depName])
+    ) {
+      this.notifier?.warn(`Changing ${depName} on ${depType} from ${this.content[depType][depName]} to ${depVersion}`)
+      this.content[depType][depName] = depVersion
+    }
+  }
+
+  public addDependency(depName: string, depVersionOrUrl: string, depType: 'dependencies' | 'devDependencies') {
+    this.content[depType] = {
+      ...this.content[depType],
+      [depName]: depVersionOrUrl,
+    }
+  }
+}

--- a/src/lib/pinnedDependencies.ts
+++ b/src/lib/pinnedDependencies.ts
@@ -1,0 +1,58 @@
+import logger from '../logger'
+import { getAppRoot } from '../manifest'
+import { PackageJson } from './packageJson'
+
+export interface PinnedDeps {
+  common: {
+    [depName: string]: string
+  }
+  builders: {
+    [builder: string]: {
+      [majorLocator: string]: {
+        [depName: string]: string
+      }
+    }
+  }
+}
+
+export const fixBuilderFolderPinnedDeps = async (
+  appRoot: string,
+  builder: string,
+  builderPinnedDeps: Record<string, string>
+) => {
+  const pkgJson = await PackageJson.getBuilderPackageJsonIfExists(appRoot, builder, true, logger)
+  if (!pkgJson) {
+    return
+  }
+
+  const depNames = Object.keys(builderPinnedDeps)
+  depNames.forEach(depName => {
+    const depVersion = builderPinnedDeps[depName]
+    pkgJson.changeDepVersionIfUnsatisfied(depName, depVersion)
+  })
+
+  await pkgJson.flushChanges()
+}
+
+export const fixPinnedDependencies = async (
+  pinnedDeps: PinnedDeps,
+  buildersToFixDeps: string[],
+  manifestBuilders: Record<string, string>
+) => {
+  const appRoot = getAppRoot()
+  await Promise.all(
+    buildersToFixDeps.map((builder: string) => {
+      const builderMajorLocator = manifestBuilders[builder]
+      if (!builderMajorLocator) {
+        return Promise.resolve()
+      }
+
+      const pinnedDepsForBuilder = {
+        ...pinnedDeps.builders[builder]?.[builderMajorLocator],
+        ...pinnedDeps.common,
+      }
+
+      return fixBuilderFolderPinnedDeps(appRoot, builder, pinnedDepsForBuilder)
+    })
+  )
+}

--- a/src/modules/apps/link.ts
+++ b/src/modules/apps/link.ts
@@ -244,6 +244,7 @@ export default async options => {
     await fixPinnedDependencies(pinnedDeps, buildersToRunLocalYarn, manifest.builders)
   } catch (e) {
     log.info('Failed to check for pinned dependencies')
+    log.debug(e)
   }
   // Always run yarn locally for some builders
   map(runYarnIfPathExists, buildersToRunLocalYarn)

--- a/src/modules/apps/testCommand.ts
+++ b/src/modules/apps/testCommand.ts
@@ -1,5 +1,4 @@
 import * as retry from 'async-retry'
-import * as bluebird from 'bluebird'
 import chalk from 'chalk'
 import { concat, map, prop, toPairs } from 'ramda'
 import { createClients } from '../../clients'
@@ -9,7 +8,7 @@ import { toAppLocator } from '../../locator'
 import log from '../../logger'
 import { getAppRoot, getManifest, writeManifestSchema } from '../../manifest'
 import { listenBuild } from '../build'
-import { fixPinnedDependencies, runYarnIfPathExists } from '../utils'
+import { fixPinnedDependencies, PinnedDeps, runYarnIfPathExists } from '../utils'
 import { createLinkConfig, getLinkedFiles, listLocalFiles } from './file'
 import { ProjectUploader } from './ProjectUploader'
 import { pathToFileObject, validateAppAction } from './utils'
@@ -102,9 +101,8 @@ export default async options => {
   const projectUploader = ProjectUploader.getProjectUploader(appId, builder)
 
   try {
-    const aux = await builder.getPinnedDependencies()
-    const pinnedDeps: Map<string, string> = new Map(Object.entries(aux))
-    await bluebird.map(buildersToRunLocalYarn, fixPinnedDependencies(pinnedDeps), { concurrency: 1 })
+    const pinnedDeps: PinnedDeps = await builder.getPinnedDependencies()
+    fixPinnedDependencies(pinnedDeps, manifest.builders)
   } catch (e) {
     log.info('Failed to check for pinned dependencies')
   }

--- a/src/modules/apps/testCommand.ts
+++ b/src/modules/apps/testCommand.ts
@@ -4,11 +4,12 @@ import { concat, map, prop, toPairs } from 'ramda'
 import { createClients } from '../../clients'
 import { getAccount, getEnvironment, getWorkspace } from '../../conf'
 import { CommandError } from '../../errors'
+import { fixPinnedDependencies, PinnedDeps } from '../../lib/pinnedDependencies'
 import { toAppLocator } from '../../locator'
 import log from '../../logger'
 import { getAppRoot, getManifest, writeManifestSchema } from '../../manifest'
 import { listenBuild } from '../build'
-import { fixPinnedDependencies, PinnedDeps, runYarnIfPathExists } from '../utils'
+import { runYarnIfPathExists } from '../utils'
 import { createLinkConfig, getLinkedFiles, listLocalFiles } from './file'
 import { ProjectUploader } from './ProjectUploader'
 import { pathToFileObject, validateAppAction } from './utils'
@@ -102,7 +103,7 @@ export default async options => {
 
   try {
     const pinnedDeps: PinnedDeps = await builder.getPinnedDependencies()
-    fixPinnedDependencies(pinnedDeps, manifest.builders)
+    await fixPinnedDependencies(pinnedDeps, buildersToRunLocalYarn, manifest.builders)
   } catch (e) {
     log.info('Failed to check for pinned dependencies')
   }

--- a/src/modules/tree.ts
+++ b/src/modules/tree.ts
@@ -291,7 +291,7 @@ export default {
   },
   test: {
     description: 'Run your VTEX app unit tests',
-    handler: './apps/test',
+    handler: './apps/testCommand',
     options: [
       {
         description: 'Allow tests with Typescript errors',

--- a/yarn.lock
+++ b/yarn.lock
@@ -6403,10 +6403,10 @@ semver@^6.0.0, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
-semver@~5.3.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
-  integrity sha1-myzl094C0XxgEq0yaqa00M9U+U8=
+semver@~7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.1.1.tgz#29104598a197d6cbe4733eeecbe968f7b43a9667"
+  integrity sha512-WfuG+fl6eh3eZ2qAf6goB7nhiCd7NPXhmyFxigB/TOkQyeLP8w8GsVehvtGNtnNmyboz4TgeK40B1Kbql/8c5A==
 
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -708,6 +708,11 @@
   dependencies:
     "@types/yargs-parser" "*"
 
+"@types/yarnpkg__lockfile@^1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@types/yarnpkg__lockfile/-/yarnpkg__lockfile-1.1.3.tgz#38fb31d82ed07dea87df6bd565721d11979fd761"
+  integrity sha512-mhdQq10tYpiNncMkg1vovCud5jQm+rWeRVz6fxjCJlY6uhDlAn9GnMSmBa2DQwqPf/jS5YR0K/xChDEh1jdOQg==
+
 "@typescript-eslint/eslint-plugin@^2.3.0":
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.10.0.tgz#c4cb103275e555e8a7e9b3d14c5951eb6d431e70"
@@ -796,6 +801,11 @@
   integrity sha512-mB6ceGjpMGz1ZTza8HYnrPGos2mC6So4NhS1PtZ8s4Qt0K7fBiIGhpSxUbQmhwcSWE3no+bYxmI2OL6KuXYmoQ==
   dependencies:
     tslib "^1.9.3"
+
+"@yarnpkg/lockfile@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"
+  integrity sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==
 
 abab@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
#### What is the purpose of this pull request?
Scope pinned dependencies by builder.

This change requires https://github.com/vtex/builder-hub/pull/823

#### What problem is this solving?
With new runtime 6 we would like to force `@vtex/api` on version `^6.0.0`.

#### How should this be manually tested?
Link this builder-hub branch:
```
git clone git@github.com:vtex/builder-hub.git && \
cd builder-hub && \
git checkout feat/scoped-pinned-dependencies && \
vtex link --verbose
```
Use this toolbelt branch:
```
git clone https://github.com/vtex/toolbelt.git && \
cd toolbelt && \
git checkout  feat/scoped-pinned-deps && \
yarn && yarn global add file:$PWD
```

- Go to a project and change node/react typescript version. After `vtex link` or `vtex test` the version should be pinned to `3.7.3`.

- Go to a project with node@4.x. Change the `@vtex/api` version on the node's `package.json` and `vtex link` or `vtex test`. The version should be pinned to `^3.0.0`.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
