### PR TITLE
Fix `PayloadTooLargeError` error

### DIFF
--- a/src/clients/telemetryClient.ts
+++ b/src/clients/telemetryClient.ts
@@ -4,7 +4,7 @@ import archiver from 'archiver'
 import { ZlibOptions } from 'zlib'
 
 export class TelemetryClient extends AppClient {
-  private static readonly OBJECT_SIZE_LIMIT = 100000 //1Kb
+  private static readonly OBJECT_SIZE_LIMIT = 100000 // 1Kb
 
   private compressDataOnMemory = async (errorOrMetricArray: any[], zlibOptions: ZlibOptions = {}) => {
     const zip = archiver('zip', { zlib: zlibOptions })

--- a/src/clients/telemetryClient.ts
+++ b/src/clients/telemetryClient.ts
@@ -1,11 +1,40 @@
 import { AppClient, InstanceOptions, IOContext } from '@vtex/api'
+import getStream from 'get-stream'
+import archiver from 'archiver'
+import { ZlibOptions } from 'zlib'
 
 export class TelemetryClient extends AppClient {
+  private static readonly OBJECT_SIZE_LIMIT = 100000 //1Kb
+
+  private compressDataOnMemory = async (errorOrMetricArray: any[], zlibOptions: ZlibOptions = {}) => {
+    const zip = archiver('zip', { zlib: zlibOptions })
+
+    zip.on('error', (err: any) => {
+      throw err
+    })
+    zip.append(errorOrMetricArray.toString(), { name: 'TelemetryData' })
+
+    const [zipContent] = await Promise.all([getStream.buffer(zip), zip.finalize()])
+    return zipContent as Buffer
+  }
+
+  private async maybeCompressData(dataToCompress: any[]) {
+    const dataToCompressAsString = dataToCompress.toString()
+    const bytesSize = Buffer.byteLength(dataToCompressAsString)
+    if (bytesSize > TelemetryClient.OBJECT_SIZE_LIMIT) {
+      const compressedObject = await this.compressDataOnMemory(dataToCompress)
+      return compressedObject
+    }
+    return dataToCompress
+  }
+
   constructor(ioContext: IOContext, opts?: InstanceOptions) {
     super('vtex.toolbelt-telemetry@0.x', ioContext, opts)
   }
 
-  public reportErrors(errors: any[]) {
-    return this.http.post('/errorReport', errors)
+  public async reportErrors(errors: any[]) {
+    const maybeCompressedErrors = await this.maybeCompressData(errors)
+
+    return this.http.post('/errorReport', maybeCompressedErrors)
   }
 }

--- a/src/clients/telemetryClient.ts
+++ b/src/clients/telemetryClient.ts
@@ -34,6 +34,6 @@ export class TelemetryClient extends AppClient {
   public async reportErrors(errors: any[]) {
     const maybeCompressedErrors = await this.maybeCompressData(errors)
 
-    return await this.http.post('/errorReport', maybeCompressedErrors)
+    return this.http.post('/errorReport', maybeCompressedErrors)
   }
 }

--- a/src/clients/telemetryClient.ts
+++ b/src/clients/telemetryClient.ts
@@ -1,4 +1,4 @@
-import { AppClient, InstanceOptions, IOContext } from '@vtex/api'
+import { AppClient, IOContext, InstanceOptions } from '@vtex/api'
 import getStream from 'get-stream'
 import archiver from 'archiver'
 import { ZlibOptions } from 'zlib'
@@ -19,8 +19,7 @@ export class TelemetryClient extends AppClient {
   }
 
   private async maybeCompressData(dataToCompress: any[]) {
-    const dataToCompressAsString = dataToCompress.toString()
-    const bytesSize = Buffer.byteLength(dataToCompressAsString)
+    const bytesSize = JSON.stringify(dataToCompress).length
     if (bytesSize > TelemetryClient.OBJECT_SIZE_LIMIT) {
       const compressedObject = await this.compressDataOnMemory(dataToCompress)
       return compressedObject
@@ -35,6 +34,6 @@ export class TelemetryClient extends AppClient {
   public async reportErrors(errors: any[]) {
     const maybeCompressedErrors = await this.maybeCompressData(errors)
 
-    return this.http.post('/errorReport', maybeCompressedErrors)
+    return await this.http.post('/errorReport', maybeCompressedErrors)
   }
 }

--- a/src/clients/telemetryClient.ts
+++ b/src/clients/telemetryClient.ts
@@ -1,40 +1,13 @@
 import { AppClient, IOContext, InstanceOptions } from '@vtex/api'
-import getStream from 'get-stream'
-import archiver from 'archiver'
-import { ZlibOptions } from 'zlib'
 
 export class TelemetryClient extends AppClient {
-  private static readonly OBJECT_SIZE_LIMIT = 100000 // 1Kb
-
-  private compressDataOnMemory = async (errorOrMetric: string, zlibOptions: ZlibOptions = {}) => {
-    const zip = archiver('zip', { zlib: zlibOptions })
-
-    zip.on('error', (err: any) => {
-      throw err
-    })
-    zip.append(errorOrMetric, { name: 'TelemetryData' })
-
-    const [zipContent] = await Promise.all([getStream.buffer(zip), zip.finalize()])
-    return zipContent as Buffer
-  }
-
-  private async maybeCompressData(dataToCompress: any[]) {
-    const stringfiedDataToCompress = JSON.stringify(dataToCompress)
-    const bytesSize = stringfiedDataToCompress.length
-    if (bytesSize > TelemetryClient.OBJECT_SIZE_LIMIT) {
-      const compressedObject = await this.compressDataOnMemory(stringfiedDataToCompress)
-      return compressedObject
-    }
-    return dataToCompress
-  }
-
   constructor(ioContext: IOContext, opts?: InstanceOptions) {
     super('vtex.toolbelt-telemetry@0.x', ioContext, opts)
   }
 
   public async reportErrors(errors: any[]) {
-    const maybeCompressedErrors = await this.maybeCompressData(errors)
-
-    return this.http.post('/errorReport', maybeCompressedErrors)
+    let bufferFromErrors = Buffer.from(JSON.stringify(errors))
+    let errorsInBase64 = bufferFromErrors.toString('base64')
+    return this.http.post('/errorReport', errorsInBase64)
   }
 }

--- a/src/clients/telemetryClient.ts
+++ b/src/clients/telemetryClient.ts
@@ -6,22 +6,23 @@ import { ZlibOptions } from 'zlib'
 export class TelemetryClient extends AppClient {
   private static readonly OBJECT_SIZE_LIMIT = 100000 // 1Kb
 
-  private compressDataOnMemory = async (errorOrMetricArray: any[], zlibOptions: ZlibOptions = {}) => {
+  private compressDataOnMemory = async (errorOrMetric: string, zlibOptions: ZlibOptions = {}) => {
     const zip = archiver('zip', { zlib: zlibOptions })
 
     zip.on('error', (err: any) => {
       throw err
     })
-    zip.append(errorOrMetricArray.toString(), { name: 'TelemetryData' })
+    zip.append(errorOrMetric, { name: 'TelemetryData' })
 
     const [zipContent] = await Promise.all([getStream.buffer(zip), zip.finalize()])
     return zipContent as Buffer
   }
 
   private async maybeCompressData(dataToCompress: any[]) {
-    const bytesSize = JSON.stringify(dataToCompress).length
+    const stringfiedDataToCompress = JSON.stringify(dataToCompress)
+    const bytesSize = stringfiedDataToCompress.length
     if (bytesSize > TelemetryClient.OBJECT_SIZE_LIMIT) {
-      const compressedObject = await this.compressDataOnMemory(dataToCompress)
+      const compressedObject = await this.compressDataOnMemory(stringfiedDataToCompress)
       return compressedObject
     }
     return dataToCompress

--- a/src/lib/telemetry/TelemetryReporter.ts
+++ b/src/lib/telemetry/TelemetryReporter.ts
@@ -87,7 +87,7 @@ export class TelemetryReporter {
       await remove(telemetryObjFilePath)
     } catch (err) {
       await this.dataPendingLock.lock()
-      if (err.response?.status == 413) {
+      if (err.response?.status === 413) {
         await remove(telemetryObjFilePath)
         const entityTooLargeError = new EntityTooLargeError(typeof err.config?.data === 'string' ? err.config.data : '')
         await this.createTelemetryReporterMetaError(entityTooLargeError)

--- a/src/lib/telemetry/TelemetryReporter.ts
+++ b/src/lib/telemetry/TelemetryReporter.ts
@@ -42,7 +42,12 @@ class EntityTooLargeError extends Error {
   private static readonly originalErrorSizeToCrop = 200
   constructor(public originalErrorMessage: string) {
     super(
-      `First ${EntityTooLargeError.originalErrorSizeToCrop} characters from original error: ${originalErrorMessage.substring(0, EntityTooLargeError.originalErrorSizeToCrop)}`
+      `First ${
+        EntityTooLargeError.originalErrorSizeToCrop
+      } characters from original error: ${originalErrorMessage.substring(
+        0,
+        EntityTooLargeError.originalErrorSizeToCrop
+      )}`
     )
   }
 }
@@ -84,7 +89,7 @@ export class TelemetryReporter {
       await this.dataPendingLock.lock()
       if (err.response?.status == 413) {
         await remove(telemetryObjFilePath)
-        const entityTooLargeError = new EntityTooLargeError(typeof(err.config?.data) === 'string' ? err.config.data : '')
+        const entityTooLargeError = new EntityTooLargeError(typeof err.config?.data === 'string' ? err.config.data : '')
         await this.createTelemetryReporterMetaError(entityTooLargeError)
       } else {
         await move(telemetryObjFilePath, join(TelemetryReporter.PENDING_DATA_DIR, basename(telemetryObjFilePath)))


### PR DESCRIPTION
#### What is the purpose of this pull request?
Convert telemetry body to base64 to avoid `PayloadTooLargeError` error. Also correctly deal with this error when received.
OBS: This PR should only be merged and released after the PR in `toolbelt-telemetry` parsing the body from base64.

#### What problem is this solving?
Avoiding error when sending telemetry data from toolbelt to toolbelt-telemetry and using too much space in the user computer with toolbelt telemetry.

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [ ] Update `CHANGELOG.md`