### PR TITLE
Execute commands in the host container

### DIFF
--- a/src/clients/runtime.ts
+++ b/src/clients/runtime.ts
@@ -46,8 +46,8 @@ export class Runtime {
       pathname: path,
       query: {
         __v: manifest.majorRange,
-        params: command?.split(' '),
-        interactive,
+        cmd: command?.split(' '),
+        stdin: interactive,
       },
     }
     const formattedUrl = url.format(urlObject)

--- a/src/clients/runtime.ts
+++ b/src/clients/runtime.ts
@@ -19,7 +19,7 @@ export class Runtime {
     this.workspace = workspace
   }
 
-  public executeCommand = async (command: string, interactive: boolean) => {
+  public async executeCommand(command: string, interactive: boolean) {
     const manifest = await ManifestEditor.getManifestEditor()
     const { name, vendor, builders } = manifest
     const { dotnet, node, 'service-js': serviceJs } = builders

--- a/src/clients/runtime.ts
+++ b/src/clients/runtime.ts
@@ -55,13 +55,18 @@ export class Runtime {
     const ws = new WebSocket(formattedUrl, clientOptions)
     const wsDuplexStream = (WebSocket as any).createWebSocketStream(ws, { encoding: 'utf8' })
 
+    wsDuplexStream.on('error', () => {
+      console.log('Connection closed')
+      process.exit(0)
+    })
+
+    wsDuplexStream.pipe(process.stdout)
+
     if (interactive) {
       process.stdin.pipe(wsDuplexStream, { end: false })
       process.stdin.on('end', () => {
         wsDuplexStream.end(EOT)
       })
     }
-
-    wsDuplexStream.pipe(process.stdout)
   }
 }

--- a/src/clients/runtime.ts
+++ b/src/clients/runtime.ts
@@ -1,0 +1,67 @@
+import { IOContext } from '@vtex/api'
+import { ManifestEditor } from '../lib/manifest'
+import { cluster } from '../env'
+import * as url from 'url'
+import * as WebSocket from 'ws'
+import { getToken } from '../conf'
+
+const EOT = '\x04'
+
+export class Runtime {
+  private region: string
+  private account: string
+  private workspace: string
+
+  constructor(context: IOContext) {
+    const { region, account, workspace } = context
+    this.region = region
+    this.account = account
+    this.workspace = workspace
+  }
+
+  public executeCommand = async (command: string, interactive: boolean) => {
+    const manifest = await ManifestEditor.getManifestEditor()
+    const { name, vendor, builders } = manifest
+    const { dotnet, node, 'service-js': serviceJs } = builders
+    if (!dotnet && !node && !serviceJs) {
+      return
+    }
+
+    const host = `${name}.${vendor}.${this.region}.vtex.io`
+    const path = `/${this.account}/${this.workspace}/_exec`
+    const clusterHeader = cluster() ? { 'x-vtex-upstream-target': cluster() } : null
+
+    const clientOptions = {
+      headers: {
+        Authorization: getToken(),
+        Host: host,
+        'X-Vtex-Runtime-Api': 'true',
+        ...clusterHeader,
+      },
+    }
+
+    const urlObject = {
+      protocol: 'ws',
+      hostname: host,
+      pathname: path,
+      query: {
+        __v: manifest.majorRange,
+        params: command?.split(' '),
+        interactive,
+      },
+    }
+    const formattedUrl = url.format(urlObject)
+
+    const ws = new WebSocket(formattedUrl, clientOptions)
+    const wsDuplexStream = (WebSocket as any).createWebSocketStream(ws, { encoding: 'utf8' })
+
+    if (interactive) {
+      process.stdin.pipe(wsDuplexStream, { end: false })
+      process.stdin.on('end', () => {
+        wsDuplexStream.end(EOT)
+      })
+    }
+
+    wsDuplexStream.pipe(process.stdout)
+  }
+}

--- a/src/lib/manifest/ManifestEditor.ts
+++ b/src/lib/manifest/ManifestEditor.ts
@@ -77,6 +77,10 @@ export class ManifestEditor {
     return `${vendor}.${name}@${version}`
   }
 
+  public get majorRange() {
+    return `${this.manifest.version.split('.', 2)[0]}.x`
+  }
+
   public flushChangesSync() {
     return writeJsonSync(this.path, this.manifest, { spaces: 2 })
   }

--- a/src/modules/apps/exec.ts
+++ b/src/modules/apps/exec.ts
@@ -1,0 +1,53 @@
+import * as WebSocket from 'ws'
+import * as url from 'url'
+import { getAccount, getToken, getWorkspace } from '../../conf'
+import { getManifest } from '../../manifest'
+import { region } from '../../env'
+import { toMajorRange } from '../../locator'
+const EOT = '\x04'
+export default async (command: string, options) => {
+  const manifest = await getManifest()
+  const { name, vendor, version, builders } = manifest
+  const { dotnet, node, 'service-js': serviceJs } = builders
+  if (!dotnet && !node && !serviceJs) {
+    return
+  }
+  const majorRange = toMajorRange(version)
+  const host = `${name}.${vendor}.${region()}.vtex.io`
+  const path = `/${getAccount()}/${getWorkspace()}/_exec`
+  const clientOptions = {
+    headers: {
+      Authorization: getToken(),
+      Host: host,
+      'X-Vtex-Runtime-Api': 'true',
+    },
+  }
+  var urlObject = {
+    protocol: 'ws',
+    hostname: host,
+    pathname: path,
+    query: {
+      __v: majorRange,
+      params: command?.split(' '),
+      interactive: options.i || options.interactive,
+    },
+  }
+  const formattedUrl = url.format(urlObject)
+  const ws = new WebSocket(formattedUrl, clientOptions)
+  ws.on('open', function open() {
+    process.stdin.resume()
+    process.stdin.setEncoding('utf8')
+    process.stdin.on('data', function(chunk) {
+      ws.send(chunk)
+    })
+    process.stdin.on('end', function() {
+      ws.send(EOT)
+    })
+  })
+  ws.on('close', function close() {
+    process.exit(0)
+  })
+  ws.on('message', function incoming(data) {
+    process.stdout.write(data.toString())
+  })
+}

--- a/src/modules/apps/exec.ts
+++ b/src/modules/apps/exec.ts
@@ -1,54 +1,7 @@
-import * as WebSocket from 'ws'
-import * as url from 'url'
-import { getAccount, getToken, getWorkspace } from '../../conf'
-import { cluster, region } from '../../env'
-import { ManifestEditor } from '../../lib/manifest'
-
-const EOT = '\x04'
+import { Runtime } from '../../clients/runtime'
+import { getIOContext } from '../utils'
 
 export default async (command: string, options) => {
-  const manifest = await ManifestEditor.getManifestEditor()
-  const { name, vendor, builders } = manifest
-  const { dotnet, node, 'service-js': serviceJs } = builders
-  if (!dotnet && !node && !serviceJs) {
-    return
-  }
-
-  const host = `${name}.${vendor}.${region()}.vtex.io`
-  const path = `/${getAccount()}/${getWorkspace()}/_exec`
-  const clusterHeader = cluster() ? { 'x-vtex-upstream-target': cluster() } : null
-
-  const clientOptions = {
-    headers: {
-      Authorization: getToken(),
-      Host: host,
-      'X-Vtex-Runtime-Api': 'true',
-      ...clusterHeader,
-    },
-  }
-  const interactive = options.i || options.interactive
-
-  const urlObject = {
-    protocol: 'ws',
-    hostname: host,
-    pathname: path,
-    query: {
-      __v: manifest.majorRange,
-      params: command?.split(' '),
-      interactive,
-    },
-  }
-  const formattedUrl = url.format(urlObject)
-
-  const ws = new WebSocket(formattedUrl, clientOptions)
-  const wsDuplexStream = (WebSocket as any).createWebSocketStream(ws, { encoding: 'utf8' })
-
-  if (interactive) {
-    process.stdin.pipe(wsDuplexStream, { end: false })
-    process.stdin.on('end', () => {
-      wsDuplexStream.end(EOT)
-    })
-  }
-
-  wsDuplexStream.pipe(process.stdout)
+  const runtimeClient = new Runtime(getIOContext())
+  await runtimeClient.executeCommand(command, options.i || options.interactive)
 }

--- a/src/modules/tree.ts
+++ b/src/modules/tree.ts
@@ -498,4 +498,17 @@ export default {
       requiredArgs: 'edition',
     },
   },
+  exec: {
+    description: "Execute a command in your backend service's host",
+    handler: './apps/exec',
+    requiredArgs: 'command',
+    options: [
+      {
+        description: 'Pass stdin to the host',
+        long: 'interactive',
+        short: 'i',
+        type: 'boolean',
+      },
+    ],
+  },
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add a new command that allows the user to execute commands in the host container. 

By using this command you are instructing Toolbelt to connect with the host container via WebSockets so it can execute the commands sent by the user (passing the stdin or not). 

#### What problem is this solving?
In order to debug .Net apps, we need a mechanism to execute commands in the host container.

#### How should this be manually tested?
Please see https://github.com/vtex/service-runtime-base/pull/95 for instructions on how to test this PR.

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
