### PR TITLE
Fix publish docs URL and warn about 'vtex validate' on publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Use url shortener for new publish process docs url
+
+### Added
+- Message after `vtex publish` regarding new `vtex validate` command
 
 ## [2.82.0] - 2019-12-30
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.82.1] - 2020-01-02
 ### Fixed
 - Use url shortener for new publish process docs url
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.82.0",
+  "version": "2.82.1",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/modules/apps/publish.ts
+++ b/src/modules/apps/publish.ts
@@ -108,6 +108,7 @@ const publisher = (workspace: string = 'master') => {
         )
       } else {
         spinner.succeed(`${appId} was published successfully!`)
+        log.info(`You can validate it with: ${chalk.blueBright(`vtex validate ${appId}`)}`)
       }
     } catch (e) {
       spinner.fail(`Failed to publish ${appId}`)

--- a/src/modules/apps/publish.ts
+++ b/src/modules/apps/publish.ts
@@ -138,7 +138,7 @@ export default async (path: string, options) => {
 
   const response = await promptConfirm(
     chalk.yellow.bold(
-      `Starting January 2, 2020, the 'vtex publish' command will change its behavior and more steps will be added to the publishing process. Read more about this change here: https://vtex.io/docs/releases/2019-week-47-48-49-50-51/publish-command. Acknowledged?`
+      `Starting January 2, 2020, the 'vtex publish' command will change its behavior and more steps will be added to the publishing process. Read more about this change on the following link:\nhttp://bit.ly/2ZIJucc\nAcknowledged?`
     ),
     false
   )


### PR DESCRIPTION
If the terminal truncated the previous URL and the user clicked to open it, the URL copied to the browser could be incomplete. Using a shortener may solve the problem

#### How should this be manually tested?

```
git clone https://github.com/vtex/toolbelt.git && \
cd toolbelt && \
git checkout fix/publish-url && \
yarn && yarn global add file:$PWD
```

Try to publish any app. The new publish process prompt will show up - then test the link.

#### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
