### PR TITLE
Refactor yarn linked modules sending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,21 +5,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Refactor
+- Yarn linked modules files sending.
 
 ## [2.85.0] - 2020-01-16
 ### Added
-- Create an OS notification when an link dies (except for windows systems)
+- Create an OS notification when an link dies (except for windows systems).
 
 ### Fixed
-- Short circuit bad toolbelt version error when linking
+- Short circuit bad toolbelt version error when linking.
 
 ### Changed
-- Add dependencies pinned by builder-hub scoped by builder
+- Add dependencies pinned by builder-hub scoped by builder.
 
 ## [2.84.1] - 2020-01-13
 ### Fixed
-- Debug logs on linked apps now are printed on verbose mode
-- Post publish message now notifies about `vtex deploy` instead of `vtex validate`
+- Debug logs on linked apps now are printed on verbose mode.
+- Post publish message now notifies about `vtex deploy` instead of `vtex validate`.
 
 ## [2.84.0] - 2020-01-13
 ### Added

--- a/src/lib/files/ProjectFilesManager.ts
+++ b/src/lib/files/ProjectFilesManager.ts
@@ -1,0 +1,75 @@
+import { createReadStream, lstat, readFileSync, statSync } from 'fs-extra'
+import * as glob from 'globby'
+import { join } from 'path'
+import { reject } from 'ramda'
+
+export const pathToFileObject = (root: string, prefix: string = '') => {
+  return (path: string): BatchStream => {
+    const realAbsolutePath = join(root, path)
+    const stats = statSync(realAbsolutePath)
+    return {
+      path: join(prefix, path),
+      content: createReadStream(realAbsolutePath),
+      byteSize: stats.size,
+    }
+  }
+}
+
+export class ProjectFilesManager {
+  public static DEFAULT_IGNORED_FILES = [
+    '.DS_Store',
+    'README.md',
+    '.gitignore',
+    'package.json',
+    'node_modules/**',
+    '**/node_modules/**',
+    '.git/**',
+  ]
+
+  private static isTestOrMockPath = (path: string) => {
+    return /.*(test|mock|snapshot).*/.test(path.toLowerCase())
+  }
+
+  public root: string
+  constructor(projectRoot: string) {
+    this.root = projectRoot
+  }
+
+  private getIgnoredPaths(test: boolean = false): string[] {
+    try {
+      const filesToIgnore = readFileSync(join(this.root, '.vtexignore'))
+        .toString()
+        .split('\n')
+        .map(path => path.trim())
+        .filter(path => path !== '')
+        .map(path => path.replace(/\/$/, '/**'))
+        .concat(ProjectFilesManager.DEFAULT_IGNORED_FILES)
+      return test ? reject(ProjectFilesManager.isTestOrMockPath, filesToIgnore) : filesToIgnore
+    } catch (e) {
+      return ProjectFilesManager.DEFAULT_IGNORED_FILES
+    }
+  }
+
+  public async getLocalFiles(test: boolean = false): Promise<string[]> {
+    const files: string[] = await glob(['manifest.json', 'policies.json', 'node/.*', 'react/.*'], {
+      cwd: this.root,
+      follow: true,
+      ignore: this.getIgnoredPaths(test),
+      nodir: true,
+    })
+
+    const filesStats = Promise.all(
+      files.map(async file => {
+        const stats = await lstat(join(this.root, file))
+        return { file, stats }
+      })
+    )
+
+    return filesStats.reduce((acc, { file, stats }) => {
+      if (stats.size > 0) {
+        acc.push(file)
+      }
+      return acc
+    }, [])
+  }
+}

--- a/src/lib/files/ProjectFilesManager.ts
+++ b/src/lib/files/ProjectFilesManager.ts
@@ -3,7 +3,7 @@ import * as glob from 'globby'
 import { join } from 'path'
 import { reject } from 'ramda'
 
