### PR TITLE
Change template for `store`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.91.1] - 2020-03-03
 ### Changed
 - [vtex init] Use better template for `store`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- [vtex init] Use better template for `store`.
 
 ## [2.91.0] - 2020-03-03
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.91.0",
+  "version": "2.91.1",
   "description": "The platform for e-commerce apps",
   "main": "lib/index.js",
   "bin": "lib/cli.js",

--- a/src/modules/init/index.ts
+++ b/src/modules/init/index.ts
@@ -9,7 +9,6 @@ import { promptConfirm } from '../prompts'
 import * as git from './git'
 
 const VTEX_APPS = 'vtex-apps'
-const VTEX_TRAININGS = 'vtex-trainings'
 
 const VTEXInternalTemplates = [
   // Only show these templates for VTEX e-mail users.
@@ -44,8 +43,8 @@ const templates: Record<string, Template> = {
     organization: VTEX_APPS,
   },
   store: {
-    repository: 'store-framework-template',
-    organization: VTEX_TRAININGS,
+    repository: 'minimum-boilerplate-theme',
+    organization: VTEX_APPS,
   },
   'delivery-theme': {
     repository: 'delivery-theme',


### PR DESCRIPTION
#### What is the purpose of this pull request?
@saviomuniz proposed a better template to be used as a boilerplate for `store`.

#### What problem is this solving?
Improving the experience for a quick start in the platform.

#### How should this be manually tested?
Use `yarn watch` in this branch of `toolbelt` and then use the command `vtex-test init`. Select `store` and, if the repository `minimum-boilerplate-theme` is successfully cloned, everything is working :)

#### Screenshots or example usage

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [x] Update `CHANGELOG.md`