### PR TITLE
Improvements in toolbelt telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
  - Add "edition app" to vtex init.
  - Allow testing editions in non-master workspaces.
- - Add an interval to remote flush telemetry.
- - Use a file to write telemetry object argument for `ToolbeltReporter`.
+ - Improvements in telemetry.
+  - Add an interval to remote flush telemetry.
+  - Use a file to write telemetry object argument for `TelemetryReporter`.
+  - Send `TelemetryReporter` meta errors to `toolbelt-telemetry`.
 
 ## [2.91.1] - 2020-03-03
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
  - Add "edition app" to vtex init.
  - Allow testing editions in non-master workspaces.
+ - Add an interval to remote flush telemetry.
+ - Use a file to write telemetry object argument for `ToolbeltReporter`.
 
 ## [2.91.1] - 2020-03-03
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Add "edition app" to vtex init.
  - Allow testing editions in non-master workspaces.
  - Improvements in telemetry.
-  - Add an interval to remote flush telemetry.
-  - Use a file to write telemetry object argument for `TelemetryReporter`.
-  - Send `TelemetryReporter` meta errors to `toolbelt-telemetry`.
+    - Add an interval to remote flush telemetry.
+    - Use a file to write telemetry object argument for `TelemetryReporter`.
+    - Send `TelemetryReporter` meta errors to `toolbelt-telemetry`.
 
 ## [2.91.1] - 2020-03-03
 ### Changed

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "json-array-split": "~1.0.0",
     "json2csv": "~4.5.4",
     "jsonwebtoken": "~8.5.1",
