### PR TITLE
Fix wsl url opening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - [vtex setup] Make generated `yarn format` command also format `.jsx` and `.tsx` files.
+- [dependencies:open] Fix `open` usage that caused malfunction on wsl.
 
 ### Changed
 - [vtex redirects] Downloads the bindings along with the redirects.

--- a/src/lib/auth/AuthProviders/OAuthAuthenticator.ts
+++ b/src/lib/auth/AuthProviders/OAuthAuthenticator.ts
@@ -32,7 +32,7 @@ export class OAuthAuthenticator extends AuthProviderBase {
   private async startUserAuth(account: string, workspace: string): Promise<string[] | never> {
     const state = randomstring.generate()
     const [url, fullReturnUrl] = await this.getLoginUrl(account, workspace, state)
-    opn(url, { wait: false })
+    opn(url, { url: true, wait: false })
     return onAuth(account, workspace, state, fullReturnUrl)
   }
 

--- a/src/modules/browse.ts
+++ b/src/modules/browse.ts
@@ -45,5 +45,5 @@ export default async (endpointInput, { q, qr }) => {
     return
   }
 
-  opn(uri, { wait: false })
+  opn(uri, { url: true, wait: false })
 }

--- a/src/nps.ts
+++ b/src/nps.ts
@@ -41,7 +41,7 @@ export async function checkAndOpenNPSLink() {
           .add(3, 'months')
           .toISOString()
       )
-      opn(NPSFormURL, { wait: false })
+      opn(NPSFormURL, { url: true, wait: false })
     } else {
       let { remindChoice } = await enquirer.prompt({
         name: 'remindChoice',


### PR DESCRIPTION
#### What is the purpose of this pull request?
This fixes the usage of `open`, allowing WSL users to successfully login again. 

#### How should this be manually tested?
On WSL:
```
yarn global add vtex@2.93.0-beta
```
Try to `vtex login`

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [ ] Update `CHANGELOG.md`