### PR TITLE
Refactor `vtex unlink`. Use ManifestEditor class on `vtex link`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Refactor
 - Refactor `vtex add`
+- Refactor `vtex unlink`
+- Use `ManifestEditor` on `vtex link`
 
 ### Deprecate
 - Deprecate `vtex validate` command in favor of `vtex deploy`

--- a/src/lib/manifest/ManifestEditor.ts
+++ b/src/lib/manifest/ManifestEditor.ts
@@ -85,11 +85,12 @@ export class ManifestEditor {
     return writeJson(this.path, this.manifest, { spaces: 2 })
   }
 
-  public async writeSchema() {
-    const json = await readJson(this.path)
-    if (!json.$schema || json.$schema !== ManifestEditor.MANIFEST_SCHEMA) {
-      json.$schema = ManifestEditor.MANIFEST_SCHEMA
+  public async writeSchema(): Promise<void> {
+    if (!this.manifest.$schema || this.manifest.$schema !== ManifestEditor.MANIFEST_SCHEMA) {
+      this.manifest.$schema = ManifestEditor.MANIFEST_SCHEMA
     }
+
+    return this.flushChanges()
   }
 
   public addDependency(app: string, version: string): Promise<void> {

--- a/src/lib/manifest/ManifestEditor.ts
+++ b/src/lib/manifest/ManifestEditor.ts
@@ -86,7 +86,7 @@ export class ManifestEditor {
   }
 
   public async writeSchema(): Promise<void> {
-    if (!this.manifest.$schema || this.manifest.$schema !== ManifestEditor.MANIFEST_SCHEMA) {
+    if (this.manifest.$schema !== ManifestEditor.MANIFEST_SCHEMA) {
       this.manifest.$schema = ManifestEditor.MANIFEST_SCHEMA
     }
 

--- a/src/lib/manifest/ManifestEditor.ts
+++ b/src/lib/manifest/ManifestEditor.ts
@@ -68,6 +68,10 @@ export class ManifestEditor {
     return this.manifest.builders
   }
 
+  public get builderNames() {
+    return Object.keys(this.manifest.builders)
+  }
+
   public get appLocator() {
     const { vendor, name, version } = this.manifest
     return `${vendor}.${name}@${version}`

--- a/src/modules/apps/debugger.ts
+++ b/src/modules/apps/debugger.ts
@@ -1,9 +1,9 @@
 import * as streamToString from 'get-stream'
 import * as net from 'net'
 import * as WebSocket from 'ws'
-
 import { getAccount, getToken, getWorkspace } from '../../conf'
 import { region } from '../../env'
+import { ManifestEditor } from '../../lib/manifest'
 import { toMajorRange } from '../../locator'
 import log from '../../logger'
 
@@ -90,7 +90,7 @@ function webSocketTunnelHandler(host, path: string): (socket: net.Socket) => voi
 }
 
 export default function startDebuggerTunnel(
-  manifest: Manifest,
+  manifest: ManifestEditor,
   port: number = DEFAULT_DEBUGGER_PORT
 ): Promise<number | void> {
   const { name, vendor, version, builders } = manifest

--- a/src/modules/apps/link.ts
+++ b/src/modules/apps/link.ts
@@ -12,7 +12,7 @@ import { createClients } from '../../clients'
 import { getAccount, getEnvironment, getWorkspace } from '../../conf'
 import { CommandError } from '../../errors'
 import { ManifestEditor } from '../../lib/manifest'
-import { default as log, default as logger } from '../../logger'
+import log from '../../logger'
 import { getAppRoot } from '../../manifest'
 import { listenBuild } from '../build'
 import { default as setup } from '../setup'
@@ -86,7 +86,7 @@ const watchAndSendChanges = async (
       })
     } catch (err) {
       if (err instanceof ChangeSizeLimitError) {
-        logger.error(err.message)
+        log.error(err.message)
         process.exit(1)
       }
       onInitialLinkRequired(err)

--- a/src/modules/apps/utils.ts
+++ b/src/modules/apps/utils.ts
@@ -12,6 +12,7 @@ import { CommandError, UserCancelledError } from '../../errors'
 import { ManifestEditor } from '../../lib/manifest'
 import log from '../../logger'
 import { promptConfirm } from '../prompts'
+import { ManifestEditor } from '../../lib/manifest'
 
 export const pathToFileObject = (root = process.cwd(), prefix: string = '') => (path: string): BatchStream => {
   const realAbsolutePath = join(root, path)
@@ -231,7 +232,7 @@ const promptConfirmName = (msg: string): Promise<string> =>
     })
     .then<string>(prop('appName'))
 
-export async function showBuilderHubMessage(message: string, showPrompt: boolean, manifest: Manifest) {
+export async function showBuilderHubMessage(message: string, showPrompt: boolean, manifest: ManifestEditor) {
   if (message) {
     if (showPrompt) {
       const confirmMsg = `Are you absolutely sure?\n${

--- a/src/modules/apps/utils.ts
+++ b/src/modules/apps/utils.ts
@@ -12,7 +12,6 @@ import { CommandError, UserCancelledError } from '../../errors'
 import { ManifestEditor } from '../../lib/manifest'
 import log from '../../logger'
 import { promptConfirm } from '../prompts'
-import { ManifestEditor } from '../../lib/manifest'
 
 export const pathToFileObject = (root = process.cwd(), prefix: string = '') => (path: string): BatchStream => {
   const realAbsolutePath = join(root, path)


### PR DESCRIPTION
#### How should this be manually tested?

Install this toolbelt branch:

```
git clone https://github.com/vtex/toolbelt.git && \
cd toolbelt && \
git checkout refactor/unlink && \
yarn && yarn global add file:$PWD
```

```
// Same project link and unlink
git clone https://github.com/vtex-apps/checkout-summary.git && cd checkout-summary
vtex link --verbose
vtex list
vtex unlink --verbose
vtex list

// Many project unlinks
vtex unlink --verbose vtex.checkout-summary@0.x vtex.builder-hub@0.x
```

Apparently many project unlinks aren't working, even on the current stable version. I'm suspecting it's an Apps issue.

#### Types of changes
- [X] Refactor
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.