### PR TITLE
Fix: Escape `git add` filepath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Spawn of `git add` on paths with special chars
 
 ## [2.83.1] - 2020-01-07
 
@@ -61,7 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ### Removed
-- Remove unnused client 
+- Remove unnused client
 
 ## [2.80.1] - 2019-12-16
 ### Fixed
@@ -94,7 +96,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New command to validate a published app
 
 ### Fixed
-- Use vtex/api on undeprecate request instead of axios 
+- Use vtex/api on undeprecate request instead of axios
 
 ## [2.78.6] - 2019-12-04
 ### Refactor

--- a/src/modules/release/utils.ts
+++ b/src/modules/release/utils.ts
@@ -185,10 +185,10 @@ export const postRelease = () => {
 }
 
 export const add = () => {
-  let gitAddCommand = `git add ${versionFile}`
+  let gitAddCommand = `git add "${versionFile}"`
   let successMessage = `File ${versionFile} added`
   if (existsSync(changelogPath)) {
-    gitAddCommand += ` ${changelogPath}`
+    gitAddCommand += ` "${changelogPath}"`
     successMessage = `Files ${versionFile} ${changelogPath} added`
   }
   return runCommand(gitAddCommand, successMessage, true)


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix a bug that occurs primarily on Windows when running `vtex release` if the some path has special chars like spaces eg: `C:\Users\Julio Moreira\foo\bar`.

#### How should this be manually tested?
Run `vtex release` on some directory that has spaces on it.

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/1207017/71921766-3abc4c00-3168-11ea-8e93-3b2ef170922d.png)

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
