### PR TITLE
Create new vtex setup flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- [vtex setup] Create new flags for specifying what to setup:
+  - `--all`: Select all setup flags existent.
+  - `--typings`: Download and setup GraphQL and React typings.
+  - `--tooling`: Setup Prettier, Husky and ESLint.
+  - `--tsconfig`: Setup React's and Node's TSconfig, if applicable.
 
 ### Changed
 - [telemetry] Add suffix specifying if `env.platform` is container or WSL.

--- a/src/lib/error/ErrorKinds.ts
+++ b/src/lib/error/ErrorKinds.ts
@@ -3,4 +3,7 @@ export const enum ErrorKinds {
   GENERIC_ERROR = 'GenericError',
   TELEMETRY_REPORTER_ERROR = 'TelemetryReporterError',
   DEPRECATION_CHECK_ERROR = 'DeprecationCheckError',
+  SETUP_TOOLING_ERROR = 'SetupToolingError',
+  SETUP_TSCONFIG_ERROR = 'SetupTSConfigError',
+  SETUP_TYPINGS_ERROR = 'SetupTypingsError',
 }

--- a/src/lib/telemetry/TelemetryCollector.ts
+++ b/src/lib/telemetry/TelemetryCollector.ts
@@ -4,7 +4,7 @@ import { spawn } from 'child_process'
 import { join } from 'path'
 
 import * as pkgJson from '../../../package.json'
-import { ErrorReport } from '../error/ErrorReport'
+import { ErrorReport, ErrorCreationArguments } from '../error/ErrorReport'
 import { ITelemetryLocalStore, TelemetryLocalStore } from './TelemetryStore'
 import { configDir } from '../../conf'
 import logger from '../../logger'
@@ -22,6 +22,11 @@ export class TelemetryCollector {
     }
 
     return TelemetryCollector.telemetryCollectorSingleton
+  }
+
+  public static createAndRegisterErrorReport(args: ErrorCreationArguments) {
+    const err = ErrorReport.create(args)
+    return TelemetryCollector.getCollector().registerError(err)
   }
 
   private errors: ErrorReport[]

--- a/src/modules/setup/index.ts
+++ b/src/modules/setup/index.ts
@@ -1,14 +1,42 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
+import chalk from 'chalk'
+import logger from '../../logger'
 import { getManifest } from '../../manifest'
 import { setupTooling } from './setupTooling'
 import { setupTSConfig } from './setupTSConfig'
 import { setupTypings } from './setupTypings'
 
-export default async (opts: { i?: boolean; 'ignore-linked': boolean }) => {
-  const ignoreLinked = opts.i || opts['ignore-linked']
-  const manifest = await getManifest()
+interface SetupOpts {
+  i?: boolean
+  'ignore-linked'?: boolean
+  all?: boolean
+  tooling?: boolean
+  typings?: boolean
+  tsconfig?: boolean
+}
 
-  setupTooling(manifest)
-  await setupTSConfig(manifest)
-  await setupTypings(manifest, ignoreLinked)
+export default async (opts: SetupOpts) => {
+  const all = opts.all || (!opts.tooling && !opts.typings && !opts.tsconfig)
+  const tooling = opts.tooling || opts.all
+  const typings = opts.typings || opts.all
+  const tsconfig = opts.tsconfig || opts.all
+  const ignoreLinked = opts.i || opts['ignore-linked']
+
+  if (ignoreLinked && !(all || typings)) {
+    logger.error(
+      chalk`The flag {bold --ignore-linked (-i)} can only be used when {bold --typings} or {bold --all} are also used`
+    )
+  }
+
+  const manifest = await getManifest()
+  if (tooling) {
+    setupTooling(manifest)
+  }
+
+  if (tsconfig) {
+    await setupTSConfig(manifest, opts.tsconfig)
+  }
+
+  if (typings) {
+    await setupTypings(manifest, ignoreLinked)
+  }
 }

--- a/src/modules/tree.ts
+++ b/src/modules/tree.ts
@@ -127,9 +127,29 @@ export default {
     optionalArgs: 'app',
   },
   setup: {
-    description: 'Download react app typings, graphql app typings, lint config and tsconfig',
+    description: 'Setup development enviroment',
     handler: './setup',
     options: [
+      {
+        description: 'Select all existing setup flags',
+        long: 'all',
+        type: 'boolean',
+      },
+      {
+        description: 'Setup GraphQL and React typings',
+        long: 'typings',
+        type: 'boolean',
+      },
+      {
+        description: 'Setup tools for applicable builders\nNode and React: Prettier, Husky and ESLint',
+        long: 'tooling',
+        type: 'boolean',
+      },
+      {
+        description: "Setup React and Node's TSconfig, if applicable",
+        long: 'tsconfig',
+        type: 'boolean',
+      },
       {
         description: 'Add only types from apps published',
         long: 'ignore-linked',


### PR DESCRIPTION
#### What is the purpose of this pull request?
- Allow granularity on what is being set up.
- Increase observability on errors being thrown when `vtex setup` is executed.
 
#### How should this be manually tested?
```
cd /tmp && rm -rf toolbelt && \
git clone https://github.com/vtex/toolbelt.git && \
cd toolbelt && \
git checkout feat/create-new-setup-cmds && \
yarn && yarn watch
```
Test:
`vtex setup`
`vtex setup --tooling`
`vtex setup --tsconfig`
`vtex setup --typings`

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [x] Update `CHANGELOG.md`