### PR TITLE
Log debug events from linked apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.84.1] - 2020-01-13
 ### Fixed
+- Debug logs on linked apps now are printed on verbose mode
 - Post publish message now notifies about `vtex deploy` instead of `vtex validate`
 
 ## [2.84.0] - 2020-01-13

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -49,17 +49,25 @@ const errorJsonReplacer = (key: any, value: any) => {
   return value
 }
 
+export const consoleLoggerLevel = () => {
+  return isVerbose ? 'debug' : 'info'
+}
+
+export const fileLoggerLevel = () => {
+  return 'debug'
+}
+
 const logger = createLogger({
   format: format.combine(addArgs(), format.timestamp({ format: 'HH:mm:ss.SSS' })),
   transports: [
     new transports.Console({
       format: format.combine(format.colorize(), messageFormatter),
-      level: isVerbose ? 'debug' : 'info',
+      level: consoleLoggerLevel(),
     }),
     new transports.File({
       filename: DEBUG_LOG_FILE_PATH,
       format: format.combine(format.json({ replacer: errorJsonReplacer, space: 2 })),
-      level: 'debug',
+      level: fileLoggerLevel(),
       maxsize: 5e6,
       maxFiles: 2,
     }),
@@ -89,5 +97,7 @@ logger.on('error', err => {
 logger.on('finish', info => {
   console.log(`Logging has finished: ${info}`)
 })
+
+
 
 export default logger

--- a/src/modules/build.ts
+++ b/src/modules/build.ts
@@ -1,6 +1,6 @@
 import { currentContext } from '../conf'
 import { BuildFailError } from '../errors'
-import log from '../logger'
+import log, { fileLoggerLevel } from '../logger'
 import { logAll, onEvent } from '../sse'
 
 interface ListeningOptions {
@@ -29,7 +29,7 @@ const onBuildEvent = (
   callback: (type: BuildEvent, message?: Message) => void,
   senders?: string[]
 ) => {
-  const unlistenLogs = logAll(ctx, log.level, appOrKey, senders)
+  const unlistenLogs = logAll(ctx, fileLoggerLevel(), appOrKey, senders)
   const unlistenBuild = onEvent(ctx, 'vtex.builder-hub', appOrKey, ['build.status'], message =>
     callback('build.status', message)
   )


### PR DESCRIPTION
#### What problem is this solving?
Logs from `ctx.vtex.logger.debug` on linked apps wasn't being logged on toolbelt on verbose mode 

#### How should this be manually tested?
Install this branch:
```
git clone https://github.com/vtex/toolbelt.git && \
cd toolbelt && \
git checkout feat/print-debug-events && \
yarn && yarn global add file:$PWD
```
Link and app in verbose mode and then link an app without verbose mode.

To reset to the official toolbelt version just run `yarn global add vtex`

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
