### PR TITLE
Add account name on master confirmation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Displays account name when confirming actions on master workspace.
+
 ### Refactor
 - Refactor `vtex add`
 

--- a/src/modules/apps/utils.ts
+++ b/src/modules/apps/utils.ts
@@ -51,9 +51,11 @@ export const parseArgs = (args: string[]): string[] => {
   return drop(1, args)
 }
 
-export const promptWorkspaceMaster = async () => {
+export const promptWorkspaceMaster = async account => {
   const confirm = await promptConfirm(
-    `Are you sure you want to force this operation on the ${chalk.green('master')} workspace?`,
+    `Are you sure you want to force this operation on the ${chalk.green(
+      'master'
+    )} workspace on the account ${chalk.blue(account)}?`,
     false
   )
   if (!confirm) {
@@ -70,7 +72,7 @@ export const validateAppAction = async (operation: string, app?) => {
     if (!contains(operation, workspaceMasterAllowedOperations)) {
       throw new CommandError(workspaceMasterMessage)
     } else {
-      await promptWorkspaceMaster()
+      await promptWorkspaceMaster(account)
     }
   }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
Displays account name when confirming actions on master workspace.

Before:
<img width="393" alt="Screen Shot 2020-01-08 at 14 55 50" src="https://user-images.githubusercontent.com/5691711/72003444-25a6f200-3228-11ea-8d0a-289a5040d597.png">

After:
<img width="440" alt="Screen Shot 2020-01-08 at 15 01 25" src="https://user-images.githubusercontent.com/5691711/72003460-2f305a00-3228-11ea-9ef3-afe93a6a0e82.png">


#### What problem is this solving?
<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