-export const pathToFileObject = (root: string, prefix: string = '') => {
+export const createPathToFileObject = (root: string, prefix = '') => {
   return (path: string): BatchStream => {
     const realAbsolutePath = join(root, path)
     const stats = statSync(realAbsolutePath)
@@ -16,7 +16,7 @@ export const pathToFileObject = (root: string, prefix: string = '') => {
 }
 
 export class ProjectFilesManager {
-  public static DEFAULT_IGNORED_FILES = [
+  private static readonly DEFAULT_IGNORED_FILES = [
     '.DS_Store',
     'README.md',
     '.gitignore',
@@ -35,7 +35,7 @@ export class ProjectFilesManager {
     this.root = projectRoot
   }
 
-  private getIgnoredPaths(test: boolean = false): string[] {
+  private getIgnoredPaths(test = false): string[] {
     try {
       const filesToIgnore = readFileSync(join(this.root, '.vtexignore'))
         .toString()
@@ -50,7 +50,7 @@ export class ProjectFilesManager {
     }
   }
 
-  public async getLocalFiles(test: boolean = false): Promise<string[]> {
+  public async getLocalFiles(test = false): Promise<string[]> {
     const files: string[] = await glob(['manifest.json', 'policies.json', 'node/.*', 'react/.*'], {
       cwd: this.root,
       follow: true,
@@ -58,7 +58,7 @@ export class ProjectFilesManager {
       nodir: true,
     })
 
-    const filesStats = Promise.all(
+    const filesStats = await Promise.all(
       files.map(async file => {
         const stats = await lstat(join(this.root, file))
         return { file, stats }

--- a/src/lib/files/YarnFilesManager.ts
+++ b/src/lib/files/YarnFilesManager.ts
@@ -2,7 +2,7 @@ import * as glob from 'globby'
 import { join, resolve } from 'path'
 import { PassThrough } from 'stream'
 import log from '../../logger'
-import { pathToFileObject } from './ProjectFilesManager'
+import { createPathToFileObject } from './ProjectFilesManager'
 import { YarnSymlinkedModulesConfig } from './YarnLinkedFilesConfig'
 
 const stringToStream = (str: string) => {
@@ -12,7 +12,7 @@ const stringToStream = (str: string) => {
 }
 
 export class YarnFilesManager {
-  private static LINKED_YARN_MODULES_IGNORED_FILES = [
+  private static readonly LINKED_YARN_MODULES_IGNORED_FILES = [
     '.DS_Store',
     'README.md',
     '.gitignore',
@@ -20,6 +20,12 @@ export class YarnFilesManager {
     'node_modules/**',
     '**/node_modules/**',
   ]
+
+  private static readonly BUILDER_HUB_LINKED_DEPS_DIR = '.linked_deps'
+  private static readonly BUILDER_HUB_LINKED_DEPS_CONFIG_PATH = join(
+    YarnFilesManager.BUILDER_HUB_LINKED_DEPS_DIR,
+    '.config'
+  )
 
   public static async createFilesManager(projectSrc: string) {
     const yarnLinkedModulesConfig = await YarnSymlinkedModulesConfig.createConfig(projectSrc)
@@ -32,7 +38,9 @@ export class YarnFilesManager {
       ignore: YarnFilesManager.LINKED_YARN_MODULES_IGNORED_FILES,
       nodir: true,
     })
-    return files.map(pathToFileObject(path, join('.linked_deps', npmModule))) as BatchStream[]
+    return files.map(
+      createPathToFileObject(path, join(YarnFilesManager.BUILDER_HUB_LINKED_DEPS_DIR, npmModule))
+    ) as BatchStream[]
   }
 
   constructor(private linkConfig: YarnSymlinkedModulesConfig) {}
@@ -57,30 +65,32 @@ export class YarnFilesManager {
       return acc.concat(...moduleFiles)
     }, [])
 
-    if (npmModulesFiles.length > 0) {
-      const configJson = this.linkConfig.toJson()
-      npmModulesFiles.push({
-        path: join('.linked_deps', '.config'),
-        content: stringToStream(configJson),
-        byteSize: Buffer.byteLength(configJson),
-      } as BatchStream)
+    if (npmModulesFiles.length === 0) {
+      return []
     }
+
+    const configJson = this.linkConfig.toJson()
+    npmModulesFiles.push({
+      path: YarnFilesManager.BUILDER_HUB_LINKED_DEPS_CONFIG_PATH,
+      content: stringToStream(configJson),
+      byteSize: Buffer.byteLength(configJson),
+    } as BatchStream)
 
     return npmModulesFiles
   }
 
   public logSymlinkedDependencies() {
     const linkedDeps = this.yarnLinkedDependencies
-    if (linkedDeps.length) {
-      const plural = linkedDeps.length > 1
-      log.info(`The following local dependenc${plural ? 'ies are' : 'y is'} linked to your app:`)
-      linkedDeps.forEach(({ moduleName, path }) => log.info(`${moduleName} (from: ${path})`))
-      log.info(
-        `If you don\'t want ${plural ? 'them' : 'it'} to be used by your vtex app, please unlink ${
-          plural ? 'them' : 'it'
-        }`
-      )
+    if (!linkedDeps.length) {
+      return
     }
+
+    const plural = linkedDeps.length > 1
+    log.info(`The following local dependenc${plural ? 'ies are' : 'y is'} linked to your app:`)
+    linkedDeps.forEach(({ moduleName, path }) => log.info(`${moduleName} (from: ${path})`))
+    log.info(
+      `If you don't want ${plural ? 'them' : 'it'} to be used by your vtex app, please unlink ${plural ? 'them' : 'it'}`
+    )
   }
 
   public maybeMapLocalYarnLinkedPathToProjectPath = (path: string, projectPath: string) => {
@@ -88,7 +98,10 @@ export class YarnFilesManager {
     const linkedModules = this.yarnLinkedDependencies
     for (const moduleInfo of linkedModules) {
       if (absolutePath.startsWith(moduleInfo.path)) {
-        return absolutePath.replace(moduleInfo.path, join('.linked_deps', moduleInfo.moduleName))
+        return absolutePath.replace(
+          moduleInfo.path,
+          join(YarnFilesManager.BUILDER_HUB_LINKED_DEPS_DIR, moduleInfo.moduleName)
+        )
       }
     }
 

--- a/src/lib/files/YarnFilesManager.ts
+++ b/src/lib/files/YarnFilesManager.ts
@@ -1,0 +1,97 @@
+import * as glob from 'globby'
+import { join, resolve } from 'path'
+import { PassThrough } from 'stream'
+import log from '../../logger'
+import { pathToFileObject } from './ProjectFilesManager'
+import { YarnSymlinkedModulesConfig } from './YarnLinkedFilesConfig'
+
+const stringToStream = (str: string) => {
+  const stream = new PassThrough()
+  stream.end(str)
+  return stream
+}
+
+export class YarnFilesManager {
+  private static LINKED_YARN_MODULES_IGNORED_FILES = [
+    '.DS_Store',
+    'README.md',
+    '.gitignore',
+    'CHANGELOG.md',
+    'node_modules/**',
+    '**/node_modules/**',
+  ]
+
+  public static async createFilesManager(projectSrc: string) {
+    const yarnLinkedModulesConfig = await YarnSymlinkedModulesConfig.createConfig(projectSrc)
+    return new YarnFilesManager(yarnLinkedModulesConfig)
+  }
+
+  private static async getFiles(npmModule: string, path: string) {
+    const files = await glob(['**'], {
+      cwd: path,
+      ignore: YarnFilesManager.LINKED_YARN_MODULES_IGNORED_FILES,
+      nodir: true,
+    })
+    return files.map(pathToFileObject(path, join('.linked_deps', npmModule))) as BatchStream[]
+  }
+
+  constructor(private linkConfig: YarnSymlinkedModulesConfig) {}
+
+  get symlinkedDepsDirs() {
+    return this.linkConfig.symlinkedDepsDirs
+  }
+
+  get yarnLinkedDependencies() {
+    return this.linkConfig.symlinkedDependencies
+  }
+
+  public async getYarnLinkedFiles(): Promise<BatchStream[]> {
+    const npmModules = this.linkConfig.symlinkedModules
+    const filesPerNpmModule = await Promise.all(
+      npmModules.map(npmModule => {
+        return YarnFilesManager.getFiles(npmModule, this.linkConfig.metadata[npmModule])
+      })
+    )
+
+    const npmModulesFiles = filesPerNpmModule.reduce((acc, moduleFiles) => {
+      return acc.concat(...moduleFiles)
+    }, [])
+
+    if (npmModulesFiles.length > 0) {
+      const configJson = this.linkConfig.toJson()
+      npmModulesFiles.push({
+        path: join('.linked_deps', '.config'),
+        content: stringToStream(configJson),
+        byteSize: Buffer.byteLength(configJson),
+      } as BatchStream)
+    }
+
+    return npmModulesFiles
+  }
+
+  public logSymlinkedDependencies() {
+    const linkedDeps = this.yarnLinkedDependencies
+    if (linkedDeps.length) {
+      const plural = linkedDeps.length > 1
+      log.info(`The following local dependenc${plural ? 'ies are' : 'y is'} linked to your app:`)
+      linkedDeps.forEach(({ moduleName, path }) => log.info(`${moduleName} (from: ${path})`))
+      log.info(
+        `If you don\'t want ${plural ? 'them' : 'it'} to be used by your vtex app, please unlink ${
+          plural ? 'them' : 'it'
+        }`
+      )
+    }
+  }
+
+  public maybeMapLocalYarnLinkedPathToProjectPath = (path: string, projectPath: string) => {
+    const absolutePath = resolve(projectPath, path)
+    const linkedModules = this.yarnLinkedDependencies
+    for (const moduleInfo of linkedModules) {
+      if (absolutePath.startsWith(moduleInfo.path)) {
+        return absolutePath.replace(moduleInfo.path, join('.linked_deps', moduleInfo.moduleName))
+      }
+    }
+
+    return absolutePath
+  }
+}

--- a/src/lib/files/YarnLinkedFilesConfig.ts
+++ b/src/lib/files/YarnLinkedFilesConfig.ts
@@ -1,0 +1,134 @@
+import { lstat, readdir, realpath, Stats } from 'fs-extra'
+import * as glob from 'globby'
+import { dirname, join } from 'path'
+import { partition, unnest } from 'ramda'
+import log from '../../logger'
+
+const isScopedDirOrLink = (path: string, stats: Stats) => {
+  return stats != null && ((path.startsWith('@') && stats.isDirectory()) || stats.isSymbolicLink())
+}
+
+const isLink = (_: string, stats: Stats) => {
+  return stats != null && stats.isSymbolicLink()
+}
+
+export class YarnSymlinkedModulesConfig {
+  public static async createConfig(projectSrc: string) {
+    const conf = new YarnSymlinkedModulesConfig(projectSrc)
+    await conf.init()
+    return conf
+  }
+
+  private stack = []
+  private graph: Record<string, string[]> = {}
+  private _metadata: Record<string, string> = {}
+
+  constructor(private projectSrc: string) {}
+
+  get metadata() {
+    return this._metadata
+  }
+
+  get symlinkedDepsDirs() {
+    return Object.values(this.metadata)
+  }
+
+  get symlinkedModules() {
+    return Object.keys(this.metadata)
+  }
+
+  get symlinkedDependencies() {
+    return Object.keys(this.metadata).map((moduleName: string) => {
+      return {
+        moduleName,
+        path: this.metadata[moduleName],
+      }
+    })
+  }
+
+  public async init() {
+    const allPackageJsonsFolders = (await glob([join('*', 'package.json')], { cwd: this.projectSrc })).map(dirname)
+    this.stack.push(...allPackageJsonsFolders)
+    while (this.stack.length > 0) {
+      const moduleFolder = this.stack.pop()
+      const dependencies = await this.discoverDependencies(moduleFolder, this.projectSrc)
+      this.graph[moduleFolder] = dependencies
+      this.addSubDependenciesToStack(dependencies)
+    }
+  }
+
+  public toJson() {
+    return JSON.stringify({
+      metadata: this.metadata,
+      graph: this.graph,
+    })
+  }
+
+  private async discoverDependencies(currentModule: string, projectSrc: string): Promise<string[]> {
+    const path = currentModule in this._metadata ? this._metadata[currentModule] : join(projectSrc, currentModule)
+    const depsRoot = join(path, 'node_modules')
+    const submodules = await this.getAllLinkedModules(depsRoot)
+    const realPaths = await Promise.all(
+      submodules.map((submoduleName: string) => this.getModuleRealPath(submoduleName, depsRoot))
+    )
+
+    return realPaths.map(this.addModuleMetadata)
+  }
+
+  private async getModuleRealPath(moduleName: string, depsRoot: string): Promise<[string, string]> {
+    return [moduleName, await realpath(join(depsRoot, ...moduleName.split('/')))]
+  }
+
+  private async getAllLinkedModules(root: string): Promise<string[]> {
+    try {
+      const npmDirs = await this.getDirs(root, isScopedDirOrLink)
+      const [scopedDirectories, regularModules] = partition(dir => dir.startsWith('@'), npmDirs)
+      const modulesPerScope = await Promise.all(
+        scopedDirectories.map((scopedDir: string) => this.getLinkedScopedModules(root, scopedDir))
+      )
+
+      return [...regularModules, ...unnest(modulesPerScope)]
+    } catch (err) {
+      return []
+    }
+  }
+
+  private async getLinkedScopedModules(root: string, scopedDir: string) {
+    const dirs = await this.getDirs(join(root, scopedDir), isLink)
+    return dirs.map(dir => `${scopedDir}/${dir}`)
+  }
+
+  private async getDirs(root: string, isWantedPath: (path: string, stats: Stats) => boolean): Promise<string[]> {
+    const nullifyInvalidAndUnwantedPaths = async (path: string) => {
+      try {
+        const stats = await lstat(join(root, path))
+        return isWantedPath(path, stats) ? path : null
+      } catch (err) {
+        return null
+      }
+    }
+
+    const allDirs = await readdir(root)
+    const validAndNullDirs = await Promise.all(allDirs.map(nullifyInvalidAndUnwantedPaths))
+    return validAndNullDirs.filter(dir => dir != null)
+  }
+
+  private addSubDependenciesToStack(deps: string[]) {
+    for (const dep of deps) {
+      if (dep in this.graph) {
+        continue
+      }
+      this.stack.push(dep)
+      this.graph[dep] = []
+    }
+  }
+
+  private addModuleMetadata = ([moduleName, path]): string => {
+    if (moduleName in this._metadata && this._metadata[moduleName] !== path) {
+      log.warn(`Found ${moduleName} from two sources as linked dependencies. Ignoring the one from ${path}`)
+    } else {
+      this._metadata[moduleName] = path
+    }
+    return moduleName
+  }
+}

--- a/src/modules/apps/file.ts
+++ b/src/modules/apps/file.ts
@@ -1,13 +1,10 @@
 import * as Bluebird from 'bluebird'
 import * as chokidar from 'chokidar'
-import { createReadStream, lstat, readdir, readFileSync, realpath, Stats } from 'fs-extra'
+import { createReadStream, lstat, readFileSync } from 'fs-extra'
 import * as glob from 'globby'
-import { dirname, join, resolve as resolvePath, sep } from 'path'
-import { filter, map, partition, reject, toPairs, unnest, values } from 'ramda'
-
-import { Readable } from 'stream'
+import { join, resolve as resolvePath, sep } from 'path'
+import { reject } from 'ramda'
 import log from '../../logger'
-import { pathToFileObject } from './utils'
 
 type AnyFunction = (...args: any[]) => any
 
@@ -28,112 +25,6 @@ const safeFolder = folder => {
     log.warn('Using unknown service', folder)
   }
   return folder ? './' + folder + '/**' : '*/**'
-}
-
-const mapAsync = <I, O>(f: (datum: I) => Promise<O>) => (data: I[]) => Promise.map(data, f) as Promise<O[]>
-
-function getDirs(root: string, predicate: (path: string, stat: Stats) => string): Promise<string[]> {
-  const nullInvalidPaths = (path: string) =>
-    lstat(join(root, path))
-      .catch(() => null)
-      .then(stat => (predicate(path, stat) ? path : null))
-  return readdir(root)
-    .then(mapAsync(nullInvalidPaths))
-    .then(dirs => filter(dir => dir != null, dirs)) as Promise<string[]>
-}
-
-const getLinkedNodeModules = async (root: string): Promise<string[]> => {
-  const isNamespaceOrLink = (path, stat) =>
-    stat != null && ((path.startsWith('@') && stat.isDirectory()) || stat.isSymbolicLink())
-  const isLink = (_, stat) => stat != null && stat.isSymbolicLink()
-
-  const [namespaces, modules] = (await getDirs(root, isNamespaceOrLink)
-    .catch(() => [])
-    .then(partition(dir => dir.startsWith('@')))) as [string[], string[]]
-
-  const getNamespaceLinks = namespace =>
-    getDirs(join(root, namespace), isLink).then(map(dir => [namespace, dir].join('/')))
-
-  const namespaceModules = (await Promise.map(namespaces, getNamespaceLinks).then(unnest)) as string[]
-
-  return [...modules, ...namespaceModules]
-}
-
-export async function createLinkConfig(appSrc: string): Promise<LinkConfig> {
-  const stack = []
-  const graph: Record<string, string[]> = {}
-  const metadata: Record<string, string> = {}
-
-  const app = await glob([join('*', 'package.json')], { cwd: appSrc }).then(map(dirname))
-
-  function checkLinks(deps: string[]) {
-    for (const dep of deps) {
-      if (dep in graph) {
-        continue
-      }
-      stack.push(dep)
-      graph[dep] = []
-    }
-  }
-
-  function discoverDependencies(module: string): Promise<string[]> {
-    const path = module in metadata ? metadata[module] : join(appSrc, module)
-    const depsRoot = join(path, 'node_modules')
-    const moduleRealPath = async (moduleName: string): Promise<[string, string]> => [
-      moduleName,
-      await realpath(join(depsRoot, ...moduleName.split('/'))),
-    ]
-
-    return getLinkedNodeModules(depsRoot)
-      .then(mapAsync(moduleRealPath))
-      .then(map(addMetadata)) as Promise<string[]>
-  }
-
-  function addMetadata([moduleName, path]): string {
-    if (moduleName in metadata && metadata[moduleName] !== path) {
-      log.warn(`Found ${moduleName} from two sources as linked dependencies. Ignoring the one from ${path}`)
-    } else {
-      metadata[moduleName] = path
-    }
-    return moduleName
-  }
-
-  stack.push(...app)
-  while (stack.length > 0) {
-    const module = stack.pop()
-    const dependencies = await discoverDependencies(module)
-    graph[module] = dependencies
-    checkLinks(dependencies)
-  }
-
-  return { metadata, graph }
-}
-
-export async function getLinkedFiles(linkConfig: LinkConfig): Promise<BatchStream[]> {
-  const ignore = ['.DS_Store', 'README.md', '.gitignore', 'CHANGELOG.md', 'node_modules/**', '**/node_modules/**']
-  const getFiles = async ([module, path]) => {
-    return (await glob(['**'], { cwd: path, ignore, nodir: true }).then(
-      map(pathToFileObject(path, join('.linked_deps', module)))
-    )) as BatchStream[]
-  }
-
-  const linkedModulesFiles = unnest(await Promise.map(toPairs(linkConfig.metadata), getFiles))
-  if (linkedModulesFiles.length > 0) {
-    linkedModulesFiles.push(jsonToStream(join('.linked_deps', '.config'), linkConfig))
-  }
-  return linkedModulesFiles
-}
-
-function jsonToStream(path: string, linkConfig: LinkConfig): BatchStream {
-  const stream = new Readable()
-  const json = JSON.stringify(linkConfig)
-  stream.push(JSON.stringify(linkConfig))
-  stream.push(null) // EOF
-  return { path, content: stream, byteSize: Buffer.byteLength(json) }
-}
-
-export function getLinkedDepsDirs(linkConfig: LinkConfig): string[] {
-  return values(linkConfig.metadata)
 }
 
 const isTestOrMockPath = (p: string) => /.*(test|mock|snapshot).*/.test(p.toLowerCase())

--- a/src/modules/apps/link.ts
+++ b/src/modules/apps/link.ts
@@ -10,7 +10,7 @@ import { createInterface } from 'readline'
 import { createClients } from '../../clients'
 import { getAccount, getEnvironment, getWorkspace } from '../../conf'
 import { CommandError } from '../../errors'
-import { pathToFileObject } from '../../lib/files/ProjectFilesManager'
+import { createPathToFileObject } from '../../lib/files/ProjectFilesManager'
 import { YarnFilesManager } from '../../lib/files/YarnFilesManager'
 import { ManifestEditor } from '../../lib/manifest'
 import { fixPinnedDependencies, PinnedDeps } from '../../lib/pinnedDependencies'
@@ -158,7 +158,7 @@ const performInitialLink = async (
   const linkApp = async (bail: any, tryCount: number) => {
     // wrapper for builder.linkApp to be used with the retry function below.
     const [localFiles, linkedFiles] = await Promise.all([
-      listLocalFiles(root).then(paths => map(pathToFileObject(root), paths)),
+      listLocalFiles(root).then(paths => map(createPathToFileObject(root), paths)),
       yarnFilesManager.getYarnLinkedFiles(),
     ])
     const filesWithContent = concat(localFiles, linkedFiles) as BatchStream[]

--- a/src/modules/apps/link.ts
+++ b/src/modules/apps/link.ts
@@ -5,11 +5,13 @@ import * as debounce from 'debounce'
 import { readFileSync } from 'fs'
 import * as moment from 'moment'
 import { join, resolve as resolvePath, sep } from 'path'
-import { concat, intersection, isEmpty, map, pipe, prop, toPairs } from 'ramda'
+import { concat, intersection, isEmpty, map, pipe, prop } from 'ramda'
 import { createInterface } from 'readline'
 import { createClients } from '../../clients'
 import { getAccount, getEnvironment, getWorkspace } from '../../conf'
 import { CommandError } from '../../errors'
+import { pathToFileObject } from '../../lib/files/ProjectFilesManager'
+import { YarnFilesManager } from '../../lib/files/YarnFilesManager'
 import { ManifestEditor } from '../../lib/manifest'
 import { fixPinnedDependencies, PinnedDeps } from '../../lib/pinnedDependencies'
 import log from '../../logger'
@@ -18,9 +20,9 @@ import { listenBuild } from '../build'
 import { default as setup } from '../setup'
 import { formatNano, runYarnIfPathExists } from '../utils'
 import startDebuggerTunnel from './debugger'
-import { createLinkConfig, getIgnoredPaths, getLinkedDepsDirs, getLinkedFiles, listLocalFiles } from './file'
+import { getIgnoredPaths, listLocalFiles } from './file'
 import { ChangeSizeLimitError, ChangeToSend, ProjectSizeLimitError, ProjectUploader } from './ProjectUploader'
-import { checkBuilderHubMessage, pathToFileObject, showBuilderHubMessage, validateAppAction } from './utils'
+import { checkBuilderHubMessage, showBuilderHubMessage, validateAppAction } from './utils'
 
 let nodeNotifier
 if (process.platform !== 'win32') {
@@ -53,7 +55,7 @@ const shouldStartDebugger = (manifest: ManifestEditor) => {
 const warnAndLinkFromStart = (
   projectUploader: ProjectUploader,
   unsafe: boolean,
-  extraData: { linkConfig: LinkConfig } = { linkConfig: null }
+  extraData: { yarnFilesManager: YarnFilesManager } = { yarnFilesManager: null }
 ) => {
   log.warn('Initial link requested by builder')
   performInitialLink(projectUploader, extraData, unsafe)
@@ -63,7 +65,7 @@ const warnAndLinkFromStart = (
 const watchAndSendChanges = async (
   appId: string,
   projectUploader: ProjectUploader,
-  extraData: { linkConfig: LinkConfig },
+  { yarnFilesManager }: { yarnFilesManager: YarnFilesManager },
   unsafe: boolean
 ): Promise<any> => {
   const changeQueue: ChangeToSend[] = []
@@ -71,13 +73,13 @@ const watchAndSendChanges = async (
   const onInitialLinkRequired = e => {
     const data = e.response && e.response.data
     if (data && data.code && data.code === 'initial_link_required') {
-      return warnAndLinkFromStart(projectUploader, unsafe, extraData)
+      return warnAndLinkFromStart(projectUploader, unsafe, { yarnFilesManager })
     }
     throw e
   }
 
   const defaultPatterns = ['*/**', 'manifest.json', 'policies.json']
-  const linkedDepsPatterns = map(path => join(path, '**'), getLinkedDepsDirs(extraData.linkConfig))
+  const linkedDepsPatterns = map(path => join(path, '**'), yarnFilesManager.symlinkedDepsDirs)
 
   const queueChange = (path: string, remove?: boolean) => {
     console.log(`${chalk.gray(moment().format('HH:mm:ss:SSS'))} - ${remove ? DELETE_SIGN : UPDATE_SIGN} ${path}`)
@@ -114,19 +116,10 @@ const watchAndSendChanges = async (
     }
   }
 
-  const moduleAndMetadata = toPairs(extraData.linkConfig.metadata)
-
-  const mapLocalToBuiderPath = path => {
-    const abs = resolvePath(root, path)
-    for (const [module, modulePath] of moduleAndMetadata as any) {
-      if (abs.startsWith(modulePath)) {
-        return abs.replace(modulePath, join('.linked_deps', module))
-      }
-    }
-    return path
-  }
-
-  const pathModifier = pipe(mapLocalToBuiderPath, path => path.split(sep).join('/'))
+  const pathModifier = pipe(
+    (path: string) => yarnFilesManager.maybeMapLocalYarnLinkedPathToProjectPath(path, root),
+    path => path.split(sep).join('/')
+  )
 
   const addIgnoreNodeModulesRule = (paths: Array<string | ((path: string) => boolean)>) =>
     paths.concat((path: string) => path.includes('node_modules'))
@@ -155,30 +148,18 @@ const watchAndSendChanges = async (
 
 const performInitialLink = async (
   projectUploader: ProjectUploader,
-  extraData: { linkConfig: LinkConfig },
+  extraData: { yarnFilesManager: YarnFilesManager },
   unsafe: boolean
 ): Promise<void> => {
-  const linkConfig = await createLinkConfig(root)
-
-  extraData.linkConfig = linkConfig
-
-  const usedDeps = toPairs(linkConfig.metadata)
-  if (usedDeps.length) {
-    const plural = usedDeps.length > 1
-    log.info(`The following local dependenc${plural ? 'ies are' : 'y is'} linked to your app:`)
-    usedDeps.forEach(([dep, path]) => log.info(`${dep} (from: ${path})`))
-    log.info(
-      `If you don\'t want ${plural ? 'them' : 'it'} to be used by your vtex app, please unlink ${
-        plural ? 'them' : 'it'
-      }`
-    )
-  }
+  const yarnFilesManager = await YarnFilesManager.createFilesManager(root)
+  extraData.yarnFilesManager = yarnFilesManager
+  yarnFilesManager.logSymlinkedDependencies()
 
   const linkApp = async (bail: any, tryCount: number) => {
     // wrapper for builder.linkApp to be used with the retry function below.
     const [localFiles, linkedFiles] = await Promise.all([
       listLocalFiles(root).then(paths => map(pathToFileObject(root), paths)),
-      getLinkedFiles(linkConfig),
+      yarnFilesManager.getYarnLinkedFiles(),
     ])
     const filesWithContent = concat(localFiles, linkedFiles) as BatchStream[]
 
@@ -303,7 +284,7 @@ export default async options => {
   log.info(`Linking app ${appId}`)
 
   let unlistenBuild
-  const extraData = { linkConfig: null }
+  const extraData = { yarnFilesManager: null }
   try {
     const buildTrigger = performInitialLink.bind(this, projectUploader, extraData, unsafe)
     const [subject] = appId.split('@')

--- a/src/modules/apps/publish.ts
+++ b/src/modules/apps/publish.ts
@@ -6,7 +6,7 @@ import { isEmpty, map } from 'ramda'
 import * as conf from '../../conf'
 import { region } from '../../env'
 import { UserCancelledError } from '../../errors'
-import { pathToFileObject } from '../../lib/files/ProjectFilesManager'
+import { createPathToFileObject } from '../../lib/files/ProjectFilesManager'
 import { ManifestEditor } from '../../lib/manifest'
 import { toAppLocator } from '../../locator'
 import log from '../../logger'
@@ -24,7 +24,7 @@ const buildersToRunLocalYarn = ['node', 'react']
 
 const automaticTag = (version: string): string => (version.indexOf('-') > 0 ? null : 'latest')
 
-const publisher = (workspace: string = 'master') => {
+const publisher = (workspace = 'master') => {
   const publishApp = async (
     appRoot: string,
     tag: string,
@@ -38,7 +38,7 @@ const publisher = (workspace: string = 'master') => {
       factor: 2,
     }
     const publish = async (_, tryCount) => {
-      const filesWithContent = map(pathToFileObject(appRoot), paths)
+      const filesWithContent = map(createPathToFileObject(appRoot), paths)
       if (tryCount === 1) {
         log.debug('Sending files:', '\n' + paths.join('\n'))
       }

--- a/src/modules/apps/publish.ts
+++ b/src/modules/apps/publish.ts
@@ -6,6 +6,8 @@ import { isEmpty, map } from 'ramda'
 import * as conf from '../../conf'
 import { region } from '../../env'
 import { UserCancelledError } from '../../errors'
+import { pathToFileObject } from '../../lib/files/ProjectFilesManager'
+import { ManifestEditor } from '../../lib/manifest'
 import { toAppLocator } from '../../locator'
 import log from '../../logger'
 import { getAppRoot } from '../../manifest'
@@ -15,8 +17,7 @@ import { promptConfirm } from '../prompts'
 import { runYarnIfPathExists, switchToPreviousAccount } from '../utils'
 import { listLocalFiles } from './file'
 import { ProjectUploader } from './ProjectUploader'
-import { checkBuilderHubMessage, pathToFileObject, showBuilderHubMessage } from './utils'
-import { ManifestEditor } from '../../lib/manifest'
+import { checkBuilderHubMessage, showBuilderHubMessage } from './utils'
 
 const root = getAppRoot()
 const buildersToRunLocalYarn = ['node', 'react']

--- a/src/modules/apps/testCommand.ts
+++ b/src/modules/apps/testCommand.ts
@@ -4,7 +4,7 @@ import { concat, map, prop } from 'ramda'
 import { createClients } from '../../clients'
 import { getAccount, getEnvironment, getWorkspace } from '../../conf'
 import { CommandError } from '../../errors'
-import { pathToFileObject } from '../../lib/files/ProjectFilesManager'
+import { createPathToFileObject } from '../../lib/files/ProjectFilesManager'
 import { YarnFilesManager } from '../../lib/files/YarnFilesManager'
 import { fixPinnedDependencies, PinnedDeps } from '../../lib/pinnedDependencies'
 import { toAppLocator } from '../../locator'
@@ -36,7 +36,7 @@ const performTest = async (
   const testApp = async (bail: any, tryCount: number) => {
     const test = true
     const [localFiles, linkedFiles] = await Promise.all([
-      listLocalFiles(root, test).then(paths => map(pathToFileObject(root), paths)),
+      listLocalFiles(root, test).then(paths => map(createPathToFileObject(root), paths)),
       yarnFilesManager.getYarnLinkedFiles(),
     ])
     const filesWithContent = concat(localFiles, linkedFiles) as BatchStream[]

--- a/src/modules/apps/utils.ts
+++ b/src/modules/apps/utils.ts
@@ -2,8 +2,6 @@ import axios from 'axios'
 import chalk from 'chalk'
 import * as Table from 'cli-table2'
 import * as enquirer from 'enquirer'
-import { createReadStream, statSync } from 'fs-extra'
-import { join } from 'path'
 import { compose, concat, contains, curry, drop, head, last, prop, propSatisfies, reduce, split, tail, __ } from 'ramda'
 import * as semverDiff from 'semver-diff'
 import { apps, createClients, workspaces } from '../../clients'
@@ -12,16 +10,6 @@ import { CommandError, UserCancelledError } from '../../errors'
 import { ManifestEditor } from '../../lib/manifest'
 import log from '../../logger'
 import { promptConfirm } from '../prompts'
-
-export const pathToFileObject = (root = process.cwd(), prefix: string = '') => (path: string): BatchStream => {
-  const realAbsolutePath = join(root, path)
-  const stats = statSync(realAbsolutePath)
-  return {
-    path: join(prefix, path),
-    content: createReadStream(realAbsolutePath),
-    byteSize: stats.size,
-  }
-}
 
 const workspaceExampleName = process.env.USER || 'example'
 

--- a/src/typings/global.d.ts
+++ b/src/typings/global.d.ts
@@ -153,9 +153,4 @@ declare global {
     hostname: string | undefined
     score: number
   }
-
-  interface LinkConfig {
-    metadata: Record<string, string>
-    graph: Record<string, string[]>
-  }
 }


### PR DESCRIPTION
#### How should this be manually tested?

Install this toolbelt branch:

```
git clone https://github.com/vtex/toolbelt.git && \
cd toolbelt && \
git checkout refactor/yarn-linked-modules-management && \
yarn && yarn global add file:$PWD
```

Clone the two packages that will be used to test `yarn link`:
```
git clone git@github.com:tiagonapoli/test-pkg-a.git
git clone git@github.com:tiagonapoli/test-pkg-b.git
```

Clone the app that will be used to test:
```
git clone git@github.com:tiagonapoli/service-example.git && \
cd service-example && \
git checkout test/linked-npm-modules
```

Test `vtex link --verbose` and `vtex test --verbose` with this scenarios (maybe more that you think of):
- No modules yarn-linked
- One module yarn-linked - change the yarn-linked module files to check if the `vtex link` watcher works
- Two modules yarn-linked - change the yarn-linked module files to check if the `vtex link` watcher works

Note: To yarn-link a module, go to the module folder and run `yarn link`, then go to the `app/node` folder and run `yarn link moduleName`
For these tests you'll need the following:
```
yarn link @tiagonapoli/test-pkg-a
yarn unlink @tiagonapoli/test-pkg-a

yarn link @tiagonapoli/test-pkg-b
yarn unlink @tiagonapoli/test-pkg-b
```

You should check the files names sent to builder-hub logged by toolbelt to make sure that they are correct.

#### Types of changes
- [X] Refactor
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
