### PR TITLE
Fix post publish message notifying about deprecated 'vtex validate' command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Post publish message now notifies about `vtex deploy` instead of `vtex validate`
 
 ## [2.84.0] - 2020-01-13
 ### Added

--- a/src/modules/apps/publish.ts
+++ b/src/modules/apps/publish.ts
@@ -108,7 +108,7 @@ const publisher = (workspace: string = 'master') => {
         )
       } else {
         spinner.succeed(`${appId} was published successfully!`)
-        log.info(`You can validate it with: ${chalk.blueBright(`vtex validate ${appId}`)}`)
+        log.info(`You can deploy it with: ${chalk.blueBright(`vtex deploy ${appId}`)}`)
       }
     } catch (e) {
       spinner.fail(`Failed to publish ${appId}`)


### PR DESCRIPTION
#### How should this be manually tested?
Install this branch:

```
git clone https://github.com/vtex/toolbelt.git && \
cd toolbelt && \
git checkout fix/post-publish-message && \
yarn && yarn global add file:$PWD
```
Test publishing an app and check the post publish message

#### Screenshots or example usage
![Screenshot from 2020-01-13 15-09-41](https://user-images.githubusercontent.com/26463288/72280294-c4f82a80-3616-11ea-9768-3b555e08012a.png)


#### Types of changes
- [X] Chore
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
