### PR TITLE
Add GraphQL files to lint-staged config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Update release notes message.
 - Improve SSE errors logs.
+- [vtex setup] Add GraphQL files to `lint-staged` config.
 
 ## [2.98.0] - 2020-04-22
 ### Added

--- a/src/modules/setup/setupTooling.ts
+++ b/src/modules/setup/setupTooling.ts
@@ -45,7 +45,7 @@ function getBasePackageJson(appName: string) {
     },
     'lint-staged': {
       '*.{ts,js,tsx,jsx}': ['eslint --fix', 'prettier --write'],
-      '*.json': ['prettier --write'],
+      '*.{json,graphql,gql}': ['prettier --write'],
     },
     devDependencies: {},
   }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Updates the configuration of `lint-staged` to include GraphQL files when running prettier, alongside JSON.

#### What problem is this solving?
Make all GraphQL files _prettier_ ✨

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [x] Update `CHANGELOG.md`