### PR TITLE
Add deprecation precheck

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Add deprecation precheck
 
 ## [2.87.0] - 2020-01-30
 ### Added

--- a/package.json
+++ b/package.json
@@ -117,7 +117,6 @@
     "eslint": "^6.7.2",
     "eslint-config-vtex": "^11.2.0",
     "jest": "24.9.0",
-    "longjohn": "0.2.12",
     "mkdirp": "0.5.1",
     "npm-run-all": "4.1.5",
     "prettier": "^1.19.1",

--- a/src/CLIPrechecker.ts
+++ b/src/CLIPrechecker.ts
@@ -5,7 +5,7 @@ import { NpmClient } from './clients/npmClient.js'
 
 export class CLIPrechecker {
   private static ensureCompatibleNode() {
-    const nodeVersion = process.version.replace('v', '')
+    const nodeVersion = process.version
     if (!semver.satisfies(nodeVersion, pkg.engines.node)) {
       const minMajor = pkg.engines.node.replace('>=', '')
       console.error(

--- a/src/CLIPrechecker.ts
+++ b/src/CLIPrechecker.ts
@@ -1,0 +1,36 @@
+import chalk from 'chalk'
+import * as semver from 'semver'
+import * as pkg from '../package.json'
+import { NpmClient } from './clients/npmClient.js'
+
+export class CLIPrechecker {
+  private static ensureCompatibleNode() {
+    const nodeVersion = process.version.replace('v', '')
+    if (!semver.satisfies(nodeVersion, pkg.engines.node)) {
+      const minMajor = pkg.engines.node.replace('>=', '')
+      console.error(
+        chalk.bold(`Incompatible with node < v${minMajor}. Please upgrade node to major ${minMajor} or higher.`)
+      )
+
+      process.exit(1)
+    }
+  }
+
+  private static async ensureNotDeprecated() {
+    const { deprecated } = await NpmClient.getPackageMetadata(pkg.name, pkg.version)
+    if (deprecated != null) {
+      console.error(
+        `This version ${pkg.version} was deprecated. Please update to the latest version: ${chalk.green(
+          'yarn global add vtex'
+        )}.`
+      )
+
+      process.exit(1)
+    }
+  }
+
+  public static async runChecks() {
+    this.ensureCompatibleNode()
+    await this.ensureNotDeprecated()
+  }
+}

--- a/src/CLIPrechecker.ts
+++ b/src/CLIPrechecker.ts
@@ -8,27 +8,26 @@ export class CLIPrechecker {
     const nodeVersion = process.version
     if (!semver.satisfies(nodeVersion, pkg.engines.node)) {
       const minMajor = pkg.engines.node.replace('>=', '')
-      console.error(
-        chalk.bold(`Incompatible with node < v${minMajor}. Please upgrade node to major ${minMajor} or higher.`)
+      const errMsg = chalk.bold(
+        `Incompatible with node < v${minMajor}. Please upgrade node to major ${minMajor} or higher.`
       )
 
+      console.error(errMsg)
       process.exit(1)
     }
   }
 
   private static async ensureNotDeprecated() {
     const { deprecated } = await NpmClient.getPackageMetadata(pkg.name, pkg.version)
-    if (deprecated != null) {
-      console.error(
-        chalk.bold(
-          `This version ${pkg.version} was deprecated. Please update to the latest version: ${chalk.green(
-            'yarn global add vtex'
-          )}.`
-        )
-      )
+    if (deprecated == null) return
+    const errMsg = chalk.bold(
+      `This version ${pkg.version} was deprecated. Please update to the latest version: ${chalk.green(
+        'yarn global add vtex'
+      )}.`
+    )
 
-      process.exit(1)
-    }
+    console.error(errMsg)
+    process.exit(1)
   }
 
   public static async runChecks() {

--- a/src/CLIPrechecker.ts
+++ b/src/CLIPrechecker.ts
@@ -20,9 +20,11 @@ export class CLIPrechecker {
     const { deprecated } = await NpmClient.getPackageMetadata(pkg.name, pkg.version)
     if (deprecated != null) {
       console.error(
-        `This version ${pkg.version} was deprecated. Please update to the latest version: ${chalk.green(
-          'yarn global add vtex'
-        )}.`
+        chalk.bold(
+          `This version ${pkg.version} was deprecated. Please update to the latest version: ${chalk.green(
+            'yarn global add vtex'
+          )}.`
+        )
       )
 
       process.exit(1)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -172,10 +172,9 @@ Bluebird.config({
 process.on('unhandledRejection', onError)
 
 CLIPrechecker.runChecks().then(() => {
+  // Show update notification if newer version is available
+  notify()
   try {
-    // Show update notification if newer version is available
-    notify()
-
     main().catch(onError)
   } catch (e) {
     onError(e)

--- a/src/clients/npmClient.ts
+++ b/src/clients/npmClient.ts
@@ -1,0 +1,14 @@
+import axios from 'axios'
+import { PackageJson } from '../lib/packageJson'
+
+interface PackageMetadata extends PackageJson {
+  deprecated?: string
+}
+
+export class NpmClient {
+  private static REGISTRY_BASE_URL = 'http://registry.npmjs.org'
+
+  public static getPackageMetadata(name: string, version: string): Promise<PackageMetadata> {
+    return axios.get(`${this.REGISTRY_BASE_URL}/${name}/${version}`).then(response => response.data)
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4928,13 +4928,6 @@ long@^4.0.0:
   resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
   integrity sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==
 
-longjohn@0.2.12:
-  version "0.2.12"
-  resolved "https://registry.yarnpkg.com/longjohn/-/longjohn-0.2.12.tgz#7ca7446b083655c377e7512213dc754d52a64a7e"
-  integrity sha1-fKdEawg2VcN351EiE9x1TVKmSn4=
-  dependencies:
-    source-map-support "0.3.2 - 1.0.0"
-
 loose-envify@^1.0.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
@@ -6612,14 +6605,6 @@ source-map-resolve@^0.5.0:
     resolve-url "^0.2.1"
     source-map-url "^0.4.0"
     urix "^0.1.0"
-
-"source-map-support@0.3.2 - 1.0.0":
-  version "0.5.9"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.9.tgz#41bc953b2534267ea2d605bccfa7bfa3111ced5f"
-  integrity sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==
-  dependencies:
-    buffer-from "^1.0.0"
-    source-map "^0.6.0"
 
 source-map-support@^0.5.6:
   version "0.5.13"


### PR DESCRIPTION
#### What is the purpose of this pull request?
Installing toolbelt will just warn about the deprecation and will allow installation.

This PR will deactivate the installed version if it's deprecated

#### How should this be manually tested?
```
git clone https://github.com/vtex/toolbelt.git && \
cd toolbelt && \
git checkout fix/check-npm-deprecation && \
yarn && yarn global add file:$PWD
```
Change the version on `package.json` to `2.86.0`:
```
code  $(yarn global dir)/node_modules/vtex/package.json
```
Try to run `vtex whoami` - it will warn about deprecation and close the process.

#### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
