### PR TITLE
Fix bugs when cluster is defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Invalid URLs when `cluster` variable is set.
 
 ## [2.86.1] - 2020-01-24
 ### Fixed

--- a/src/clients/rewriter.ts
+++ b/src/clients/rewriter.ts
@@ -42,7 +42,7 @@ export class Rewriter extends AppGraphQLClient {
   constructor(context: IOContext, options: InstanceOptions) {
     super('vtex.rewriter@1.x', context, {
       ...options,
-      headers: { 'cache-control': 'no-cache' },
+      headers: { ...options.headers, 'cache-control': 'no-cache' },
       retries: 5,
       timeout: 10000,
     })

--- a/src/env.ts
+++ b/src/env.ts
@@ -4,22 +4,24 @@ export function colossusEndpoint() {
   return process.env.VTEX_COLOSSUS_ENDPOINT || `https://infra.io.vtex.com/colossus/v0`
 }
 
-export function region(): string {
-  return process.env.VTEX_CLUSTER || Region.Production
-}
-
 export function cluster() {
   return process.env.VTEX_CLUSTER || getCluster() || ''
 }
 
+export function region(): string {
+  return cluster() || Region.Production
+}
+
 export function publicEndpoint(): string {
-  return region() === Region.Production ? 'myvtex.com' : 'myvtexdev.com'
+  return cluster() ? 'myvtexdev.com' : 'myvtex.com'
 }
 
 export function clusterIdDomainInfix(): string {
-  return cluster() ? `.${process.env.VTEX_CLUSTER}` : ''
+  const upstreamCluster = cluster()
+  return upstreamCluster ? `.${upstreamCluster}` : ''
 }
 
 export function envCookies(): string {
-  return cluster() ? `VtexIoClusterId=${process.env.VTEX_CLUSTER}` : ''
+  const upstreamCluster = cluster()
+  return upstreamCluster ? `VtexIoClusterId=${upstreamCluster}` : ''
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
- Fix URL build when cluster is set
- Add cluster upstream header to billing client

#### How should this be manually tested?
```
git clone https://github.com/vtex/toolbelt.git && \
cd toolbelt && \
git checkout fix/bugs-with-upstream-defined && \
yarn && yarn global add file:$PWD
```
Set a cluster to use:
```
vtex config set cluster 'test-3a'
````
Test using `vtex login`.

Check the host of the URL opened to be: `https://$account.$cluster.myvtexdev.com/`

Check `vtex link` if the pod is created on the specified cluster.

#### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
