### PR TITLE
Deprecate vtex validate and use vtex deploy instead

### DIFF
--- a/src/modules/apps/deploy.ts
+++ b/src/modules/apps/deploy.ts
@@ -4,11 +4,11 @@ import { createClients } from '../../clients'
 import { getAccount, getToken, getWorkspace } from '../../conf'
 import { UserCancelledError } from '../../errors'
 import { ManifestValidator } from '../../lib/manifest'
+import { parseLocator, toAppLocator } from '../../locator'
 import log from '../../logger'
 import { getManifest } from '../../manifest'
 import switchAccount from '../auth/switch'
 import { promptConfirm } from '../prompts'
-import { parseLocator, toAppLocator } from './../../locator'
 import { switchAccountMessage } from './utils'
 
 const switchToVendorMessage = (vendor: string): string => {
@@ -17,7 +17,7 @@ const switchToVendorMessage = (vendor: string): string => {
   )}?`
 }
 
-const promptValidate = (app: string): Bluebird<boolean> => promptConfirm(`Are you sure you want to deploy app ${app}`)
+const promptDeploy = (app: string): Bluebird<boolean> => promptConfirm(`Are you sure you want to deploy app ${app}`)
 
 const switchToPreviousAccount = async (previousAccount: string, previousWorkspace: string) => {
   const currentAccount = getAccount()
@@ -45,7 +45,7 @@ const deployRelease = async (app: string): Promise<void> => {
   return await registry.validateApp(`${vendor}.${name}`, version)
 }
 
-const prepareValidate = async (app, originalAccount, originalWorkspace: string): Promise<void> => {
+const prepareDeploy = async (app, originalAccount, originalWorkspace: string): Promise<void> => {
   app = await ManifestValidator.validateApp(app)
   try {
     log.debug('Starting to deploy app:', app)
@@ -71,9 +71,9 @@ export default async (optionalApp: string, options) => {
   const originalWorkspace = getWorkspace()
   const app = optionalApp || toAppLocator(await getManifest())
 
-  if (!preConfirm && !(await promptValidate(app))) {
+  if (!preConfirm && !(await promptDeploy(app))) {
     throw new UserCancelledError()
   }
   log.debug(`Deploying app ${app}`)
-  return prepareValidate(app, originalAccount, originalWorkspace)
+  return prepareDeploy(app, originalAccount, originalWorkspace)
 }

--- a/src/modules/apps/deploy.ts
+++ b/src/modules/apps/deploy.ts
@@ -1,0 +1,79 @@
+import * as Bluebird from 'bluebird'
+import chalk from 'chalk'
+import { createClients } from '../../clients'
+import { getAccount, getToken, getWorkspace } from '../../conf'
+import { UserCancelledError } from '../../errors'
+import { ManifestValidator } from '../../lib/manifest'
+import log from '../../logger'
+import { getManifest } from '../../manifest'
+import switchAccount from '../auth/switch'
+import { promptConfirm } from '../prompts'
+import { parseLocator, toAppLocator } from './../../locator'
+import { switchAccountMessage } from './utils'
+
+const switchToVendorMessage = (vendor: string): string => {
+  return `You are trying to deploy this app in an account that differs from the indicated vendor. Do you want to deploy in account ${chalk.blue(
+    vendor
+  )}?`
+}
+
+const promptValidate = (app: string): Bluebird<boolean> => promptConfirm(`Are you sure you want to deploy app ${app}`)
+
+const switchToPreviousAccount = async (previousAccount: string, previousWorkspace: string) => {
+  const currentAccount = getAccount()
+  if (previousAccount !== currentAccount) {
+    const canSwitchToPrevious = await promptConfirm(switchAccountMessage(previousAccount, currentAccount))
+    if (canSwitchToPrevious) {
+      return await switchAccount(previousAccount, { workspace: previousWorkspace })
+    }
+  }
+  return
+}
+
+const deployRelease = async (app: string): Promise<void> => {
+  const { vendor, name, version } = parseLocator(app)
+  const account = getAccount()
+  if (vendor !== account) {
+    const canSwitchToVendor = await promptConfirm(switchToVendorMessage(vendor))
+    if (!canSwitchToVendor) {
+      throw new UserCancelledError()
+    }
+    await switchAccount(vendor, {})
+  }
+  const context = { account: vendor, workspace: 'master', authToken: getToken() }
+  const { registry } = createClients(context)
+  return await registry.validateApp(`${vendor}.${name}`, version)
+}
+
+const prepareValidate = async (app, originalAccount, originalWorkspace: string): Promise<void> => {
+  app = await ManifestValidator.validateApp(app)
+  try {
+    log.debug('Starting to deploy app:', app)
+    await deployRelease(app)
+    log.info('Successfully deployed', app)
+  } catch (e) {
+    if (e.response && e.response.status && e.response.status === 404) {
+      log.error(`Error deploying ${app}. App not found or already deployed`)
+    } else if (e.message && e.response.statusText) {
+      log.error(`Error deploying ${app}. ${e.message}. ${e.response.statusText}`)
+      return await switchToPreviousAccount(originalAccount, originalWorkspace)
+    } else {
+      await switchToPreviousAccount(originalAccount, originalWorkspace)
+      throw e
+    }
+  }
+  await switchToPreviousAccount(originalAccount, originalWorkspace)
+}
+
+export default async (optionalApp: string, options) => {
+  const preConfirm = options.y || options.yes
+  const originalAccount = getAccount()
+  const originalWorkspace = getWorkspace()
+  const app = optionalApp || toAppLocator(await getManifest())
+
+  if (!preConfirm && !(await promptValidate(app))) {
+    throw new UserCancelledError()
+  }
+  log.debug(`Deploying app ${app}`)
+  return prepareValidate(app, originalAccount, originalWorkspace)
+}

--- a/src/modules/apps/deploy.ts
+++ b/src/modules/apps/deploy.ts
@@ -52,7 +52,7 @@ const prepareValidate = async (app, originalAccount, originalWorkspace: string):
     await deployRelease(app)
     log.info('Successfully deployed', app)
   } catch (e) {
-    if (e.response && e.response.status && e.response.status === 404) {
+    if (e?.response?.status === 404) {
       log.error(`Error deploying ${app}. App not found or already deployed`)
     } else if (e.message && e.response.statusText) {
       log.error(`Error deploying ${app}. ${e.message}. ${e.response.statusText}`)

--- a/src/modules/apps/validate.ts
+++ b/src/modules/apps/validate.ts
@@ -2,7 +2,10 @@ import chalk from 'chalk'
 import logger from '../../logger'
 
 export default async () => {
-  logger.error(`This command is being deprecated in favor of ${chalk.bold.blue('vtex deploy')}`)
-  logger.warn(`Your app wasn't deployed`)
+  logger.error(
+    `${chalk.bold.red(
+      `Your app was NOT deployed. The command 'vtex validate' is deprecated, please use`
+    )} ${chalk.bold.blue('vtex deploy')} ${chalk.bold.red(`instead.`)}`
+  )
   process.exit(1)
 }

