### PR TITLE
Short circuit bad toolbelt version error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Short circuit bad toolbelt version error when linking
 
 ## [2.84.1] - 2020-01-13
 ### Fixed

--- a/src/modules/apps/link.ts
+++ b/src/modules/apps/link.ts
@@ -193,6 +193,12 @@ const performInitialLink = async (
         process.exit(1)
       }
 
+      const data = err?.response?.data
+      if (data?.code === 'bad_toolbelt_version') {
+        log.error(data.message)
+        process.exit(1)
+      }
+
       if (err.status) {
         const response = err.response
         const status = response.status


### PR DESCRIPTION
#### What problem is this solving?
When builder-hub asks for a new toolbelt version and the toolbelt is on an older version it will respond with an error. Now toolbelt just retries many times until the retry limit, which is annoying. This PR fixes this.

#### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
