### PR TITLE
Add checkout-ui-settings template in vtex init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- [vtex init] `checkout-ui-settings` template.
+
 ### Fixed
 - Fix `Unhandled Exception` when publish fails.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.89.0] - 2020-02-19
 ### Added
 - [vtex init] `checkout-ui-settings` template.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.88.2",
+  "version": "2.89.0",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/modules/init/index.ts
+++ b/src/modules/init/index.ts
@@ -26,6 +26,7 @@ const templates = {
   'masterdata-graphql-guide': 'masterdata-graphql-guide',
   'support app': 'hello-support',
   'react-guide': 'react-app-template',
+  'checkout-ui-settings': 'checkout-ui-settings',
 }
 
 const getTemplates = () =>


### PR DESCRIPTION
#### What is the purpose of this pull request?
Implements the part in this [doc](https://docs.google.com/document/d/1zZ1gMIbGFHGIPaz0AuNekOpww3J-iyQJoTJrokhdmKc/edit) related to `vtex init`.

![](https://media0.giphy.com/media/Ln2dAW9oycjgmTpjX9/giphy.gif?cid=790b76115c94425a0e0fa2b9f535dd1b4f5e97b6b04c6df6&rid=giphy.gif)

The others related PRs and new apps are: [builder-hub](https://github.com/vtex/builder-hub/pull/904), [checkout-ui-settings-server](https://github.com/vtex-apps/checkout-ui-settings-server) and [checkout-ui-settings](https://github.com/vtex-apps/checkout-ui-settings).

#### What problem is this solving?
Making it easy to start an app to customize the checkout ui.

#### How should this be manually tested?
Just run `yarn watch` in this branch of toolbelt and then use `vtex-test` to run `vtex-test init`. The option `checkout-ui-settings` should be shown and, if selected, the template from [checkout-ui-settings](https://github.com/vtex-apps/checkout-ui-settings) should be downloaded.

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [x] Update `CHANGELOG.md`