### PR TITLE
Add test logs url to vtex test e2e output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - [telemetry] Add suffix specifying if `env.platform` is container or WSL.
 
+### Added
+ - Showing test's logs when using the command  `vtex test e2e`.
+
 ## [2.95.0] - 2020-04-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- [vtex test e2e] Show test's logs.
 - [vtex setup] Create new flags for specifying what to setup:
   - `--all`: Select all setup flags existent.
   - `--typings`: Download and setup GraphQL and React typings.
@@ -14,9 +15,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - [telemetry] Add suffix specifying if `env.platform` is container or WSL.
-
-### Added
- - Show test's logs when using the command  `vtex test e2e`.
 
 ## [2.95.0] - 2020-04-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [telemetry] Add suffix specifying if `env.platform` is container or WSL.
 
 ### Added
- - Showing test's logs when using the command  `vtex test e2e`.
+ - Show test's logs when using the command  `vtex test e2e`.
 
 ## [2.95.0] - 2020-04-01
 

--- a/src/clients/Tester.ts
+++ b/src/clients/Tester.ts
@@ -2,6 +2,7 @@ import { AppClient, inflightURL, InstanceOptions, IOContext, CacheType } from '@
 
 export interface SpecTestReport {
   testId: string
+  logId: string
   title: string[]
   state: string
   body: string
@@ -33,9 +34,10 @@ export interface SpecReport {
     }
     tests: SpecTestReport[]
     video?: string
+    logs?: string
     screenshots: Screenshot[]
   }
-  logId?: string
+  logId: string
   lastUpdate: number
 }
 

--- a/src/clients/Tester.ts
+++ b/src/clients/Tester.ts
@@ -2,7 +2,6 @@ import { AppClient, inflightURL, InstanceOptions, IOContext, CacheType } from '@
 
 export interface SpecTestReport {
   testId: string
-  logId: string
   title: string[]
   state: string
   body: string
@@ -37,7 +36,7 @@ export interface SpecReport {
     logs?: string
     screenshots: Screenshot[]
   }
-  logId: string
+  logId?: string
   lastUpdate: number
 }
 

--- a/src/modules/apps/e2e/report/failedApps.tsx
+++ b/src/modules/apps/e2e/report/failedApps.tsx
@@ -34,6 +34,7 @@ interface SpecProps {
 
 export const FailedSpec: React.FunctionComponent<SpecProps> = ({ spec, report }) => {
   const video = report.report?.video
+  const logs = report.report?.logs
   const screenshots = report.report?.screenshots
   const notPassedSpecs = (report.report?.tests ?? []).filter(({ state }) => state !== 'passed')
 
@@ -58,6 +59,7 @@ export const FailedSpec: React.FunctionComponent<SpecProps> = ({ spec, report })
         {report.error && <FailedSpecDetail label="Error" text={report.error} indented />}
         {errorsVisualization}
         {video && <FailedSpecDetail label="Video" text={video} indented={false} />}
+        {logs && <FailedSpecDetail label="Logs" text={logs} indented={false} />}
       </Box>
     </Box>
   )


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
Show logs after e2e test execution 

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
Facilitating the viewing of logs from e2e tests when running the vtex test e2e command via toolbelt

#### How should this be manually tested?
Get tester-e2e-cypress at branch `logs`
use yarn watch on the toolbelt

Pick an app with cypress tests that has a failing test (e.g shipping-preview)
add cypress builder at manifest: "cypress": "0.x"
link the app
link the tester-e2e-cypress
wait a couple seconds

run vtex-test test e2e at the app

after the test is completed check if there is a log file you can access
#### Screenshots or example usage

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [x] Update `CHANGELOG.md`