### PR TITLE
Allow testing editions in non-master workspaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
- - Add "edition app" to vtex init
+ - Add "edition app" to vtex init.
+ - Allow testing editions in non-master workspaces.
 
 ## [2.91.1] - 2020-03-03
 ### Changed

--- a/src/clients/sponsor.ts
+++ b/src/clients/sponsor.ts
@@ -20,11 +20,11 @@ export class Sponsor extends IOClient {
 
   public getEdition = async () => this.http.get(this.routes.getEdition, { metric: 'get-edition' })
 
-  public setEdition = async (account: string, editionApp: string) => {
+  public setEdition = async (account: string, workspace, editionApp: string) => {
     const [edition, version] = editionApp.split('@')
     const [sponsor, editionName] = edition.split('.')
     return this.http.post(
-      this.routes.setEdition(account),
+      this.routes.setEdition(account, workspace),
       { sponsor, edition: editionName, version },
       { metric: 'set-edition' }
     )
@@ -36,8 +36,8 @@ export class Sponsor extends IOClient {
     return {
       getSponsorAccount: `http://kube-router.${this.region}.vtex.io/_account/${this.account}`,
       getEdition: `http://apps.${this.region}.vtex.io/${this.account}/${this.workspace}/edition`,
-      setEdition: (account: string) =>
-        `http://tenant-provisioner.vtex.${this.region}.vtex.io/${this.account}/master/tenants/${account}/migrate`,
+      setEdition: (account: string, workspace: string) =>
+        `http://tenant-provisioner.vtex.${this.region}.vtex.io/${this.account}/master/tenants/${account}/migrate?tenantWorkspace=${workspace}`,
       runHouseKeeper: `http://housekeeper.${this.region}.vtex.io/${this.account}/master/_housekeeping/perform`,
     }
   }

--- a/src/clients/sponsor.ts
+++ b/src/clients/sponsor.ts
@@ -20,7 +20,7 @@ export class Sponsor extends IOClient {
 
   public getEdition = async () => this.http.get(this.routes.getEdition, { metric: 'get-edition' })
 
-  public setEdition = async (account: string, workspace, editionApp: string) => {
+  public setEdition = async (account: string, workspace: string, editionApp: string) => {
     const [edition, version] = editionApp.split('@')
     const [sponsor, editionName] = edition.split('.')
     return this.http.post(

--- a/src/modules/sponsor/setEdition.ts
+++ b/src/modules/sponsor/setEdition.ts
@@ -41,11 +41,13 @@ export default async (edition: string) => {
     await promptSwitchToAccount(sponsorAccount, false)
   }
 
-  const sponsorClientForSponsorAccount = new Sponsor(getIOContext(), IOClientOptions)
-  await sponsorClientForSponsorAccount.setEdition(previousAccount, previousWorkspace, edition)
+  try {
+    const sponsorClientForSponsorAccount = new Sponsor(getIOContext(), IOClientOptions)
+    await sponsorClientForSponsorAccount.setEdition(previousAccount, previousWorkspace, edition)
 
-  const workspaceNotice = previousWorkspace === 'master' ? '' : `in workspace ${chalk.blue(previousWorkspace)} `
-  log.info(`Successfully set edition ${workspaceNotice}of account ${chalk.blue(previousAccount)}.`)
-
-  await switchToPreviousAccount(previousConf)
+    const workspaceNotice = previousWorkspace === 'master' ? '' : `in workspace ${chalk.blue(previousWorkspace)} `
+    log.info(`Successfully set edition ${workspaceNotice}of account ${chalk.blue(previousAccount)}.`)
+  } finally {
+    await switchToPreviousAccount(previousConf)
+  }
 }

--- a/src/modules/sponsor/setEdition.ts
+++ b/src/modules/sponsor/setEdition.ts
@@ -42,6 +42,9 @@ export default async (edition: string) => {
 
   const sponsorClientForSponsorAccount = new Sponsor(getIOContext(), IOClientOptions)
   await sponsorClientForSponsorAccount.setEdition(previousAccount, previousWorkspace, edition)
-  log.info(`Successfully set new edition in account ${chalk.blue(previousAccount)}.`)
+
+  const workspaceNotice = previousWorkspace === 'master' ? '' : `in workspace ${chalk.blue(previousWorkspace)} `
+  log.info(`Successfully set edition ${workspaceNotice}of account ${chalk.blue(previousAccount)}.`)
+
   await switchToPreviousAccount(previousConf)
 }

--- a/src/modules/sponsor/setEdition.ts
+++ b/src/modules/sponsor/setEdition.ts
@@ -25,6 +25,9 @@ export default async (edition: string) => {
   const previousAccount = previousConf.account
   const previousWorkspace = previousConf.workspace
 
+  const workspaceNotice = previousWorkspace === 'master' ? '' : ` in workspace ${chalk.blue(previousWorkspace)}`
+  log.info(`Changing edition of account ${chalk.blue(previousAccount)}${workspaceNotice}.`)
+
   const sponsorClient = new Sponsor(getIOContext(), IOClientOptions)
   const data = await sponsorClient.getSponsorAccount()
   const sponsorAccount = R.prop('sponsorAccount', data)
@@ -45,8 +48,7 @@ export default async (edition: string) => {
     const sponsorClientForSponsorAccount = new Sponsor(getIOContext(), IOClientOptions)
     await sponsorClientForSponsorAccount.setEdition(previousAccount, previousWorkspace, edition)
 
-    const workspaceNotice = previousWorkspace === 'master' ? '' : `in workspace ${chalk.blue(previousWorkspace)} `
-    log.info(`Successfully set edition ${workspaceNotice}of account ${chalk.blue(previousAccount)}.`)
+    log.info(`Successfully set edition${workspaceNotice} of account ${chalk.blue(previousAccount)}.`)
   } finally {
     await switchToPreviousAccount(previousConf)
   }

--- a/src/modules/sponsor/setEdition.ts
+++ b/src/modules/sponsor/setEdition.ts
@@ -48,7 +48,10 @@ export default async (edition: string) => {
     const sponsorClientForSponsorAccount = new Sponsor(getIOContext(), IOClientOptions)
     await sponsorClientForSponsorAccount.setEdition(previousAccount, previousWorkspace, edition)
 
-    log.info(`Successfully set edition${workspaceNotice} of account ${chalk.blue(previousAccount)}.`)
+    log.info(`Successfully changed edition${workspaceNotice} of account ${chalk.blue(previousAccount)}.`)
+  } catch (ex) {
+    log.error(`Failed to change edition of account ${chalk.blue(previousAccount)}.`)
+    throw ex
   } finally {
     await switchToPreviousAccount(previousConf)
   }

--- a/src/modules/sponsor/setEdition.ts
+++ b/src/modules/sponsor/setEdition.ts
@@ -22,7 +22,8 @@ const promptSwitchToAccount = async (account: string, initial: boolean) => {
 
 export default async (edition: string) => {
   const previousConf = conf.getAll()
-  const previousAccount = previousConf.account, previousWorkspace = previousConf.workspace
+  const previousAccount = previousConf.account
+  const previousWorkspace = previousConf.workspace
 
   const sponsorClient = new Sponsor(getIOContext(), IOClientOptions)
   const data = await sponsorClient.getSponsorAccount()

--- a/src/modules/sponsor/setEdition.ts
+++ b/src/modules/sponsor/setEdition.ts
@@ -21,17 +21,20 @@ const promptSwitchToAccount = async (account: string, initial: boolean) => {
 
 export default async (edition: string) => {
   const previousConf = conf.getAll()
-  const previousAccount = previousConf.account
+  const previousAccount = previousConf.account, previousWorkspace = previousConf.workspace
+
   const sponsorClient = new Sponsor(getIOContext(), IOClientOptions)
   const data = await sponsorClient.getSponsorAccount()
+
   const sponsorAccount = R.prop('sponsorAccount', data)
   if (!sponsorAccount) {
     await promptSwitchToAccount('vtex', true)
-  } else if (previousAccount !== sponsorAccount) {
+  } else {
     await promptSwitchToAccount(sponsorAccount, false)
   }
+
   const sponsorClientForSponsorAccount = new Sponsor(getIOContext(), IOClientOptions)
-  await sponsorClientForSponsorAccount.setEdition(previousAccount, edition)
+  await sponsorClientForSponsorAccount.setEdition(previousAccount, previousWorkspace, edition)
   log.info(`Successfully set new edition in account ${chalk.blue(previousAccount)}.`)
   await switchToPreviousAccount(previousConf)
 }

--- a/src/modules/sponsor/setEdition.ts
+++ b/src/modules/sponsor/setEdition.ts
@@ -2,8 +2,9 @@ import chalk from 'chalk'
 import R from 'ramda'
 import { Sponsor } from '../../clients/sponsor'
 import * as conf from '../../conf'
-import { UserCancelledError } from '../../errors'
+import { CommandError, UserCancelledError } from '../../errors'
 import log from '../../logger'
+import { promptWorkspaceMaster } from '../apps/utils'
 import { default as switchAccount } from '../auth/switch'
 import { promptConfirm } from '../prompts'
 import { switchToPreviousAccount, getIOContext, IOClientOptions } from '../utils'
@@ -25,11 +26,17 @@ export default async (edition: string) => {
 
   const sponsorClient = new Sponsor(getIOContext(), IOClientOptions)
   const data = await sponsorClient.getSponsorAccount()
-
   const sponsorAccount = R.prop('sponsorAccount', data)
+
   if (!sponsorAccount) {
+    if (previousWorkspace !== 'master') {
+      throw new CommandError('Can only set initial edition in master workspace')
+    }
     await promptSwitchToAccount('vtex', true)
   } else {
+    if (previousWorkspace === 'master') {
+      await promptWorkspaceMaster(previousAccount)
+    }
     await promptSwitchToAccount(sponsorAccount, false)
   }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
This is to allow setting the edition of an account in a separate workspace, something
that was not possible before and thus made testing editions quite cumbersome
(or dangerous).

With this, toolbelt starts calling the new API feature implemented by https://github.com/vtex/tenant-provisioner/pull/14
(this should be the last one to be merged)

#### What problem is this solving?
Not being able to test an edition before actually setting it on the master workspace of an account.

#### How should this be manually tested?
 - Run `vtex edition set` in a separate workspace
 - Ensure workspace's edition has been set
 - Ensure master's edition is untouched
 - Also test it on `master` just in case

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/1613383/74682646-5d00ab00-51a5-11ea-9667-5e66b2cfed40.png)

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [x] Update `CHANGELOG.md`