### PR TITLE
Add npm publish lock

### DIFF
--- a/.github/workflows/publish-prerelease-npm.yml
+++ b/.github/workflows/publish-prerelease-npm.yml
@@ -21,3 +21,4 @@ jobs:
       - run: npm publish --tag beta
         env:
             NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+            IS_CI: "true"

--- a/.github/workflows/publish-stable-npm.yml
+++ b/.github/workflows/publish-stable-npm.yml
@@ -21,3 +21,4 @@ jobs:
       - run: npm publish
         env:
             NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+            IS_CI: "true"

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "build-incremental": "tsc --incremental && yarn exe",
     "build": "yarn build-clean && tsc && yarn exe",
     "test": "jest",
+    "prepublishOnly": "bash ./scripts/publishLock.sh",
     "ci:test": "yarn test --ci",
     "ci:prettier-check": "prettier --check --config ./.prettierrc \"src/**/*.ts\" \"src/**/*.js\""
   },

--- a/scripts/publishLock.sh
+++ b/scripts/publishLock.sh
@@ -1,0 +1,13 @@
+#! /bin/bash
+
+BOLD="\e[1m"
+YELLOW="\e[33m"
+
+if [ ! "$IS_CI" == "true" ]; then
+    echo -e "${BOLD}${YELLOW}"
+    echo -e "============================================================================================="
+    echo -e "The CI is configured to publish when a new tag is created."
+    echo -e "If you still want to publish yourself you have to set the env variable IS_CI to \"true\""
+    echo -e "============================================================================================="
+    exit 1
+fi


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add a reminder step when publishing via `npm publish` without the CI.

#### Screenshots or example usage
![Screenshot from 2020-02-22 13-58-59](https://user-images.githubusercontent.com/26463288/75096210-1a134e80-557c-11ea-88b1-0940d81549f3.png)


#### Types of changes
- [X] Chore
- [ ] Refactor (non-breaking change that only makes the code better)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
