### PR TITLE
Log url for auth-sse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Typo on message requesting to change account when validating
 
+### Added
+- Log url for auth-sse
+
 ## [2.82.1] - 2020-01-02
 ### Fixed
 - Use url shortener for new publish process docs url

--- a/src/sse.ts
+++ b/src/sse.ts
@@ -1,8 +1,7 @@
 import chalk from 'chalk'
-import { compose, forEach, contains, path, pathOr } from 'ramda'
-
+import { compose, contains, forEach, path, pathOr } from 'ramda'
 import { getToken } from './conf'
-import { endpoint, publicEndpoint, envCookies } from './env'
+import { endpoint, envCookies, publicEndpoint } from './env'
 import { SSEConnectionError } from './errors'
 import EventSource from './eventsource'
 import { removeVersion } from './locator'
@@ -163,7 +162,8 @@ export const onAuth = (
   state: string,
   returnUrl: string
 ): Promise<[string, string]> => {
-  const source = `https://${workspace}--${account}.${publicEndpoint()}/_v//private/auth-server/v1/sse/${state}`
+  const source = `https://${workspace}--${account}.${publicEndpoint()}/_v/private/auth-server/v1/sse/${state}`
+  log.debug(`Listening for auth events from: ${source}`)
   const es = createEventSource(source)
   return new Promise((resolve, reject) => {
     es.onmessage = (msg: MessageJSON) => {
@@ -174,7 +174,8 @@ export const onAuth = (
 
     es.onerror = event => {
       es.close()
-      reject(new SSEConnectionError(`Connection to login server has failed with status ${event.status}`, event.status))
+      const errMessage = 'Connection to login server has failed' + (event.status ? ` with status ${event.status}` : '')
+      reject(new SSEConnectionError(errMessage, event.status))
     }
   })
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
- Log url for auth-sse

#### How should this be manually tested?
```
git clone https://github.com/vtex/toolbelt.git && \
cd toolbelt && \
git checkout chore/log-event-server-url && \
yarn && yarn global add file:$PWD
```
Try to `vtex login --verbose` - it will debug the auth-sse URL 

#### Types of changes
- [X] Chore
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
