### PR TITLE
Make yarn format also format jsx and tsx files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Make generated `yarn format` command also format `.jsx` and `.tsx` files.
 
 ## [2.92.2] - 2020-03-23
 ### Fixed

--- a/src/modules/setup/setupTooling.ts
+++ b/src/modules/setup/setupTooling.ts
@@ -36,7 +36,7 @@ function getBasePackageJson(appName: string) {
     license: 'UNLICENSED',
     scripts: {
       lint: 'eslint --ext js,jsx,ts,tsx .',
-      format: 'prettier --write "**/*.{ts,js,json}"',
+      format: 'prettier --write "**/*.{ts,tsx,js,jsx,json}"',
     },
     husky: {
       hooks: {


### PR DESCRIPTION
#### What is the purpose of this pull request?

Currently the `yarn format` script generated by `vtex setup` ignores `tsx` and `jsx` files. This PR fixes that.

#### How should this be manually tested?

n/a

#### Screenshots or example usage
n/a

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [x] Update `CHANGELOG.md`