### PR TITLE
Improve unhandled request errors logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.83.1] - 2020-01-07
+
 ### Changed
 - Debug response headers on unhandled errors when available
 - Log request url and method on unhandled errors when `request.status` is available and is `4xx` or `5xx`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Debug response headers on unhandled errors when available
+- Log request url and method on unhandled errors when `request.status` is available and is `4xx` or `5xx`
+
 ## [2.83.0] - 2020-01-07
 ### Fixed
 - Typo on message requesting to change account when validating
@@ -14,10 +18,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Log url for auth-sse
 - `VTEX_CLUSTER` env variable now specifies which cluster will be used
 - `vtex config set cluster` and `vtex config get cluster` are now available and specify the cluster to be used
-
-### Changed
-- Change Colossus endpoint used by SSE
-
 
 ## [2.82.1] - 2020-01-02
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.83.0",
+  "version": "2.83.1",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -127,6 +127,10 @@ const onError = e => {
       const source = e.config.url
       log.error('API:', status, statusText)
       log.error('Source:', source)
+      if (e.config?.method) {
+        log.error('Method:', e.config.method)
+      }
+
       if (message) {
         log.error('Message:', message)
         log.debug('Raw error:', data)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -100,8 +100,13 @@ const main = async () => {
 const onError = e => {
   const status = e?.response?.status
   const statusText = e?.response?.statusText
+  const headers = e?.response?.headers
   const data = e?.response?.data
   const code = e?.code || null
+
+  if (headers) {
+    log.debug('Failed request headers:', headers)
+  }
 
   if (status) {
     if (status === 401) {
@@ -116,15 +121,15 @@ const onError = e => {
         return // Prevent multiple login attempts
       }
     }
+
     if (status >= 400) {
       const message = data ? data.message : null
       const source = e.config.url
       log.error('API:', status, statusText)
+      log.error('Source:', source)
       if (message) {
         log.error('Message:', message)
-        if (isVerbose) {
-          log.debug('Raw error:', data)
-        }
+        log.debug('Raw error:', data)
       } else {
         log.error('Raw error:', {
           data,
@@ -174,7 +179,7 @@ const onError = e => {
       default:
         log.error('Unhandled exception')
         log.error('Please report the issue in https://github.com/vtex/toolbelt/issues')
-        log.error(e)
+        log.error('Raw error:', e)
     }
   }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
- Log request url on unhandled errors when request.status is available and is 4xx or 5xx
- Debug response headers on unhandled errors when available - when the user doesn't run the command with `--verbose` it will be available on `vtex_debug.json`.

#### Types of changes
- [X] Chore
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