+    "lockfile": "^1.0.4",
     "moment": "~2.24.0",
     "node-notifier": "^6.0.0",
     "numbro": "2.1.0",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -179,7 +179,7 @@ const start = async () => {
 
   try {
     await main()
-    TelemetryCollector.getCollector().flush()
+    await TelemetryCollector.getCollector().flush()
   } catch (err) {
     await onError(err)
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -158,7 +158,7 @@ const onError = async (e: any) => {
 
   const errorReport = TelemetryCollector.getCollector().registerError(e)
   log.error(`ErrorID: ${errorReport.errorId}`)
-  TelemetryCollector.getCollector().flush()
+  await TelemetryCollector.getCollector().flush()
   process.exit(1)
 }
 

--- a/src/lib/error/ErrorCodes.ts
+++ b/src/lib/error/ErrorCodes.ts
@@ -1,4 +1,5 @@
 export const enum ErrorCodes {
   REQUEST_ERROR = 'RequestError',
   GENERIC_ERROR = 'GenericError',
+  TELEMETRY_REPORTER_ERROR = 'TelemetryReporterError',
 }

--- a/src/lib/telemetry/TelemetryCollector.ts
+++ b/src/lib/telemetry/TelemetryCollector.ts
@@ -6,10 +6,11 @@ import { join } from 'path'
 import * as pkgJson from '../../../package.json'
 import { ErrorReport } from '../error/ErrorReport'
 import { ITelemetryLocalStore, TelemetryLocalStore } from './TelemetryStore'
+import { configDir } from '../../conf'
 
 export class TelemetryCollector {
   private static readonly REMOTE_FLUSH_INTERVAL = 1000 * 60 * 10 // Ten minutes
-  private static readonly telemetryObjFilePathPrefix = '~/.config/configstore/vtex/telemetry'
+  private static readonly TELEMETRY_LOCAL_DIR = join(configDir, 'vtex', 'telemetry')
   private static telemetryCollectorSingleton: TelemetryCollector
 
   public static getCollector() {
@@ -66,7 +67,7 @@ export class TelemetryCollector {
       errors: this.errors.map(err => err.toObject()),
       metrics: this.metrics,
     }
-    const objFilePath = `${TelemetryCollector.telemetryObjFilePathPrefix}-${randomBytes(8).toString('hex')}.json`
+    const objFilePath = join(TelemetryCollector.TELEMETRY_LOCAL_DIR, `${randomBytes(8).toString('hex')}.json`)
     try {
       await ensureFile(objFilePath)
       await writeJson(objFilePath, obj) // Telemetry object should be saved in a file since it can be too large to be passed as a cli argument

--- a/src/lib/telemetry/TelemetryCollector.ts
+++ b/src/lib/telemetry/TelemetryCollector.ts
@@ -11,7 +11,7 @@ import { logger } from '../../clients'
 
 export class TelemetryCollector {
   private static readonly REMOTE_FLUSH_INTERVAL = 1000 * 60 * 10 // Ten minutes
-  private static readonly TELEMETRY_LOCAL_DIR = join(configDir, 'vtex', 'telemetry')
+  public static readonly TELEMETRY_LOCAL_DIR = join(configDir, 'vtex', 'telemetry')
   private static telemetryCollectorSingleton: TelemetryCollector
 
   public static getCollector() {

--- a/src/lib/telemetry/TelemetryCollector.ts
+++ b/src/lib/telemetry/TelemetryCollector.ts
@@ -72,13 +72,12 @@ export class TelemetryCollector {
     try {
       await ensureFile(objFilePath)
       await writeJson(objFilePath, obj) // Telemetry object should be saved in a file since it can be too large to be passed as a cli argument
+      spawn(process.execPath, [join(__dirname, 'TelemetryReporter.js'), this.store.storeName, objFilePath], {
+        detached: true,
+        stdio: 'ignore',
+      }).unref()
     } catch (e) {
       logger.error('Error writing telemetry file. Error: ', e)
     }
-
-    spawn(process.execPath, [join(__dirname, 'TelemetryReporter.js'), this.store.storeName, objFilePath], {
-      detached: true,
-      stdio: 'ignore',
-    }).unref()
   }
 }

--- a/src/lib/telemetry/TelemetryCollector.ts
+++ b/src/lib/telemetry/TelemetryCollector.ts
@@ -66,7 +66,7 @@ export class TelemetryCollector {
       errors: this.errors.map(err => err.toObject()),
       metrics: this.metrics,
     }
-    const objFilePath = `${TelemetryCollector.telemetryObjFilePathPrefix}-${randomBytes(8).toString()}.json`
+    const objFilePath = `${TelemetryCollector.telemetryObjFilePathPrefix}-${randomBytes(8).toString('hex')}.json`
     try {
       await ensureFile(objFilePath)
       await writeJson(objFilePath, obj) // Telemetry object should be saved in a file since it can be too large to be passed as a cli argument

--- a/src/lib/telemetry/TelemetryCollector.ts
+++ b/src/lib/telemetry/TelemetryCollector.ts
@@ -10,7 +10,7 @@ import { configDir } from '../../conf'
 import { logger } from '../../clients'
 
 export class TelemetryCollector {
-  private static readonly REMOTE_FLUSH_INTERVAL = 0//1000 * 60 * 10 // Ten minutes
+  private static readonly REMOTE_FLUSH_INTERVAL = 1000 * 60 * 10 // Ten minutes
   public static readonly TELEMETRY_LOCAL_DIR = join(configDir, 'vtex', 'telemetry')
   private static telemetryCollectorSingleton: TelemetryCollector
 

--- a/src/lib/telemetry/TelemetryCollector.ts
+++ b/src/lib/telemetry/TelemetryCollector.ts
@@ -10,7 +10,7 @@ import { configDir } from '../../conf'
 import { logger } from '../../clients'
 
 export class TelemetryCollector {
-  private static readonly REMOTE_FLUSH_INTERVAL = 1000 * 60 * 10 // Ten minutes
+  private static readonly REMOTE_FLUSH_INTERVAL = 0//1000 * 60 * 10 // Ten minutes
   public static readonly TELEMETRY_LOCAL_DIR = join(configDir, 'vtex', 'telemetry')
   private static telemetryCollectorSingleton: TelemetryCollector
 
@@ -70,13 +70,20 @@ export class TelemetryCollector {
     }
     const objFilePath = join(TelemetryCollector.TELEMETRY_LOCAL_DIR, `${randomBytes(8).toString('hex')}.json`)
     try {
+      console.log({obj, objFilePath})
+      console.log('Antes')
       await ensureFile(objFilePath)
+      console.log('Meio')
       await writeJson(objFilePath, obj) // Telemetry object should be saved in a file since it can be too large to be passed as a cli argument
-      spawn(process.execPath, [join(__dirname, 'TelemetryReporter.js'), this.store.storeName, objFilePath], {
-        detached: true,
-        stdio: 'ignore',
-      }).unref()
+      console.log('Depois')
+      const cp = spawn(process.execPath, [join(__dirname, 'TelemetryReporter.js'), this.store.storeName, objFilePath], {
+        // detached: true,
+        // stdio: 'ignore',
+      })//.unref()
+      cp.stderr.pipe(process.stderr)
+      cp.stdout.pipe(process.stdout)
     } catch (e) {
+      console.log(e)
       logger.error('Error writing telemetry file. Error: ', e)
     }
   }

--- a/src/lib/telemetry/TelemetryCollector.ts
+++ b/src/lib/telemetry/TelemetryCollector.ts
@@ -7,6 +7,7 @@ import * as pkgJson from '../../../package.json'
 import { ErrorReport } from '../error/ErrorReport'
 import { ITelemetryLocalStore, TelemetryLocalStore } from './TelemetryStore'
 import { configDir } from '../../conf'
+import { logger } from '../../clients'
 
 export class TelemetryCollector {
   private static readonly REMOTE_FLUSH_INTERVAL = 1000 * 60 * 10 // Ten minutes
@@ -72,7 +73,7 @@ export class TelemetryCollector {
       await ensureFile(objFilePath)
       await writeJson(objFilePath, obj) // Telemetry object should be saved in a file since it can be too large to be passed as a cli argument
     } catch (e) {
-      console.log('Error writing telemetry file. Error: ', e)
+      logger.error('Error writing telemetry file. Error: ', e)
     }
 
     spawn(process.execPath, [join(__dirname, 'TelemetryReporter.js'), this.store.storeName, objFilePath], {

--- a/src/lib/telemetry/TelemetryCollector.ts
+++ b/src/lib/telemetry/TelemetryCollector.ts
@@ -1,5 +1,5 @@
 import { randomBytes } from 'crypto'
-import { writeJson, ensureFile } from 'fs-extra'
+import { ensureFile, writeJson } from 'fs-extra'
 import { spawn } from 'child_process'
 import { join } from 'path'
 
@@ -70,20 +70,13 @@ export class TelemetryCollector {
     }
     const objFilePath = join(TelemetryCollector.TELEMETRY_LOCAL_DIR, `${randomBytes(8).toString('hex')}.json`)
     try {
-      console.log({obj, objFilePath})
-      console.log('Antes')
       await ensureFile(objFilePath)
-      console.log('Meio')
       await writeJson(objFilePath, obj) // Telemetry object should be saved in a file since it can be too large to be passed as a cli argument
-      console.log('Depois')
-      const cp = spawn(process.execPath, [join(__dirname, 'TelemetryReporter.js'), this.store.storeName, objFilePath], {
-        // detached: true,
-        // stdio: 'ignore',
-      })//.unref()
-      cp.stderr.pipe(process.stderr)
-      cp.stdout.pipe(process.stdout)
+      spawn(process.execPath, [join(__dirname, 'TelemetryReporter.js'), this.store.storeName, objFilePath], {
+        detached: true,
+        stdio: 'ignore',
+      }).unref()
     } catch (e) {
-      console.log(e)
       logger.error('Error writing telemetry file. Error: ', e)
     }
   }

--- a/src/lib/telemetry/TelemetryCollector.ts
+++ b/src/lib/telemetry/TelemetryCollector.ts
@@ -7,7 +7,7 @@ import * as pkgJson from '../../../package.json'
 import { ErrorReport } from '../error/ErrorReport'
 import { ITelemetryLocalStore, TelemetryLocalStore } from './TelemetryStore'
 import { configDir } from '../../conf'
-import { logger } from '../../clients'
+import logger from '../../logger'
 
 export class TelemetryCollector {
   private static readonly REMOTE_FLUSH_INTERVAL = 1000 * 60 * 10 // Ten minutes

--- a/src/lib/telemetry/TelemetryCollector.ts
+++ b/src/lib/telemetry/TelemetryCollector.ts
@@ -70,19 +70,12 @@ export class TelemetryCollector {
     }
     const objFilePath = join(TelemetryCollector.TELEMETRY_LOCAL_DIR, `${randomBytes(8).toString('hex')}.json`)
     try {
-      console.log('OI 1')
       await ensureFile(objFilePath)
-      console.log('OI 2')
       await writeJson(objFilePath, obj) // Telemetry object should be saved in a file since it can be too large to be passed as a cli argument
-      console.log('OI 3')
-      const cp = spawn(process.execPath, [join(__dirname, 'TelemetryReporter.js'), this.store.storeName, objFilePath], {
-        // detached: true,
-        // stdio: 'ignore',
-      })//.unref()
-      console.log('OI 4')
-      cp.stdout.pipe(process.stdout)
-      cp.stderr.pipe(process.stderr)
-      console.log('OI 5')
+      spawn(process.execPath, [join(__dirname, 'TelemetryReporter.js'), this.store.storeName, objFilePath], {
+        detached: true,
+        stdio: 'ignore',
+      }).unref()
     } catch (e) {
       logger.error('Error writing telemetry file. Error: ', e)
     }

--- a/src/lib/telemetry/TelemetryCollector.ts
+++ b/src/lib/telemetry/TelemetryCollector.ts
@@ -70,12 +70,19 @@ export class TelemetryCollector {
     }
     const objFilePath = join(TelemetryCollector.TELEMETRY_LOCAL_DIR, `${randomBytes(8).toString('hex')}.json`)
     try {
+      console.log('OI 1')
       await ensureFile(objFilePath)
+      console.log('OI 2')
       await writeJson(objFilePath, obj) // Telemetry object should be saved in a file since it can be too large to be passed as a cli argument
-      spawn(process.execPath, [join(__dirname, 'TelemetryReporter.js'), this.store.storeName, objFilePath], {
-        detached: true,
-        stdio: 'ignore',
-      }).unref()
+      console.log('OI 3')
+      const cp = spawn(process.execPath, [join(__dirname, 'TelemetryReporter.js'), this.store.storeName, objFilePath], {
+        // detached: true,
+        // stdio: 'ignore',
+      })//.unref()
+      console.log('OI 4')
+      cp.stdout.pipe(process.stdout)
+      cp.stderr.pipe(process.stderr)
+      console.log('OI 5')
     } catch (e) {
       logger.error('Error writing telemetry file. Error: ', e)
     }

--- a/src/lib/telemetry/TelemetryCollector.ts
+++ b/src/lib/telemetry/TelemetryCollector.ts
@@ -49,7 +49,10 @@ export class TelemetryCollector {
   public registerMetric() {}
 
   public async flush(forceRemoteFlush = false) {
-    const shouldRemoteFlush = forceRemoteFlush || this.errors.length > 0 || (Date.now() - this.store.getLastRemoteFlush() >= TelemetryCollector.REMOTE_FLUSH_INTERVAL)
+    const shouldRemoteFlush =
+      forceRemoteFlush ||
+      this.errors.length > 0 ||
+      Date.now() - this.store.getLastRemoteFlush() >= TelemetryCollector.REMOTE_FLUSH_INTERVAL
     if (!shouldRemoteFlush) {
       this.store.setErrors(this.errors)
       this.store.setMetrics(this.metrics)

--- a/src/lib/telemetry/TelemetryReporter.ts
+++ b/src/lib/telemetry/TelemetryReporter.ts
@@ -2,7 +2,7 @@ import { readdir, readJson, remove, writeJson, ensureDir, ensureFile, move } fro
 import { randomBytes } from 'crypto'
 import { isArray } from 'util'
 import * as lockfile from 'lockfile'
-import { join, basename } from 'path'
+import { join, basename, dirname } from 'path'
 
 import { TelemetryClient } from '../../clients/telemetryClient'
 import { region } from '../../env'
@@ -21,7 +21,7 @@ class FileLock {
   }
 
   public async lock() {
-    await ensureDir(TelemetryReporter.PENDING_DATA_DIR)
+    await ensureDir(dirname(this.lockPath))
     return new Promise((resolve, reject) => {
       lockfile.lock(this.lockPath, this.options, err => {
         err ? reject(err) : resolve()
@@ -61,7 +61,7 @@ export class TelemetryReporter {
   private dataPendingLock: FileLock
   constructor(private telemetryClient: TelemetryClient, private pendingDataDir: string) {
     const dataPendingLockName = 'reporter.lock'
-    const dataPendingLockPath = join(TelemetryReporter.PENDING_DATA_DIR, dataPendingLockName)
+    const dataPendingLockPath = join(pendingDataDir, dataPendingLockName)
     this.dataPendingLock = new FileLock(dataPendingLockPath, {})
   }
 

--- a/src/lib/telemetry/TelemetryReporter.ts
+++ b/src/lib/telemetry/TelemetryReporter.ts
@@ -68,6 +68,7 @@ export class TelemetryReporter {
   public async reportTelemetryFile(telemetryObjFilePath: string) {
     try {
       const telemetryObj = await readJson(telemetryObjFilePath)
+      throw new Error('Error in reportErrors')
       await this.reportErrors(telemetryObj.errors)
       await remove(telemetryObjFilePath)
     } catch (err) {
@@ -88,7 +89,7 @@ export class TelemetryReporter {
         try {
           const pendingDataObject = await readJson(pendingDataFile)
           await this.reportErrors(pendingDataObject.errors)
-          await remove(pendingDataFile)
+          // await remove(pendingDataFile)
         } catch (err) {
           errors.push(err)
         }
@@ -107,6 +108,7 @@ export class TelemetryReporter {
 
   public async createTelemetryReporterMetaError(errors: any) {
     const errorArray = isArray(errors) ? errors : [errors]
+    console.log('errorArray', errorArray)
     const metaErrorFilePath = join(this.pendingDataDir, `${randomBytes(8).toString('hex')}.json`)
     const errorsReport = errorArray.map(error => {
       if (!(error instanceof ErrorReport)) {
@@ -133,6 +135,7 @@ export class TelemetryReporter {
 }
 
 const start = async () => {
+  console.log('TCHAU')
   const store = new TelemetryLocalStore(process.argv[2])
   const telemetryObjFilePath = process.argv[3]
   const reporter = TelemetryReporter.getTelemetryReporter()

--- a/src/lib/telemetry/TelemetryReporter.ts
+++ b/src/lib/telemetry/TelemetryReporter.ts
@@ -63,12 +63,11 @@ const start = async () => {
     await ensureDir(TelemetryReporter.ERRORS_DIR)
     await lockfilePromisified(lockfilePath, {})
     const metaErrorsFiles = (await readdir(TelemetryReporter.ERRORS_DIR)).filter(fileName => {
-      fileName !== lockfileName
+      return fileName !== lockfileName
     })
     await Promise.all(
       metaErrorsFiles.map(async metaErrorsFile => {
         const metaErrorsObject = await readJson(join(TelemetryReporter.ERRORS_DIR, metaErrorsFile))
-        const reporter = TelemetryReporter.getTelemetryReporter()
         await reporter.reportErrors(metaErrorsObject)
         await remove(metaErrorsFile)
       })

--- a/src/lib/telemetry/TelemetryReporter.ts
+++ b/src/lib/telemetry/TelemetryReporter.ts
@@ -29,12 +29,12 @@ class FileLock {
     })
   }
 
-  public unlock() {
-    try {
-      lockfile.unlock(this.lockPath)
-    } catch (err) {
-      return null
-    }
+  public async unlock() {
+    return new Promise((resolve, reject) => {
+      lockfile.unlock(this.lockPath, err => {
+        err ? reject(err) : resolve()
+      })
+    })
   }
 }
 
@@ -74,7 +74,7 @@ export class TelemetryReporter {
       await this.dataPendingLock.lock()
       await move(telemetryObjFilePath, join(TelemetryReporter.PENDING_DATA_DIR, basename(telemetryObjFilePath)))
       await this.createTelemetryReporterMetaError(err)
-      this.dataPendingLock.unlock()
+      await this.dataPendingLock.unlock()
     }
   }
 
@@ -96,7 +96,7 @@ export class TelemetryReporter {
     )
 
     errors.length > 0 ?? (await this.createTelemetryReporterMetaError(errors))
-    this.dataPendingLock.unlock()
+    await this.dataPendingLock.unlock()
   }
 
   public reportErrors(errors: any[]) {

--- a/src/lib/telemetry/TelemetryReporter.ts
+++ b/src/lib/telemetry/TelemetryReporter.ts
@@ -1,3 +1,5 @@
+import { readJson, remove } from 'fs-extra'
+
 import { TelemetryClient } from '../../clients/telemetryClient'
 import { region } from '../../env'
 import userAgent from '../../user-agent'
@@ -34,13 +36,15 @@ export class TelemetryReporter {
 const start = async () => {
   try {
     const store = new TelemetryLocalStore(process.argv[2])
-    const telemetryObj = JSON.parse(process.argv[3])
+    const telemetryObjFilePath = process.argv[3]
+    const telemetryObj = await readJson(telemetryObjFilePath)
+    await remove(telemetryObjFilePath)
     const reporter = TelemetryReporter.getTelemetryReporter()
     await reporter.reportErrors(telemetryObj.errors)
     store.setLastRemoteFlush(Date.now())
     process.exit()
   } catch (err) {
-    console.log(err)
+    // Here we should write a file with the error in TelemetryReporter, since it cannot write in stdio
     process.exit(1)
   }
 }

--- a/src/lib/telemetry/TelemetryReporter.ts
+++ b/src/lib/telemetry/TelemetryReporter.ts
@@ -40,7 +40,7 @@ export class TelemetryReporter {
 
 const lockfilePromisified = (lockName, options) => {
   return new Promise((resolve, reject) => {
-    lockfile.lock(lockName, options, (err) => {
+    lockfile.lock(lockName, options, err => {
       err ? reject(err) : resolve()
     })
   })
@@ -62,13 +62,17 @@ const start = async () => {
     const lockfilePath = join(TelemetryReporter.ERRORS_DIR, lockfileName)
     await ensureDir(TelemetryReporter.ERRORS_DIR)
     await lockfilePromisified(lockfilePath, {})
-    const metaErrorsFiles = (await readdir(TelemetryReporter.ERRORS_DIR)).filter((fileName) => {fileName !== lockfileName})
-    await Promise.all(metaErrorsFiles.map(async (metaErrorsFile) => {
-      const metaErrorsObject = await readJson(join(TelemetryReporter.ERRORS_DIR, metaErrorsFile))
-      const reporter = TelemetryReporter.getTelemetryReporter()
-      await reporter.reportErrors(metaErrorsObject)
-      await remove(metaErrorsFile)
-    }))
+    const metaErrorsFiles = (await readdir(TelemetryReporter.ERRORS_DIR)).filter(fileName => {
+      fileName !== lockfileName
+    })
+    await Promise.all(
+      metaErrorsFiles.map(async metaErrorsFile => {
+        const metaErrorsObject = await readJson(join(TelemetryReporter.ERRORS_DIR, metaErrorsFile))
+        const reporter = TelemetryReporter.getTelemetryReporter()
+        await reporter.reportErrors(metaErrorsObject)
+        await remove(metaErrorsFile)
+      })
+    )
     lockfile.unlock(lockfilePath)
 
     store.setLastRemoteFlush(Date.now())

--- a/src/lib/telemetry/TelemetryReporter.ts
+++ b/src/lib/telemetry/TelemetryReporter.ts
@@ -95,7 +95,9 @@ export class TelemetryReporter {
       })
     )
 
-    errors.length > 0 ?? (await this.createTelemetryReporterMetaError(errors))
+    if (errors.length > 0) {
+      await this.createTelemetryReporterMetaError(errors)
+    }
     await this.dataPendingLock.unlock()
   }
 

--- a/src/lib/telemetry/TelemetryReporter.ts
+++ b/src/lib/telemetry/TelemetryReporter.ts
@@ -95,7 +95,7 @@ export class TelemetryReporter {
       })
     )
 
-    errors.length > 0 ?? await this.createTelemetryReporterMetaError(errors)
+    errors.length > 0 ?? (await this.createTelemetryReporterMetaError(errors))
     this.dataPendingLock.unlock()
   }
 
@@ -118,7 +118,7 @@ export class TelemetryReporter {
       return error
     })
     await ensureFile(metaErrorFilePath)
-    await writeJson(metaErrorFilePath, {errors: errorsReport})
+    await writeJson(metaErrorFilePath, { errors: errorsReport })
   }
 
   private async pendingFilesPaths() {

--- a/src/lib/telemetry/TelemetryReporter.ts
+++ b/src/lib/telemetry/TelemetryReporter.ts
@@ -68,11 +68,9 @@ export class TelemetryReporter {
   public async reportTelemetryFile(telemetryObjFilePath: string) {
     try {
       const telemetryObj = await readJson(telemetryObjFilePath)
-      throw new Error('Estou tendo um erro no Telemetry Report!!! :scared:')
       await this.reportErrors(telemetryObj.errors)
       await remove(telemetryObjFilePath)
     } catch (err) {
-      console.log('Entrei no catch. Err: ', err)
       await this.dataPendingLock.lock()
       await move(telemetryObjFilePath, join(TelemetryReporter.PENDING_DATA_DIR, basename(telemetryObjFilePath)))
       await this.createTelemetryReporterMetaError(err)
@@ -89,7 +87,6 @@ export class TelemetryReporter {
       pendingDataFiles.map(async pendingDataFile => {
         try {
           const pendingDataObject = await readJson(pendingDataFile)
-          console.log({pendingDataFile, pendingDataObject})
           await this.reportErrors(pendingDataObject.errors)
           await remove(pendingDataFile)
         } catch (err) {
@@ -120,7 +117,6 @@ export class TelemetryReporter {
       }
       return error
     })
-    console.log({metaErrors: errorsReport})
     await ensureFile(metaErrorFilePath)
     await writeJson(metaErrorFilePath, {errors: errorsReport})
   }
@@ -135,7 +131,6 @@ export class TelemetryReporter {
 }
 
 const start = async () => {
-  console.log('START!!!')
   const store = new TelemetryLocalStore(process.argv[2])
   const telemetryObjFilePath = process.argv[3]
   const reporter = TelemetryReporter.getTelemetryReporter()

--- a/src/lib/telemetry/TelemetryReporter.ts
+++ b/src/lib/telemetry/TelemetryReporter.ts
@@ -1,5 +1,6 @@
-import { ensureFile, readdir, readJson, remove, writeJson } from 'fs-extra'
+import { readdir, readJson, remove, writeJson, ensureDir, ensureFile } from 'fs-extra'
 import { randomBytes } from 'crypto'
+import * as lockfile from 'lockfile'
 
 import { TelemetryClient } from '../../clients/telemetryClient'
 import { region } from '../../env'
@@ -8,11 +9,12 @@ import { createIOContext, createTelemetryClient } from '../clients'
 import { SessionManager } from '../session/SessionManager'
 import { TelemetryLocalStore } from './TelemetryStore'
 import { ErrorReport } from '../error/ErrorReport'
+import { join, resolve } from 'path'
 
 export class TelemetryReporter {
   private static readonly RETRIES = 3
   private static readonly TIMEOUT = 30 * 1000
-  public static readonly ERRORS_DIR = '~/.config/configstore/vtex/errors'
+  public static readonly ERRORS_DIR = resolve('~/.config/configstore/vtex/errors')
   public static getTelemetryReporter() {
     const { account, workspace, token } = SessionManager.getSessionManager()
     const telemetryClient = createTelemetryClient(
@@ -36,6 +38,14 @@ export class TelemetryReporter {
   }
 }
 
+const lockfilePromisified = (lockName, options) => {
+  return new Promise((resolve, reject) => {
+    lockfile.lock(lockName, options, (err) => {
+      err ? reject(err) : resolve()
+    })
+  })
+}
+
 const start = async () => {
   try {
     const store = new TelemetryLocalStore(process.argv[2])
@@ -43,23 +53,28 @@ const start = async () => {
     // Send general toolbelt errors
     const telemetryObjFilePath = process.argv[3]
     const telemetryObj = await readJson(telemetryObjFilePath)
-    await remove(telemetryObjFilePath)
     const reporter = TelemetryReporter.getTelemetryReporter()
     await reporter.reportErrors(telemetryObj.errors)
+    await remove(telemetryObjFilePath)
 
     // Send TelemetryReport errors
-    const metaErrorsFiles = await readdir(TelemetryReporter.ERRORS_DIR)
+    const lockfileName = 'reporter.lock'
+    const lockfilePath = join(TelemetryReporter.ERRORS_DIR, lockfileName)
+    await ensureDir(TelemetryReporter.ERRORS_DIR)
+    await lockfilePromisified(lockfilePath, {})
+    const metaErrorsFiles = (await readdir(TelemetryReporter.ERRORS_DIR)).filter((fileName) => {fileName !== lockfileName})
     await Promise.all(metaErrorsFiles.map(async (metaErrorsFile) => {
-      const metaErrorsObject = await readJson(metaErrorsFile)
+      const metaErrorsObject = await readJson(join(TelemetryReporter.ERRORS_DIR, metaErrorsFile))
       const reporter = TelemetryReporter.getTelemetryReporter()
       await reporter.reportErrors(metaErrorsObject)
       await remove(metaErrorsFile)
     }))
+    lockfile.unlock(lockfilePath)
 
     store.setLastRemoteFlush(Date.now())
     process.exit()
   } catch (err) {
-    const errorFilePath = `${TelemetryReporter.ERRORS_DIR}-${randomBytes(8).toString()}.json`
+    const errorFilePath = `${TelemetryReporter.ERRORS_DIR}/${randomBytes(8).toString('hex')}.json`
     let errorReport = err
     if (!(err instanceof ErrorReport)) {
       const code = ErrorReport.createGenericCode(err)

--- a/src/lib/telemetry/TelemetryReporter.ts
+++ b/src/lib/telemetry/TelemetryReporter.ts
@@ -1,4 +1,4 @@
-import { readdir, readJson, remove, writeJson, ensureDir, ensureFile, move } from 'fs-extra'
+import { readdir, readJson, remove, ensureDir, ensureFile, move, writeJson } from 'fs-extra'
 import { randomBytes } from 'crypto'
 import { isArray } from 'util'
 import * as lockfile from 'lockfile'
@@ -68,7 +68,6 @@ export class TelemetryReporter {
   public async reportTelemetryFile(telemetryObjFilePath: string) {
     try {
       const telemetryObj = await readJson(telemetryObjFilePath)
-      throw new Error('Error in reportErrors')
       await this.reportErrors(telemetryObj.errors)
       await remove(telemetryObjFilePath)
     } catch (err) {
@@ -89,7 +88,7 @@ export class TelemetryReporter {
         try {
           const pendingDataObject = await readJson(pendingDataFile)
           await this.reportErrors(pendingDataObject.errors)
-          // await remove(pendingDataFile)
+          await remove(pendingDataFile)
         } catch (err) {
           errors.push(err)
         }
@@ -108,7 +107,6 @@ export class TelemetryReporter {
 
   public async createTelemetryReporterMetaError(errors: any) {
     const errorArray = isArray(errors) ? errors : [errors]
-    console.log('errorArray', errorArray)
     const metaErrorFilePath = join(this.pendingDataDir, `${randomBytes(8).toString('hex')}.json`)
     const errorsReport = errorArray.map(error => {
       if (!(error instanceof ErrorReport)) {
@@ -117,7 +115,7 @@ export class TelemetryReporter {
           message: error.message,
           originalError: error,
           tryToParseError: true,
-        })
+        }).toObject()
       }
       return error
     })
@@ -135,7 +133,6 @@ export class TelemetryReporter {
 }
 
 const start = async () => {
-  console.log('TCHAU')
   const store = new TelemetryLocalStore(process.argv[2])
   const telemetryObjFilePath = process.argv[3]
   const reporter = TelemetryReporter.getTelemetryReporter()

--- a/src/lib/telemetry/TelemetryReporter.ts
+++ b/src/lib/telemetry/TelemetryReporter.ts
@@ -84,7 +84,7 @@ export class TelemetryReporter {
     await this.dataPendingLock.lock()
 
     const pendingDataFiles = await this.pendingFilesPaths()
-    let errors = []
+    const errors = []
     await Promise.all(
       pendingDataFiles.map(async pendingDataFile => {
         try {
@@ -128,7 +128,7 @@ export class TelemetryReporter {
       return fileName !== this.dataPendingLock.lockName
     })
 
-    return pendingDataFiles.map((pendingDataFile) => join(TelemetryReporter.PENDING_DATA_DIR, pendingDataFile))
+    return pendingDataFiles.map(pendingDataFile => join(TelemetryReporter.PENDING_DATA_DIR, pendingDataFile))
   }
 }
 

--- a/src/lib/telemetry/TelemetryStore.ts
+++ b/src/lib/telemetry/TelemetryStore.ts
@@ -5,7 +5,7 @@ export interface ITelemetryLocalStore {
   storeName: string
   getErrors: () => ErrorReport[]
   getMetrics: () => any
-  getLastRemoteFlush: () => void
+  getLastRemoteFlush: () => any
   setLastRemoteFlush: (date: number) => void
   setErrors: (errors: ErrorReport[]) => void
   setMetrics: (metrics: any) => void

--- a/src/lib/telemetry/TelemetryStore.ts
+++ b/src/lib/telemetry/TelemetryStore.ts
@@ -29,7 +29,7 @@ export class TelemetryLocalStore implements ITelemetryLocalStore {
   }
 
   public getLastRemoteFlush() {
-    this.store.get('lastRemoteFlush') ?? 0
+    return this.store.get('lastRemoteFlush') ?? 0
   }
 
   public setErrors(errors: ErrorReport[]) {

--- a/src/lib/telemetry/TelemetryStore.ts
+++ b/src/lib/telemetry/TelemetryStore.ts
@@ -5,7 +5,8 @@ export interface ITelemetryLocalStore {
   storeName: string
   getErrors: () => ErrorReport[]
   getMetrics: () => any
-  getLastRemoteFlush: () => any
+  getLastRemoteFlush: () => void
+  setLastRemoteFlush: (date: number) => void
   setErrors: (errors: ErrorReport[]) => void
   setMetrics: (metrics: any) => void
   clear: () => void
@@ -28,7 +29,7 @@ export class TelemetryLocalStore implements ITelemetryLocalStore {
   }
 
   public getLastRemoteFlush() {
-    return this.store.get('lastRemoteFlush') ?? 0
+    this.store.get('lastRemoteFlush') ?? 0
   }
 
   public setErrors(errors: ErrorReport[]) {

--- a/src/lib/telemetry/TelemetryStore.ts
+++ b/src/lib/telemetry/TelemetryStore.ts
@@ -5,6 +5,7 @@ export interface ITelemetryLocalStore {
   storeName: string
   getErrors: () => ErrorReport[]
   getMetrics: () => any
+  getLastRemoteFlush: () => any
   setErrors: (errors: ErrorReport[]) => void
   setMetrics: (metrics: any) => void
   clear: () => void

--- a/src/modules/apps/list.ts
+++ b/src/modules/apps/list.ts
@@ -44,7 +44,6 @@ const renderTable = ({
 }
 
 export default async () => {
-  throw new Error('Erro no list')
   const account = getAccount()
   const workspace = getWorkspace()
   log.debug('Starting to list apps')

--- a/src/modules/apps/list.ts
+++ b/src/modules/apps/list.ts
@@ -46,6 +46,8 @@ const renderTable = ({
 export default async () => {
   const account = getAccount()
   const workspace = getWorkspace()
+  console.log('Vou bugar')
+  throw new Error('Error em ls')
   log.debug('Starting to list apps')
   const appArray = await listApps().then(prop('data'))
   renderTable({

--- a/src/modules/apps/list.ts
+++ b/src/modules/apps/list.ts
@@ -46,8 +46,6 @@ const renderTable = ({
 export default async () => {
   const account = getAccount()
   const workspace = getWorkspace()
-  console.log('Vou bugar')
-  throw new Error('Error em ls')
   log.debug('Starting to list apps')
   const appArray = await listApps().then(prop('data'))
   renderTable({

--- a/src/modules/apps/list.ts
+++ b/src/modules/apps/list.ts
@@ -44,6 +44,7 @@ const renderTable = ({
 }
 
 export default async () => {
+  throw new Error('Erro no list')
   const account = getAccount()
   const workspace = getWorkspace()
   log.debug('Starting to list apps')


### PR DESCRIPTION
### What is the purpose of this pull request?
- Set an interval to remote flush in telemetry object to `toolbelt-telemetry` app.
- Pass telemetry object to `TelemetryReporter` in a file to avoid having errors since the object can be too large to be a cli argument.
- Send `TelemetryReporter` meta errors to `toolbelt-telemetry`.

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [x] Update `CHANGELOG.md`