### PR TITLE
Use vtexassets host instead of vteximg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- [vtex setup] Change types urls hosts from `vtex.vteximg.com.br` to `$appVendor.vtexassets.com`
 
 ## [2.86.0] - 2020-01-23
 ### Added

--- a/src/__tests__/fixtures/manifests/index.ts
+++ b/src/__tests__/fixtures/manifests/index.ts
@@ -14,6 +14,7 @@ export const manifestSamples: Record<string, AppManifest> = {
     },
     dependencies: {
       'vtex.admin': '1.x',
+      'storecomponents.test': '1.x',
     },
     policies: [],
     $schema: 'https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema',

--- a/src/__tests__/modules/setup/setupTypings.test.ts
+++ b/src/__tests__/modules/setup/setupTypings.test.ts
@@ -42,9 +42,9 @@ describe('React type dependencies are correctly inserted', () => {
       name: 'mock',
       devDependencies: {
         someApp: '^1.0.0',
-        'vtex.admin': 'http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.admin@1.18.0/public/_types/react',
+        'vtex.admin': 'http://vtex.vtexassets.com/_v/public/typings/v1/vtex.admin@1.18.0/public/_types/react',
         'vtex.render-runtime':
-          'http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.render-runtime@8.1.0/public/_types/react',
+          'http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.1.0/public/_types/react',
       },
     })
     expect(runYarn).toBeCalledTimes(1)
@@ -71,9 +71,9 @@ describe('React type dependencies are correctly inserted', () => {
       name: 'mock',
       devDependencies: {
         someApp: '^1.0.0',
-        'vtex.admin': 'http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.admin@1.18.0/public/@types/vtex.admin',
+        'vtex.admin': 'http://vtex.vtexassets.com/_v/public/typings/v1/vtex.admin@1.18.0/public/@types/vtex.admin',
         'vtex.render-runtime':
-          'http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.render-runtime@8.1.0/public/@types/vtex.render-runtime',
+          'http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.1.0/public/@types/vtex.render-runtime',
       },
     })
     expect(runYarn).toBeCalledTimes(1)
@@ -103,7 +103,7 @@ describe('React type dependencies are correctly inserted', () => {
         'vtex.admin':
           'https://current-workspace--logged-account.public-endpoint/_v/private/typings/linked/v1/vtex.admin@1.18.0+build123/public/_types/react',
         'vtex.render-runtime':
-          'http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.render-runtime@8.1.0/public/_types/react',
+          'http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.1.0/public/_types/react',
       },
     })
     expect(runYarn).toBeCalledTimes(1)
@@ -133,7 +133,7 @@ describe('React type dependencies are correctly inserted', () => {
         'vtex.admin':
           'https://current-workspace--logged-account.public-endpoint/_v/private/typings/linked/v1/vtex.admin@1.18.0+build123/public/@types/vtex.admin',
         'vtex.render-runtime':
-          'http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.render-runtime@8.1.0/public/@types/vtex.render-runtime',
+          'http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.1.0/public/@types/vtex.render-runtime',
       },
     })
     expect(runYarn).toBeCalledTimes(1)
@@ -167,9 +167,9 @@ describe('React type dependencies are correctly inserted', () => {
       name: 'mock',
       devDependencies: {
         someApp: '^1.0.0',
-        'vtex.admin': 'http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.admin@1.15.0/public/@types/vtex.admin',
+        'vtex.admin': 'http://vtex.vtexassets.com/_v/public/typings/v1/vtex.admin@1.15.0/public/@types/vtex.admin',
         'vtex.render-runtime':
-          'http://vtex.vteximg.com.br/_v/public/typings/v1/vtex.render-runtime@8.1.0/public/@types/vtex.render-runtime',
+          'http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.1.0/public/@types/vtex.render-runtime',
       },
     })
     expect(runYarn).toBeCalledTimes(1)

