### PR TITLE
Fix promptConfirm overwriting last line on `vtex validate`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Typo on message requesting to change account when validating
 
+### Added
+- Log url for auth-sse
+
 ## [2.82.1] - 2020-01-02
 ### Fixed
 - Use url shortener for new publish process docs url

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.82.1] - 2020-01-02
 ### Fixed
 - Use url shortener for new publish process docs url
+- Fix promptConfirm overwriting last line on `vtex validate`
 
 ### Added
 - Message after `vtex publish` regarding new `vtex validate` command

--- a/src/modules/apps/validate.ts
+++ b/src/modules/apps/validate.ts
@@ -20,6 +20,7 @@ const switchToVendorMessage = (vendor: string): string => {
 const promptValidate = (app: string): Bluebird<boolean> => promptConfirm(`Are you sure you want to validate app ${app}`)
 
 const switchToPreviousAccount = async (previousAccount: string, previousWorkspace: string) => {
+  process.stdout.write('\n')
   const currentAccount = getAccount()
   if (previousAccount !== currentAccount) {
     const canSwitchToPrevious = await promptConfirm(switchAccountMessage(previousAccount, currentAccount))

--- a/src/sse.ts
+++ b/src/sse.ts
@@ -1,12 +1,11 @@
 import chalk from 'chalk'
-import { compose, forEach, contains, path, pathOr } from 'ramda'
-
+import { compose, contains, forEach, path, pathOr } from 'ramda'
 import { getToken } from './conf'
-import { endpoint, publicEndpoint, envCookies } from './env'
+import { endpoint, envCookies, publicEndpoint } from './env'
 import { SSEConnectionError } from './errors'
 import EventSource from './eventsource'
 import { removeVersion } from './locator'
-import log from './logger'
+import { default as log, default as logger } from './logger'
 import userAgent from './user-agent'
 import { isVerbose } from './utils'
 
@@ -163,7 +162,8 @@ export const onAuth = (
   state: string,
   returnUrl: string
 ): Promise<[string, string]> => {
-  const source = `https://${workspace}--${account}.${publicEndpoint()}/_v//private/auth-server/v1/sse/${state}`
+  const source = `https://${workspace}--${account}.${publicEndpoint()}/_v/private/auth-server/v1/sse/${state}`
+  logger.debug(`Listening for auth events from: ${source}`)
   const es = createEventSource(source)
   return new Promise((resolve, reject) => {
     es.onmessage = (msg: MessageJSON) => {
@@ -174,7 +174,8 @@ export const onAuth = (
 
     es.onerror = event => {
       es.close()
-      reject(new SSEConnectionError(`Connection to login server has failed with status ${event.status}`, event.status))
+      const errMessage = 'Connection to login server has failed' + (event.status ? ` with status ${event.status}` : '')
+      reject(new SSEConnectionError(errMessage, event.status))
     }
   })
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
- Fix promptConfirm overwriting last line on `vtex validate`

#### How should this be manually tested?
```
git clone https://github.com/vtex/toolbelt.git && \
cd toolbelt && \
git checkout chore/log-when-app-is-validated && \
yarn && yarn global add file:$PWD
```
Try to `vtex validate vtex.builder-hub@0.192.4` from an account that differs from `vtex`. It should log a message that the app was successfully validated.

Try to `vtex validate vtex.builder-hub@0.192.4` from account `vtex`. It should log a message that the app was successfully validated.

#### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
