### PR TITLE
Fix stack and code properties on ErrorReport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Improvements in telemetry.
+  - Add an interval to remote flush telemetry.
+  - Use a file to write telemetry object argument for `TelemetryReporter`.
+  - Send `TelemetryReporter` meta errors to `toolbelt-telemetry`.
+
+### Fixed
+- `ErrorReport` class throwing `UnhandledException`.
 
 ## [2.92.0] - 2020-03-09
 ### Added
- - Add "edition app" to vtex init.
- - Allow testing editions in non-master workspaces.
- - Improvements in telemetry.
-    - Add an interval to remote flush telemetry.
-    - Use a file to write telemetry object argument for `TelemetryReporter`.
-    - Send `TelemetryReporter` meta errors to `toolbelt-telemetry`.
+- Add "edition app" to vtex init.
+- Allow testing editions in non-master workspaces.
 
 ## [2.91.1] - 2020-03-03
 ### Changed

--- a/src/lib/error/ErrorKinds.ts
+++ b/src/lib/error/ErrorKinds.ts
@@ -1,4 +1,4 @@
-export const enum ErrorCodes {
+export const enum ErrorKinds {
   REQUEST_ERROR = 'RequestError',
   GENERIC_ERROR = 'GenericError',
   TELEMETRY_REPORTER_ERROR = 'TelemetryReporterError',

--- a/src/lib/telemetry/TelemetryCollector.ts
+++ b/src/lib/telemetry/TelemetryCollector.ts
@@ -36,14 +36,7 @@ export class TelemetryCollector {
       return error
     }
 
-    const code = ErrorReport.createGenericCode(error)
-    const errorReport = ErrorReport.create({
-      code,
-      message: error.message,
-      originalError: error,
-      tryToParseError: true,
-    })
-
+    const errorReport = ErrorReport.create({ originalError: error })
     this.errors.push(errorReport)
     return errorReport
   }

--- a/src/lib/telemetry/TelemetryReporter.ts
+++ b/src/lib/telemetry/TelemetryReporter.ts
@@ -12,7 +12,7 @@ import { SessionManager } from '../session/SessionManager'
 import { TelemetryLocalStore } from './TelemetryStore'
 import { ErrorReport } from '../error/ErrorReport'
 import { TelemetryCollector } from './TelemetryCollector'
-import { ErrorCodes } from '../error/ErrorCodes'
+import { ErrorKinds } from '../error/ErrorKinds'
 
 class FileLock {
   public readonly lockName: string
@@ -111,10 +111,8 @@ export class TelemetryReporter {
     const errorsReport = errorArray.map(error => {
       if (!(error instanceof ErrorReport)) {
         return ErrorReport.create({
-          code: ErrorCodes.TELEMETRY_REPORTER_ERROR,
-          message: error.message,
+          kind: ErrorKinds.TELEMETRY_REPORTER_ERROR,
           originalError: error,
-          tryToParseError: true,
         }).toObject()
       }
       return error

--- a/yarn.lock
+++ b/yarn.lock
@@ -4727,6 +4727,13 @@ locate-path@^3.0.0:
     p-locate "^3.0.0"
     path-exists "^3.0.0"
 
+lockfile@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/lockfile/-/lockfile-1.0.4.tgz#07f819d25ae48f87e538e6578b6964a4981a5609"
+  integrity sha512-cvbTwETRfsFh4nHsL1eGWapU1XFi5Ot9E85sWAwia7Y7EgB7vfqcZhTKZ+l7hCGxSPoushMv5GKhT5PdLv03WA==
+  dependencies:
+    signal-exit "^3.0.2"
+
 lodash.assign@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.assign/-/lodash.assign-4.2.0.tgz#0d99f3ccd7a6d261d19bdaeb9245005d285808e7"


### PR DESCRIPTION
- Fix `stack` property on `ErrorReport` to save the `originalError` `stack`.
- Fix destructuring `err.response` - it may be `undefined`.
- Use `kind` instead of `code`, since `originalError` may already have a `code` property.
- Create `createGenericError` utility function.
- Fixes https://github.com/vtex/toolbelt/issues/773

#### What problem is this solving?
Implementation errors on `ErrorReport` class.

#### How should this be manually tested?
```
cd /tmp && rm -rf toolbelt && \
git clone https://github.com/vtex/toolbelt.git && \
cd toolbelt && \
git checkout fix/error-report-class && \
yarn && yarn watch
```
This is kinda difficult to manually test without inserting some `console.logs` inside the code or throwing manual errors :(

I tested adding a `throw Error('asdfasdf')` on `vtex ls` and adding a `console.log` on `TelemtryCollector` right after the `ErrorReport` instance was created - checked the `toObject` function for correct data.
Tested with `await axios.get('asdfasdf')` on the beginning of `vtex ls` - it threw an `axiosError` with code `ECONNREFUSED`, generating the following object on `errorReport.toObject()`:
```js
{
  errorId: 'fab2ae3fb0ff45f7',
  timestamp: '2020-03-16T16:33:05.458Z',
  kind: 'RequestError',
  message: 'connect ECONNREFUSED 127.0.0.1:80',
  errorDetails: {
    requestConfig: {
      url: 'asdfasdf',
      method: 'get',
      params: undefined,
      headers: [Object],
      data: undefined,
      timeout: 0
    },
    response: undefined
  },
  stack: 'Error: connect ECONNREFUSED 127.0.0.1:80\n' +
    '    at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1137:16)',
  env: {
    account: 'storecomponents',
    workspace: 'n1poli',
    toolbeltVersion: '2.92.0',
    nodeVersion: 'v12.16.1',
    platform: 'linux',
    command: 'ls'
  },
  code: 'ECONNREFUSED'
}

```

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [x] Update `CHANGELOG.md`