### PR TITLE
Show checkout ui settings for users outside VTEX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- [vtex init] Show `checkout-ui-settings` template for users outside VTEX.
 
 ## [2.93.1] - 2020-03-30
 

--- a/src/modules/init/index.ts
+++ b/src/modules/init/index.ts
@@ -21,7 +21,6 @@ const VTEXInternalTemplates = [
   'masterdata-graphql-guide',
   'support app',
   'react-guide',
-  'checkout-ui-settings',
 ]
 
 interface Template {


### PR DESCRIPTION
#### What is the purpose of this pull request?
Users that don't have a VTEX email should be able to use the template `checkout-ui-settings` to implement [checkout ui custom using apps](https://vtex.io/docs/components/functional/vtex.checkout-ui-settings@0.0.2).

#### Screenshots or example usage

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [x] Update `CHANGELOG.md`