### PR TITLE
Create yes flag for 'vtex publish'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `yes` flag to `vtex publish`
+
 ### Refactor
 - Yarn linked modules files sending.
 

--- a/src/modules/apps/publish.ts
+++ b/src/modules/apps/publish.ts
@@ -129,22 +129,32 @@ export default async (path: string, options) => {
   const manifest = await ManifestEditor.getManifestEditor()
   const versionMsg = chalk.bold.yellow(manifest.version)
   const appNameMsg = chalk.bold.yellow(`${manifest.vendor}.${manifest.name}`)
-  const confirmVersion = await promptConfirm(
-    `Are you sure that you want to release version ${chalk.bold(`${versionMsg} of ${appNameMsg}?`)}`,
-    false
-  )
 
-  if (!confirmVersion) {
-    process.exit(1)
+  const yesFlag = options.y || options.yes
+
+  if (!yesFlag) {
+    const confirmVersion = await promptConfirm(
+      `Are you sure that you want to release version ${chalk.bold(`${versionMsg} of ${appNameMsg}?`)}`,
+      false
+    )
+
+    if (!confirmVersion) {
+      process.exit(1)
+    }
+
+    const response = await promptConfirm(
+      chalk.yellow.bold(
+        `Starting January 2, 2020, the 'vtex publish' command will change its behavior and more steps will be added to the publishing process. Read more about this change on the following link:\nhttp://bit.ly/2ZIJucc\nAcknowledged?`
+      ),
+      false
+    )
+    if (!response) {
+      process.exit(1)
+    }
   }
 
-  const response = await promptConfirm(
-    chalk.yellow.bold(
-      `Starting January 2, 2020, the 'vtex publish' command will change its behavior and more steps will be added to the publishing process. Read more about this change on the following link:\nhttp://bit.ly/2ZIJucc\nAcknowledged?`
-    ),
-    false
-  )
-  if (!response) {
+  if (yesFlag && manifest.vendor !== conf.getAccount()) {
+    log.error(`When using the 'yes' flag, you need to be logged in to the same account as your app’s vendor.`)
     process.exit(1)
   }
 

--- a/src/modules/tree.ts
+++ b/src/modules/tree.ts
@@ -258,6 +258,12 @@ export default {
         short: 'f',
         type: 'boolean',
       },
+      {
+        description: 'Answer yes to confirmation prompts',
+        long: 'yes',
+        short: 'y',
+        type: 'boolean',
+      },
     ],
   },
   settings: {


### PR DESCRIPTION
Closes https://github.com/vtex/toolbelt/issues/713

#### What problem is this solving?
`vtex publish` wasn't suitable for using in scripts

#### How should this be manually tested?
```
git clone https://github.com/vtex/toolbelt.git && \
cd toolbelt && \
git checkout feat/publish-yes-flag && \
yarn && yarn global add file:$PWD
```
Try to `vtex publish` an app

To reset the toolbelt version run `yarn global vtex`

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
