### PR TITLE
Remove all templates but `store` for non vtex users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Release notes URL.
 ### Changed
 - [vtex init] Keep only store template for non VTEX users and change template repository.
+- [vtex init] Allow to select template organization.
 
 ## [2.90.0] - 2020-03-02
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - Release notes URL.
+### Changed
+- [vtex init] Keep only store template for non VTEX users and change template repository.
 
 ## [2.90.0] - 2020-03-02
 ### Added

--- a/src/modules/init/git.ts
+++ b/src/modules/init/git.ts
@@ -3,13 +3,13 @@ import pipeStreams from 'pipe-streams-to-promise'
 import request from 'request'
 import unzip from 'unzip-stream'
 
-const urlForRepo = (repo: string) => `https://github.com/vtex-apps/${repo}/archive/master.zip`
+const urlForRepo = (repo: string, org: string) => `https://github.com/${org}/${repo}/archive/master.zip`
 
 const fetchAndUnzip = async (url: string, path: string) => pipeStreams([request(url), unzip.Extract({ path })])
 
-export const clone = async (repo: string) => {
+export const clone = async (repo: string, org: string) => {
   const cwd = process.cwd()
-  const url = urlForRepo(repo)
+  const url = urlForRepo(repo, org)
   const destPath = `${cwd}/${repo}`
   const cloned = `${destPath}/${repo}-master`
 

--- a/src/modules/init/index.ts
+++ b/src/modules/init/index.ts
@@ -11,17 +11,22 @@ import * as git from './git'
 const VTEXInternalTemplates = [
   // Only show these templates for VTEX e-mail users.
   'graphql-example',
-  'service-example',
-  'react-guide',
-  'masterdata-graphql-guide',
   'payment-provider-example',
+  'admin-example',
+  'delivery-theme',
+  'service-example',
+  'render-guide',
+  'masterdata-graphql-guide',
+  'support app',
+  'react-guide',
+  'checkout-ui-settings',
 ]
 
 const templates = {
   'graphql-example': 'graphql-example',
   'payment-provider-example': 'payment-provider-example',
   'admin-example': 'admin-example',
-  'store-theme': 'store-theme',
+  'store': 'store-framework-template',
   'delivery-theme': 'delivery-theme',
   'service-example': 'service-example',
   'render-guide': 'render-guide',

--- a/src/modules/init/index.ts
+++ b/src/modules/init/index.ts
@@ -116,7 +116,7 @@ export default async () => {
   try {
     const { repository: repo, organization: org } = templates[await promptTemplates()]
     await promptContinue(repo)
-    log.info(`Cloning https://${org}/${repo}.git`)
+    log.info(`Cloning ${chalk.bold.cyan(repo)} from ${chalk.bold.cyan(org)}.`)
     await git.clone(repo, org)
     log.info(`Run ${chalk.bold.green(`cd ${repo}`)} and ${chalk.bold.green('vtex link')} to start developing!`)
   } catch (err) {

--- a/src/modules/init/index.ts
+++ b/src/modules/init/index.ts
@@ -8,6 +8,9 @@ import { promptConfirm } from '../prompts'
 
 import * as git from './git'
 
+const VTEX_APPS = 'vtex-apps'
+const VTEX_TRAININGS = 'vtex-trainings'
+
 const VTEXInternalTemplates = [
   // Only show these templates for VTEX e-mail users.
   'graphql-example',
@@ -22,18 +25,56 @@ const VTEXInternalTemplates = [
   'checkout-ui-settings',
 ]
 
-const templates = {
-  'graphql-example': 'graphql-example',
-  'payment-provider-example': 'payment-provider-example',
-  'admin-example': 'admin-example',
-  store: 'store-framework-template',
-  'delivery-theme': 'delivery-theme',
-  'service-example': 'service-example',
-  'render-guide': 'render-guide',
-  'masterdata-graphql-guide': 'masterdata-graphql-guide',
-  'support app': 'hello-support',
-  'react-guide': 'react-app-template',
-  'checkout-ui-settings': 'checkout-ui-settings',
+interface Template {
+  repository: string,
+  organization: string
+}
+
+const templates: Record<string, Template> = {
+  'graphql-example': {
+    repository: 'graphql-example',
+    organization: VTEX_APPS
+  },
+  'payment-provider-example': {
+    repository: 'payment-provider-example',
+    organization: VTEX_APPS
+  },
+  'admin-example': {
+    repository: 'admin-example',
+    organization: VTEX_APPS
+  },
+  store: {
+    repository: 'store-framework-template',
+    organization: VTEX_TRAININGS
+  },
+  'delivery-theme': {
+    repository: 'delivery-theme',
+    organization: VTEX_APPS
+  },
+  'service-example': {
+    repository: 'service-example',
+    organization: VTEX_APPS
+  },
+  'render-guide': {
+    repository: 'render-guide',
+    organization: VTEX_APPS
+  },
+  'masterdata-graphql-guide': {
+    repository: 'masterdata-graphql-guide',
+    organization: VTEX_APPS
+  },
+  'support app': {
+    repository: 'hello-support',
+    organization: VTEX_APPS
+  },
+  'react-guide': {
+    repository: 'react-app-template',
+    organization: VTEX_APPS
+  },
+  'checkout-ui-settings': {
+    repository: 'checkout-ui-settings',
+    organization: VTEX_APPS
+  },
 }
 
 const getTemplates = () =>
@@ -73,10 +114,10 @@ export default async () => {
   log.debug('Prompting for app info')
   log.info('Hello! I will help you generate basic files and folders for your app.')
   try {
-    const repo = templates[await promptTemplates()]
+    const { repository: repo, organization: org } = templates[await promptTemplates()]
     await promptContinue(repo)
-    log.info(`Cloning https://vtex-apps/${repo}.git`)
-    await git.clone(repo)
+    log.info(`Cloning https://${org}/${repo}.git`)
+    await git.clone(repo, org)
     log.info(`Run ${chalk.bold.green(`cd ${repo}`)} and ${chalk.bold.green('vtex link')} to start developing!`)
   } catch (err) {
     log.error(err.message)

--- a/src/modules/init/index.ts
+++ b/src/modules/init/index.ts
@@ -26,7 +26,7 @@ const templates = {
   'graphql-example': 'graphql-example',
   'payment-provider-example': 'payment-provider-example',
   'admin-example': 'admin-example',
-  'store': 'store-framework-template',
+  store: 'store-framework-template',
   'delivery-theme': 'delivery-theme',
   'service-example': 'service-example',
   'render-guide': 'render-guide',

--- a/src/modules/init/index.ts
+++ b/src/modules/init/index.ts
@@ -26,54 +26,54 @@ const VTEXInternalTemplates = [
 ]
 
 interface Template {
-  repository: string,
+  repository: string
   organization: string
 }
 
 const templates: Record<string, Template> = {
   'graphql-example': {
     repository: 'graphql-example',
-    organization: VTEX_APPS
+    organization: VTEX_APPS,
   },
   'payment-provider-example': {
     repository: 'payment-provider-example',
-    organization: VTEX_APPS
+    organization: VTEX_APPS,
   },
   'admin-example': {
     repository: 'admin-example',
-    organization: VTEX_APPS
+    organization: VTEX_APPS,
   },
   store: {
     repository: 'store-framework-template',
-    organization: VTEX_TRAININGS
+    organization: VTEX_TRAININGS,
   },
   'delivery-theme': {
     repository: 'delivery-theme',
-    organization: VTEX_APPS
+    organization: VTEX_APPS,
   },
   'service-example': {
     repository: 'service-example',
-    organization: VTEX_APPS
+    organization: VTEX_APPS,
   },
   'render-guide': {
     repository: 'render-guide',
-    organization: VTEX_APPS
+    organization: VTEX_APPS,
   },
   'masterdata-graphql-guide': {
     repository: 'masterdata-graphql-guide',
-    organization: VTEX_APPS
+    organization: VTEX_APPS,
   },
   'support app': {
     repository: 'hello-support',
-    organization: VTEX_APPS
+    organization: VTEX_APPS,
   },
   'react-guide': {
     repository: 'react-app-template',
-    organization: VTEX_APPS
+    organization: VTEX_APPS,
   },
   'checkout-ui-settings': {
     repository: 'checkout-ui-settings',
-    organization: VTEX_APPS
+    organization: VTEX_APPS,
   },
 }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
Nowadays `vtex init` is too chaotic. Let's tidy up the house!

![](https://gph.is/1DTzhK1)

For now we will only allow the `store` template for users outside VTEX and also replace the `store-theme` (the current store template) for `store-framework-template`, that is simpler and easier for a quick start.

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [x] Update `CHANGELOG.md`