### PR TITLE
Add payment-provider-example to vtex init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Including `payment-provider-example` on `vtex init`.
+
 ### Changed
 - Update `typescript` to `3.8.2`
 - Update `eslint` and `eslint-config-vtex`.

--- a/src/modules/init/index.ts
+++ b/src/modules/init/index.ts
@@ -14,10 +14,12 @@ const VTEXInternalTemplates = [
   'service-example',
   'react-guide',
   'masterdata-graphql-guide',
+  'payment-provider-example',
 ]
 
 const templates = {
   'graphql-example': 'graphql-example',
+  'payment-provider-example': 'payment-provider-example',
   'admin-example': 'admin-example',
   'store-theme': 'store-theme',
   'delivery-theme': 'delivery-theme',


### PR DESCRIPTION
As title says

Repo: https://github.com/vtex-apps/connector-example
#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [ ] Update `CHANGELOG.md`