### PR TITLE
Add publish confirm prompt and how to update toolbelt on builder-hub's update request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add update method to builder hub's error requesting to update toolbelt
+- Add confirm prompt on `vtex publish`
 
 ## [2.81.4] - 2019-12-23
 ### Added

--- a/src/modules/apps/link.ts
+++ b/src/modules/apps/link.ts
@@ -321,6 +321,10 @@ export default async options => {
           )}) to be able to link apps`
         )
       }
+
+      if(data.code === 'bad_toolbelt_version') {
+        return log.error(`${data.message} To update just run ${chalk.bold.green('yarn global add vtex')}.`)
+      }
     }
     throw e
   }

--- a/src/modules/apps/publish.ts
+++ b/src/modules/apps/publish.ts
@@ -124,6 +124,18 @@ const publisher = (workspace: string = 'master') => {
 export default async (path: string, options) => {
   log.debug(`Starting to publish app in ${conf.getEnvironment()}`)
 
+  const manifest = await ManifestEditor.getManifestEditor()
+  const versionMsg = chalk.bold.yellow(manifest.version)
+  const appNameMsg = chalk.bold.yellow(`${manifest.vendor}.${manifest.name}`)
+  const confirmVersion = await promptConfirm(
+    `Are you sure that you want to release version ${chalk.bold(`${versionMsg} of ${appNameMsg}?`)}`,
+    false
+  )
+
+  if (!confirmVersion) {
+    process.exit(1)
+  }
+
   const response = await promptConfirm(
     chalk.yellow.bold(
       `Starting January 2, 2020, the 'vtex publish' command will change its behavior and more steps will be added to the publishing process. Read more about this change here: https://vtex.io/docs/releases/2019-week-47-48-49-50-51/publish-command. Acknowledged?`


### PR DESCRIPTION
#### How should this be manually tested?
Install this branch:
```
git clone https://github.com/vtex/toolbelt.git && \
cd toolbelt && \
git checkout  chore/improve-update-message && \
yarn && yarn global add file:$PWD
```

Try to link - builder-hub will throw an error because of the version.
Try to publish and check for the new prompt 

#### Screenshots or example usage
![Screenshot from 2019-12-27 12-15-50](https://user-images.githubusercontent.com/26463288/71522260-acf87b00-28a2-11ea-9362-ece3b8204048.png)

![Screenshot from 2019-12-27 12-23-31](https://user-images.githubusercontent.com/26463288/71522521-c5b56080-28a3-11ea-9930-139984360cbb.png)


#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