--- a/src/modules/apps/validate.ts
+++ b/src/modules/apps/validate.ts
@@ -1,79 +1,8 @@
-import * as Bluebird from 'bluebird'
 import chalk from 'chalk'
+import logger from '../../logger'
 
-import { createClients } from '../../clients'
-import { getAccount, getToken, getWorkspace } from '../../conf'
-import { UserCancelledError } from '../../errors'
-import log from '../../logger'
-import { getManifest, validateApp } from '../../manifest'
-import switchAccount from '../auth/switch'
-import { promptConfirm } from '../prompts'
-import { parseLocator, toAppLocator } from './../../locator'
-import { switchAccountMessage } from './utils'
-
-const switchToVendorMessage = (vendor: string): string => {
-  return `You are trying to validate this app in an account that differs from the indicated vendor. Do you want to validate in account ${chalk.blue(
-    vendor
-  )}?`
-}
-
-const promptValidate = (app: string): Bluebird<boolean> => promptConfirm(`Are you sure you want to validate app ${app}`)
-
-const switchToPreviousAccount = async (previousAccount: string, previousWorkspace: string) => {
-  const currentAccount = getAccount()
-  if (previousAccount !== currentAccount) {
-    const canSwitchToPrevious = await promptConfirm(switchAccountMessage(previousAccount, currentAccount))
-    if (canSwitchToPrevious) {
-      return await switchAccount(previousAccount, { workspace: previousWorkspace })
-    }
-  }
-  return
-}
-
-const validateRelease = async (app: string): Promise<void> => {
-  const { vendor, name, version } = parseLocator(app)
-  const account = getAccount()
-  if (vendor !== account) {
-    const canSwitchToVendor = await promptConfirm(switchToVendorMessage(vendor))
-    if (!canSwitchToVendor) {
-      throw new UserCancelledError()
-    }
-    await switchAccount(vendor, {})
-  }
-  const context = { account: vendor, workspace: 'master', authToken: getToken() }
-  const { registry } = createClients(context)
-  return await registry.validateApp(`${vendor}.${name}`, version)
-}
-
-const prepareValidate = async (app, originalAccount, originalWorkspace: string): Promise<void> => {
-  app = await validateApp(app)
-  try {
-    log.debug('Starting to validate app:', app)
-    await validateRelease(app)
-    log.info('Successfully validated', app)
-  } catch (e) {
-    if (e.response && e.response.status && e.response.status === 404) {
-      log.error(`Error validating ${app}. App not found or already validated`)
-    } else if (e.message && e.response.statusText) {
-      log.error(`Error validating ${app}. ${e.message}. ${e.response.statusText}`)
-      return await switchToPreviousAccount(originalAccount, originalWorkspace)
-    } else {
-      await switchToPreviousAccount(originalAccount, originalWorkspace)
-      throw e
-    }
-  }
-  await switchToPreviousAccount(originalAccount, originalWorkspace)
-}
-
-export default async (optionalApp: string, options) => {
-  const preConfirm = options.y || options.yes
-  const originalAccount = getAccount()
-  const originalWorkspace = getWorkspace()
-  const app = optionalApp || toAppLocator(await getManifest())
-
-  if (!preConfirm && !(await promptValidate(app))) {
-    throw new UserCancelledError()
-  }
-  log.debug(`Validating app ${app}`)
-  return prepareValidate(app, originalAccount, originalWorkspace)
+export default async () => {
+  logger.error(`This command is being deprecated in favor of ${chalk.bold.blue('vtex deploy')}`)
+  logger.warn(`Your app wasn't deployed`)
+  process.exit(1)
 }

--- a/src/modules/tree.ts
+++ b/src/modules/tree.ts
@@ -30,8 +30,13 @@ export default {
     ],
   },
   validate: {
-    description: 'Validate a release of an app',
+    description: 'DEPRECATED',
     handler: './apps/validate',
+    optionalArgs: 'app',
+  },
+  deploy: {
+    description: 'Deploy a release of an app',
+    handler: './apps/deploy',
     optionalArgs: 'app',
   },
   deprecate: {


### PR DESCRIPTION
#### What problem is this solving?
`vtex deploy` has much better semantics than `vtex validate`.

#### How should this be manually tested?
Install this branch:
```
git clone https://github.com/vtex/toolbelt.git && \
cd toolbelt && \
git checkout chore/change-validate-to-deploy && \
yarn && yarn global add file:$PWD
```
Run `vtex validate` to check the deprecation message.

To reset to the official toolbelt version just run `yarn global add vtex`

#### Screenshots or example usage
![Screenshot from 2020-01-13 08-54-59](https://user-images.githubusercontent.com/26463288/72255683-2227b800-35e6-11ea-9c69-7105fd80eb0e.png)

#### Types of changes
- [X] Chore
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
