### PR TITLE
Fix vtex infra install creating semver object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Refactor
 - Yarn linked modules files sending.
 
+### Fixed
+- Fix `vtex infra install` creating `semver` object 
+
 ## [2.85.0] - 2020-01-16
 ### Added
 - Create an OS notification when an link dies (except for windows systems).

--- a/src/modules/infra/utils.ts
+++ b/src/modules/infra/utils.ts
@@ -61,8 +61,8 @@ export const getTag = (version: string): string => {
 }
 
 export const diffVersions = (a: string, b: string): [string, string] => {
-  const semverA = semver(a)
-  const semverB = semver(b)
+  const semverA = semver.parse(a)
+  const semverB = semver.parse(b)
   const [aMain, bMain] = diff(
     [semverA.major, semverA.minor, semverA.patch],
     [semverB.major, semverB.minor, semverB.patch]


### PR DESCRIPTION
`vtex infra install sphinx@0.26.0-beta --verbose` is not working

#### How should this be manually tested?
```
git clone https://github.com/vtex/toolbelt.git && \
cd toolbelt && \
git checkout fix/vtex-infra-install && \
yarn && yarn global add file:$PWD
```
Test `vtex infra install sphinx@0.26.0-beta --verbose`

To reset to official version just run `yarn global add vtex`

#### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