--- a/src/__tests__/modules/setup/setupTypings.test.ts
+++ b/src/__tests__/modules/setup/setupTypings.test.ts
@@ -25,6 +25,7 @@ describe('React type dependencies are correctly inserted', () => {
     setAppsAvailableAppIDs({
       'vtex.admin': { '1.x': 'vtex.admin@1.18.0' },
       'vtex.render-runtime': { '8.x': 'vtex.render-runtime@8.1.0' },
+      'storecomponents.test': { '1.x': 'storecomponents.test@1.0.0' },
     })
 
     setPackageJsonByBuilder({
@@ -42,6 +43,8 @@ describe('React type dependencies are correctly inserted', () => {
       name: 'mock',
       devDependencies: {
         someApp: '^1.0.0',
+        'storecomponents.test':
+          'http://storecomponents.vtexassets.com/_v/public/typings/v1/storecomponents.test@1.0.0/public/_types/react',
         'vtex.admin': 'http://vtex.vtexassets.com/_v/public/typings/v1/vtex.admin@1.18.0/public/_types/react',
         'vtex.render-runtime':
           'http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.1.0/public/_types/react',
@@ -54,6 +57,7 @@ describe('React type dependencies are correctly inserted', () => {
     setAppsAvailableAppIDs({
       'vtex.admin': { '1.x': 'vtex.admin@1.18.0' },
       'vtex.render-runtime': { '8.x': 'vtex.render-runtime@8.1.0' },
+      'storecomponents.test': { '1.x': 'storecomponents.test@1.0.0' },
     })
 
     setPackageJsonByBuilder({
@@ -71,6 +75,8 @@ describe('React type dependencies are correctly inserted', () => {
       name: 'mock',
       devDependencies: {
         someApp: '^1.0.0',
+        'storecomponents.test':
+          'http://storecomponents.vtexassets.com/_v/public/typings/v1/storecomponents.test@1.0.0/public/@types/storecomponents.test',
         'vtex.admin': 'http://vtex.vtexassets.com/_v/public/typings/v1/vtex.admin@1.18.0/public/@types/vtex.admin',
         'vtex.render-runtime':
           'http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.1.0/public/@types/vtex.render-runtime',
@@ -83,6 +89,7 @@ describe('React type dependencies are correctly inserted', () => {
     setAppsAvailableAppIDs({
       'vtex.admin': { '1.x': 'vtex.admin@1.18.0+build123' },
       'vtex.render-runtime': { '8.x': 'vtex.render-runtime@8.1.0' },
+      'storecomponents.test': { '1.x': 'storecomponents.test@1.0.0' },
     })
 
     setPackageJsonByBuilder({
@@ -100,6 +107,8 @@ describe('React type dependencies are correctly inserted', () => {
       name: 'mock',
       devDependencies: {
         someApp: '^1.0.0',
+        'storecomponents.test':
+          'http://storecomponents.vtexassets.com/_v/public/typings/v1/storecomponents.test@1.0.0/public/_types/react',
         'vtex.admin':
           'https://current-workspace--logged-account.public-endpoint/_v/private/typings/linked/v1/vtex.admin@1.18.0+build123/public/_types/react',
         'vtex.render-runtime':
@@ -113,6 +122,7 @@ describe('React type dependencies are correctly inserted', () => {
     setAppsAvailableAppIDs({
       'vtex.admin': { '1.x': 'vtex.admin@1.18.0+build123' },
       'vtex.render-runtime': { '8.x': 'vtex.render-runtime@8.1.0' },
+      'storecomponents.test': { '1.x': 'storecomponents.test@1.0.0' },
     })
 
     setPackageJsonByBuilder({
@@ -130,6 +140,8 @@ describe('React type dependencies are correctly inserted', () => {
       name: 'mock',
       devDependencies: {
         someApp: '^1.0.0',
+        'storecomponents.test':
+          'http://storecomponents.vtexassets.com/_v/public/typings/v1/storecomponents.test@1.0.0/public/@types/storecomponents.test',
         'vtex.admin':
           'https://current-workspace--logged-account.public-endpoint/_v/private/typings/linked/v1/vtex.admin@1.18.0+build123/public/@types/vtex.admin',
         'vtex.render-runtime':
@@ -143,11 +155,13 @@ describe('React type dependencies are correctly inserted', () => {
     setAppsAvailableAppIDs({
       'vtex.admin': { '1.x': 'vtex.admin@1.18.0+build123' },
       'vtex.render-runtime': { '8.x': 'vtex.render-runtime@8.1.0' },
+      'storecomponents.test': { '1.x': 'storecomponents.test@1.0.0' },
     })
 
     setRegistryAvailableAppIDs({
       'vtex.admin': { '1.x': 'vtex.admin@1.15.0' },
       'vtex.render-runtime': { '8.x': 'vtex.render-runtime@8.1.0' },
+      'storecomponents.test': { '1.x': 'storecomponents.test@1.0.0' },
     })
 
     setPackageJsonByBuilder({
@@ -167,6 +181,8 @@ describe('React type dependencies are correctly inserted', () => {
       name: 'mock',
       devDependencies: {
         someApp: '^1.0.0',
+        'storecomponents.test':
+          'http://storecomponents.vtexassets.com/_v/public/typings/v1/storecomponents.test@1.0.0/public/@types/storecomponents.test',
         'vtex.admin': 'http://vtex.vtexassets.com/_v/public/typings/v1/vtex.admin@1.15.0/public/@types/vtex.admin',
         'vtex.render-runtime':
           'http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.1.0/public/@types/vtex.render-runtime',
@@ -184,6 +200,7 @@ test('If yarn fails, package.json is reset to its initial state', async () => {
   setAppsAvailableAppIDs({
     'vtex.admin': { '1.x': 'vtex.admin@1.18.0' },
     'vtex.render-runtime': { '8.x': 'vtex.render-runtime@8.1.0' },
+    'storecomponents.test': { '1.x': 'storecomponents.test@1.0.0' },
   })
 
   setPackageJsonByBuilder({

--- a/src/modules/setup/setupTypings.ts
+++ b/src/modules/setup/setupTypings.ts
@@ -25,7 +25,7 @@ const appTypingsURL = async (appName: string, appMajorLocator: string, ignoreLin
   const base =
     linked && !ignoreLinked
       ? `https://${getWorkspace()}--${getAccount()}.${publicEndpoint()}/_v/private/typings/linked/v1/${appId}/public`
-      : `http://vtex.vtexassets.com/_v/public/typings/v1/${appId}/public`
+      : `http://${vendor}.vtexassets.com/_v/public/typings/v1/${appId}/public`
 
   log.info(`Checking if ${chalk.bold(appId)} has new types format`)
   try {

--- a/src/modules/setup/setupTypings.ts
+++ b/src/modules/setup/setupTypings.ts
@@ -25,7 +25,7 @@ const appTypingsURL = async (appName: string, appMajorLocator: string, ignoreLin
   const base =
     linked && !ignoreLinked
       ? `https://${getWorkspace()}--${getAccount()}.${publicEndpoint()}/_v/private/typings/linked/v1/${appId}/public`
-      : `http://vtex.vteximg.com.br/_v/public/typings/v1/${appId}/public`
+      : `http://vtex.vtexassets.com/_v/public/typings/v1/${appId}/public`
 
   log.info(`Checking if ${chalk.bold(appId)} has new types format`)
   try {


### PR DESCRIPTION
#### What problem is this solving?
`vteximg` host is being deprecated. It's necessary to use `vtexassets` instead.

#### How should this be manually tested?
```
git clone https://github.com/vtex/toolbelt.git && \
cd toolbelt && \
git checkout fix/vtex-setup-urls && \
yarn && yarn global add file:$PWD
```
Run `vtex setup` in an app - check for the types urls on `node/package.json`, `react/package.json` if applicable

#### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
