### PR TITLE
Add "edition app" vtex init option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+ - Add "edition app" to vtex init
 
 ## [2.91.1] - 2020-03-03
 ### Changed

--- a/src/modules/init/index.ts
+++ b/src/modules/init/index.ts
@@ -62,6 +62,10 @@ const templates: Record<string, Template> = {
     repository: 'masterdata-graphql-guide',
     organization: VTEX_APPS,
   },
+  'edition app': {
+    repository: 'edition-hello',
+    organization: VTEX_APPS,
+  },
   'support app': {
     repository: 'hello-support',
     organization: VTEX_APPS,


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add "edition app" option to `vtex init` pointing to https://github.com/vtex-apps/edition-hello

#### What problem is this solving?
Cumbersome bootstrap of edition apps.

#### How should this be manually tested?
 - `vtex init`
 - `edition app`
 - Check cloned folder

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/1613383/74685949-cafda000-51ae-11ea-936f-8690c34755a1.png)

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] "New feature" (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [x] Update `CHANGELOG.md`