### PR TITLE
Sort package.json entries when adding typings definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Sort `package.json` dependencies when adding with `vtex setup`.
 
 ## [2.87.4] - 2020-02-06
 ### Changed

--- a/src/__tests__/modules/setup/mocks.ts
+++ b/src/__tests__/modules/setup/mocks.ts
@@ -74,6 +74,7 @@ export const mockAppsUtils = () => {
 export const mockSetupUtils = () => {
   jest.doMock('../../../modules/setup/utils', () => {
     return {
+      ...jest.requireActual('../../../modules/setup/utils'),
       checkIfTarGzIsEmpty: jest.fn(),
       tsconfigEditor: { read: jest.fn(), write: jest.fn(), path: jest.fn() },
       packageJsonEditor: { read: jest.fn(), write: jest.fn(), path: jest.fn() },

--- a/src/__tests__/modules/setup/setupTypings.test.ts
+++ b/src/__tests__/modules/setup/setupTypings.test.ts
@@ -190,6 +190,34 @@ describe('React type dependencies are correctly inserted', () => {
     })
     expect(runYarn).toBeCalledTimes(1)
   })
+
+  test('Dependencies are saved in correct order', async () => {
+    setPackageJsonByBuilder({
+      react: {
+        devDependencies: {
+          '@types/ramda': '^0.26.41',
+          '@vtex/test-tools': '^3.0.1',
+          jest: '^25.1.0',
+          waait: '^1.0.5',
+        },
+      },
+    })
+
+    await setupTypings(manifestSamples['react3-app'], true, ['react'])
+
+    expect(packageJsonEditorMock.write).toHaveBeenCalledTimes(1)
+    expect(JSON.stringify(packageJsonEditorMock.write.mock.calls[0][1], null, 2)).toMatchInlineSnapshot(`
+      "{
+        \\"devDependencies\\": {
+          \\"@types/ramda\\": \\"^0.26.41\\",
+          \\"@vtex/test-tools\\": \\"^3.0.1\\",
+          \\"jest\\": \\"^25.1.0\\",
+          \\"vtex.render-runtime\\": \\"http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.1.0/public/@types/vtex.render-runtime\\",
+          \\"waait\\": \\"^1.0.5\\"
+        }
+      }"
+    `)
+  })
 })
 
 test('If yarn fails, package.json is reset to its initial state', async () => {

--- a/src/modules/setup/setupTypings.ts
+++ b/src/modules/setup/setupTypings.ts
@@ -8,7 +8,7 @@ import { toMajorRange } from '../../locator'
 import log from '../../logger'
 import { isLinked, resolveAppId, appIdFromRegistry } from '../apps/utils'
 import { runYarn } from '../utils'
-import { checkIfTarGzIsEmpty, packageJsonEditor } from './utils'
+import { checkIfTarGzIsEmpty, packageJsonEditor, sortObject } from './utils'
 import { BUILDERS_WITH_TYPES } from './consts'
 
 const getVendor = (appId: string) => appId.split('.')[0]
@@ -88,7 +88,7 @@ const injectTypingsInPackageJson = async (appDeps: Record<string, any>, ignoreLi
     const cleanOldDevDeps = R.reject(R.test(typingsURLRegex), oldDevDeps)
     packageJsonEditor.write(builder, {
       ...packageJson,
-      ...{ devDependencies: { ...cleanOldDevDeps, ...newTypingsEntries } },
+      ...{ devDependencies: sortObject({ ...cleanOldDevDeps, ...newTypingsEntries }) },
     })
     try {
       runYarn(builder, true)

--- a/src/modules/setup/utils.ts
+++ b/src/modules/setup/utils.ts
@@ -58,3 +58,12 @@ export function getRootPackageJson(): Record<string, any> {
 export function hasDevDependenciesInstalled({ deps, pkg }: { deps: Record<string, string>; pkg: Record<string, any> }) {
   return Object.keys(deps).every(p => p in pkg.devDependencies)
 }
+
+/**
+ * Sort the given object. Useful for sorting the `package.json` dependencies
+ */
+export function sortObject<T extends object>(obj: T): T {
+  return Object.keys(obj)
+    .sort()
+    .reduce((sortedObject, key) => ({ ...sortedObject, [key]: obj[key] }), {}) as T
+}


### PR DESCRIPTION
#### What is the purpose of this pull request?
Updates the `setupTypings` step in `vtex setup` to sort the `package.json` dependencies prior to saving them, in order to match the behavior of `yarn` and `npm`.

#### What problem is this solving?
When you ran `vtex setup` the dependencies were being saved in arbitrary order, so when you ran `yarn add foo` after the setup it changed the order of the dependencies added by the setup.

#### How should this be manually tested?
Run `vtex setup` in an app that should have dependencies, and `yarn test`.

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [x] Update `CHANGELOG.md`