### PR TITLE
Error if not logged in vendor account during publish with `-w` flag.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- [vtex publish] Only allow the workspace flag when logged in the vendor account.
 
 ## [2.87.3] - 2020-02-05
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.87.4] - 2020-02-06
 ### Changed
 - [vtex publish] Only allow the workspace flag when logged in the vendor account.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.87.3",
+  "version": "2.87.4",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/modules/apps/publish.ts
+++ b/src/modules/apps/publish.ts
@@ -126,6 +126,7 @@ const publisher = (workspace = 'master') => {
 export default async (path: string, options) => {
   log.debug(`Starting to publish app in ${conf.getEnvironment()}`)
 
+  const account = conf.getAccount()
   const manifest = await ManifestEditor.getManifestEditor()
   const versionMsg = chalk.bold.yellow(manifest.version)
   const appNameMsg = chalk.bold.yellow(`${manifest.vendor}.${manifest.name}`)
@@ -143,13 +144,19 @@ export default async (path: string, options) => {
     }
   }
 
-  if (yesFlag && manifest.vendor !== conf.getAccount()) {
+  if (yesFlag && manifest.vendor !== account) {
     log.error(`When using the 'yes' flag, you need to be logged in to the same account as your app’s vendor.`)
     process.exit(1)
   }
 
-  path = path || root
   const workspace = options.w || options.workspace
+
+  if (workspace && manifest.vendor !== account) {
+    log.error(`When using the 'workspace' flag, you need to be logged in to the same account as your app’s vendor.`)
+    process.exit(1)
+  }
+
+  path = path || root
   const force = options.f || options.force
 
   // Always run yarn locally for some builders


### PR DESCRIPTION
#### What is the purpose of this pull request?
When publishing an app with the `-w` flag we use the builder-hub of the workspace used as parameter to the flag. However, if the operation is made in an account different from the app vendor the user will need to change the account during the publish process and the workspace used will be the one in the vendor account and not the one in the account the user was originally. Since this is not a behaviour we want, this PR blocks the use of `-w` flag in publishing if the account is different from the vendor.

#### What problem is this solving?
Avoiding a weird behaviour.

#### How should this be manually tested?
Install this branch of toolbelt:
````
git clone https://github.com/vtex/toolbelt.git && \
cd toolbelt && \
git checkout fix/publish-worksapce-flag-only-in-vendor-account && \
yarn && yarn build && yarn global add file:$PWD
````
Try to publish an app like `vtex.service-example`, whose vendor is vtex, in an different account like `storecomponents` using the workspace flag.
```
vtex publish vtex.service-example@{{new-version}} -w {{workspace}}
```
Where {{new-version}} should be a version not yet published and {{workspace}} should be a workspace in storecomponents (or the account you are originally logged).

It should show a message like this one: 
<Screenshot>
and your app shouldn't be publish.

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [x] Update `CHANGELOG.md`