### PR TITLE
Create outdated checker

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,5 @@
 {
-  "extends": [
-    "vtex"
-  ],
+  "extends": ["vtex"],
   "root": true,
   "env": {
     "node": true,
@@ -39,7 +37,10 @@
       }
     },
     {
-      "files": ["./src/lib/telemetry/TelemetryReporter/report.ts"],
+      "files": [
+        "./src/lib/telemetry/TelemetryReporter/report.ts",
+        "./src/CLIPreTasks/OutdatedChecker/checkForOutdated.ts"
+      ],
       "rules": {
         "import/first": "off"
       }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [vtex link] `no-watch` flag behaviour.
 - [vtex workspace delete] `force` flag type.
 
+### Added
+- [CLIPreTasks] Outdated version checking.
+
 ## [2.99.1] - 2020-04-29
 ### Fixed
 - Treat errors when checking edition of account on a workspace command.

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@oclif/plugin-help": "^2.0.0",
     "@tiagonapoli/oclif-plugin-spaced-commands": "^0.0.5",
     "@vtex/api": "3.71.1",
+    "@vtex/toolbelt-message-renderer": "^0.0.1",
     "@yarnpkg/lockfile": "^1.1.0",
     "ajv": "~6.10.2",
     "any-promise": "^1.3.0",

--- a/src/CLIPreTasks/CLIPreTasks.ts
+++ b/src/CLIPreTasks/CLIPreTasks.ts
@@ -5,6 +5,7 @@ import semver from 'semver'
 import { configDir } from '../conf'
 import { PathConstants } from '../lib/constants/Paths'
 import { DeprecationChecker } from './DeprecationChecker/DeprecationChecker'
+import { OutdatedChecker } from './OutdatedChecker/OutdatedChecker'
 
 export class CLIPreTasks {
   public static readonly PRETASKS_LOCAL_DIR = PathConstants.PRETASKS_FOLDER
@@ -54,5 +55,7 @@ export class CLIPreTasks {
       this.removeOutdatedPaths()
       DeprecationChecker.checkForDeprecation(CLIPreTasks.PRETASKS_LOCAL_DIR, this.pkg)
     }
+
+    OutdatedChecker.checkForOutdate(CLIPreTasks.PRETASKS_LOCAL_DIR, this.pkg)
   }
 }

--- a/src/CLIPreTasks/CLIPreTasks.ts
+++ b/src/CLIPreTasks/CLIPreTasks.ts
@@ -6,10 +6,10 @@ import { configDir } from '../conf'
 import { PathConstants } from '../lib/constants/Paths'
 import { DeprecationChecker } from './DeprecationChecker/DeprecationChecker'
 import { OutdatedChecker } from './OutdatedChecker/OutdatedChecker'
+import { EnvVariablesConstants } from '../lib/constants/EnvVariables'
 
 export class CLIPreTasks {
   public static readonly PRETASKS_LOCAL_DIR = PathConstants.PRETASKS_FOLDER
-  private static readonly BYPASS_LOCKS_FLAG = 'BYPASS_LOCKS'
 
   public static getCLIPreTasks(pkgJson: any) {
     return new CLIPreTasks(pkgJson)
@@ -50,12 +50,13 @@ export class CLIPreTasks {
   }
 
   public runTasks() {
-    if (process.env[CLIPreTasks.BYPASS_LOCKS_FLAG] !== 'false') {
-      this.ensureCompatibleNode()
-      this.removeOutdatedPaths()
-      DeprecationChecker.checkForDeprecation(CLIPreTasks.PRETASKS_LOCAL_DIR, this.pkg)
+    if (process.env[EnvVariablesConstants.IGNORE_CLIPRETASKS]) {
+      return
     }
 
+    this.ensureCompatibleNode()
+    this.removeOutdatedPaths()
+    DeprecationChecker.checkForDeprecation(CLIPreTasks.PRETASKS_LOCAL_DIR, this.pkg)
     OutdatedChecker.checkForOutdate(CLIPreTasks.PRETASKS_LOCAL_DIR, this.pkg)
   }
 }

--- a/src/CLIPreTasks/OutdatedChecker/OutdatedChecker.test.ts
+++ b/src/CLIPreTasks/OutdatedChecker/OutdatedChecker.test.ts
@@ -1,0 +1,57 @@
+import { OutdatedChecker } from './OutdatedChecker'
+import { IOutdatedCheckerStore, OutdatedInfo } from './OutdatedCheckerStore'
+
+class OutdatedCheckerStoreMock implements IOutdatedCheckerStore {
+  public storeFilePath = 'mockFilePath'
+  private outdatedInfo: OutdatedInfo
+  private lastOutdatedCheck: number
+
+  getLastOutdatedCheck() {
+    return this.lastOutdatedCheck
+  }
+
+  getOutdatedInfo() {
+    return this.outdatedInfo
+  }
+
+  setLastOutdatedCheck(date: number) {
+    this.lastOutdatedCheck = date
+  }
+
+  setOutdatedInfo(outdatedInfo: OutdatedInfo) {
+    this.outdatedInfo = outdatedInfo
+  }
+}
+
+describe('shouldCheckOutdated works as expected', () => {
+  it('Returns true when pkg version changes', () => {
+    const store = new OutdatedCheckerStoreMock()
+    store.setOutdatedInfo({ versionChecked: '2.90.1', outdated: true })
+    const checker = new OutdatedChecker(store, { version: '2.90.0' })
+    expect(checker.shouldCheckOutdated()).toBe(true)
+  })
+
+  it('Returns true when is outdated', () => {
+    const store = new OutdatedCheckerStoreMock()
+    store.setOutdatedInfo({ versionChecked: '2.90.0', outdated: true })
+    const checker = new OutdatedChecker(store, { version: '2.90.0' })
+    expect(checker.shouldCheckOutdated()).toBe(true)
+  })
+})
+
+describe('isOutdated works as expected', () => {
+  it.each([
+    [false, { versionChecked: '2.90.0', outdated: false }, '2.90.0'],
+    [false, { versionChecked: '2.90.1', outdated: false }, '2.90.0'],
+    [false, { versionChecked: '2.90.1', outdated: true }, '2.90.0'],
+    [true, { versionChecked: '2.90.0', outdated: true }, '2.90.0'],
+  ])(
+    'Returns %s when deprecationInfo is %p and current version is %s',
+    (result: boolean, outdatedInfo: OutdatedInfo, curVersion: string) => {
+      const store = new OutdatedCheckerStoreMock()
+      store.setOutdatedInfo(outdatedInfo)
+      const checker = new OutdatedChecker(store, { version: curVersion })
+      expect(checker.isOutdated()).toBe(result)
+    }
+  )
+})

--- a/src/CLIPreTasks/OutdatedChecker/OutdatedChecker.ts
+++ b/src/CLIPreTasks/OutdatedChecker/OutdatedChecker.ts
@@ -1,0 +1,65 @@
+import chalk from 'chalk'
+import { join } from 'path'
+import { spawnUnblockingChildProcess } from '../../lib/utils/spawnUnblockingChildProcess'
+import { IOutdatedCheckerStore, OutdatedCheckerStore, OutdatedInfo } from './OutdatedCheckerStore'
+
+export class OutdatedChecker {
+  private static readonly OUTDATED_CHECK_INTERVAL = 1 * 3600 * 1000
+  private static readonly OUTDATED_CHECKER_STORE_FILENAME = 'outdated-checking.json'
+
+  private static singleton: OutdatedChecker
+  public static checkForOutdate(storeDir: string, pkgJson: any) {
+    if (!OutdatedChecker.singleton) {
+      const store = new OutdatedCheckerStore(join(storeDir, OutdatedChecker.OUTDATED_CHECKER_STORE_FILENAME))
+      OutdatedChecker.singleton = new OutdatedChecker(store, pkgJson)
+    }
+
+    const checker = OutdatedChecker.singleton
+    if (checker.shouldCheckOutdated()) {
+      checker.startCheckerProcess()
+    }
+
+    if (!checker.isOutdated()) {
+      return
+    }
+
+    const errMsg = chalk.bold(
+      `This version ${pkgJson.version} is outdated. Please update to the latest version: ${chalk.green(
+        'yarn global add vtex'
+      )}.`
+    )
+
+    console.error(errMsg)
+    process.exit(1)
+  }
+
+  private outdatedInfo: OutdatedInfo
+
+  constructor(private store: IOutdatedCheckerStore, private pkg: any) {
+    this.outdatedInfo = store.getOutdatedInfo()
+  }
+
+  public shouldCheckOutdated() {
+    return (
+      this.outdatedInfo.outdated ||
+      this.outdatedInfo.versionChecked !== this.pkg.version ||
+      Date.now() - this.store.getLastOutdatedCheck() >= OutdatedChecker.OUTDATED_CHECK_INTERVAL
+    )
+  }
+
+  public startCheckerProcess() {
+    spawnUnblockingChildProcess(process.execPath, [
+      join(__dirname, 'checkForOutdated.js'),
+      this.store.storeFilePath,
+      this.pkg.version,
+    ])
+  }
+
+  public isOutdated() {
+    if (this.outdatedInfo.versionChecked === this.pkg.version && this.outdatedInfo.outdated) {
+      return true
+    }
+
+    return false
+  }
+}

--- a/src/CLIPreTasks/OutdatedChecker/OutdatedCheckerStore.ts
+++ b/src/CLIPreTasks/OutdatedChecker/OutdatedCheckerStore.ts
@@ -1,0 +1,37 @@
+import Configstore from 'configstore'
+
+export interface OutdatedInfo {
+  versionChecked: string
+  outdated: boolean
+}
+
+export interface IOutdatedCheckerStore {
+  storeFilePath: string
+  getLastOutdatedCheck: () => number
+  setLastOutdatedCheck: (date: number) => void
+  getOutdatedInfo: () => OutdatedInfo
+  setOutdatedInfo: (info: OutdatedInfo) => void
+}
+
+export class OutdatedCheckerStore implements IOutdatedCheckerStore {
+  private store: Configstore
+  constructor(public storeFilePath: string) {
+    this.store = new Configstore('', null, { configPath: storeFilePath })
+  }
+
+  getLastOutdatedCheck() {
+    return (this.store.get('lastOutdatedCheck') as number) ?? 0
+  }
+
+  getOutdatedInfo() {
+    return (this.store.get('outdatedInfo') as OutdatedInfo | null) ?? { versionChecked: '', outdated: false }
+  }
+
+  setLastOutdatedCheck(date: number) {
+    this.store.set('lastOutdatedCheck', date)
+  }
+
+  setOutdatedInfo(versionOutdatedInfo: OutdatedInfo) {
+    this.store.set('outdatedInfo', versionOutdatedInfo)
+  }
+}

--- a/src/CLIPreTasks/OutdatedChecker/checkForOutdated.ts
+++ b/src/CLIPreTasks/OutdatedChecker/checkForOutdated.ts
@@ -32,8 +32,10 @@ export const checkForOutdated = async (store: IOutdatedCheckerStore, pkgVersion:
 }
 
 if (require.main === module) {
+  // eslint-disable-next-line prefer-destructuring
   const storeFilePath = process.argv[2]
   const store = new OutdatedCheckerStore(storeFilePath)
+  // eslint-disable-next-line prefer-destructuring
   const pkgVersion = process.argv[3]
   checkForOutdated(store, pkgVersion)
   console.log(`Finished checking for outdated after ${hrTimeToMs(process.hrtime(initTime))}`)

--- a/src/CLIPreTasks/OutdatedChecker/checkForOutdated.ts
+++ b/src/CLIPreTasks/OutdatedChecker/checkForOutdated.ts
@@ -1,0 +1,40 @@
+const initTime = process.hrtime()
+
+import { ToolbeltConfigClient } from '../../clients/toolbeltConfigClient'
+import { ErrorKinds } from '../../lib/error/ErrorKinds'
+import { ErrorReport } from '../../lib/error/ErrorReport'
+import { TelemetryCollector } from '../../lib/telemetry/TelemetryCollector'
+import { hrTimeToMs } from '../../lib/utils/hrTimeToMs'
+import { IOutdatedCheckerStore, OutdatedCheckerStore } from './OutdatedCheckerStore'
+
+export const checkForOutdated = async (store: IOutdatedCheckerStore, pkgVersion: string) => {
+  try {
+    const client = ToolbeltConfigClient.createDefaultClient({ retries: 3 })
+    const { validVersion } = await client.versionValidate(pkgVersion)
+    store.setOutdatedInfo({
+      versionChecked: pkgVersion,
+      outdated: validVersion === false,
+    })
+
+    store.setLastOutdatedCheck(Date.now())
+  } catch (err) {
+    const telemetryCollector = TelemetryCollector.getCollector()
+    const errorReport = telemetryCollector.registerError(
+      ErrorReport.create({
+        kind: ErrorKinds.OUTDATED_CHECK_ERROR,
+        originalError: err,
+      })
+    )
+
+    console.error('Error checking for outdated', JSON.stringify(errorReport.toObject(), null, 2))
+    telemetryCollector.flush()
+  }
+}
+
+if (require.main === module) {
+  const storeFilePath = process.argv[2]
+  const store = new OutdatedCheckerStore(storeFilePath)
+  const pkgVersion = process.argv[3]
+  checkForOutdated(store, pkgVersion)
+  console.log(`Finished checking for outdated after ${hrTimeToMs(process.hrtime(initTime))}`)
+}

--- a/src/clients/toolbeltConfigClient.ts
+++ b/src/clients/toolbeltConfigClient.ts
@@ -1,0 +1,49 @@
+import { InstanceOptions, IOClient, IOContext } from '@vtex/api'
+import { NodeToRender } from '@vtex/toolbelt-message-renderer'
+import { region } from '../env'
+import { createIOContext, mergeCustomOptionsWithDefault } from '../lib/clients'
+import { SessionManager } from '../lib/session/SessionManager'
+import userAgent from '../user-agent'
+
+interface VersionCheckRes {
+  minVersion: string
+  validVersion: boolean
+  message: string
+}
+
+interface GlobalConfig {
+  config: Record<string, any>
+  messages: Record<string, NodeToRender>
+}
+
+export class ToolbeltConfigClient extends IOClient {
+  public static readonly DEFAULT_TIMEOUT = 30000
+
+  private static readonly PUBLIC_PATH_PREFIX = '/_v/public/toolbelt'
+  private static readonly GLOBAL_CONFIG_PATH = `${ToolbeltConfigClient.PUBLIC_PATH_PREFIX}/global-config`
+  private static readonly VERSION_VALIDATE_PATH = `${ToolbeltConfigClient.PUBLIC_PATH_PREFIX}/version-validate`
+
+  public static create(ctx: IOContext, customOptions: InstanceOptions = {}) {
+    return new ToolbeltConfigClient(ctx, mergeCustomOptionsWithDefault(customOptions))
+  }
+
+  public static createDefaultClient(customOptions: InstanceOptions = {}) {
+    const { account, workspace, token } = SessionManager.getSessionManager()
+    return ToolbeltConfigClient.create(
+      createIOContext({ account, workspace, authToken: token, userAgent, region: region() }),
+      { timeout: ToolbeltConfigClient.DEFAULT_TIMEOUT, ...customOptions }
+    )
+  }
+
+  constructor(context: IOContext, options?: InstanceOptions) {
+    super(context, { ...options, baseURL: 'https://master--vtex.myvtex.com' })
+  }
+
+  public versionValidate(toolbeltVersion: string) {
+    return this.http.post<VersionCheckRes>(ToolbeltConfigClient.VERSION_VALIDATE_PATH, { toolbeltVersion })
+  }
+
+  public getGlobalConfig() {
+    return this.http.get<GlobalConfig>(ToolbeltConfigClient.GLOBAL_CONFIG_PATH)
+  }
+}

--- a/src/lib/clients/index.ts
+++ b/src/lib/clients/index.ts
@@ -47,7 +47,7 @@ export const createIOContext = ({
   }
 }
 
-const mergeCustomOptionsWithDefault = (customOptions: InstanceOptions) => {
+export const mergeCustomOptionsWithDefault = (customOptions: InstanceOptions) => {
   const mergedOptions = { ...defaultOptions, ...customOptions }
   mergedOptions.headers = { ...defaultOptions.headers, ...customOptions.headers }
   return mergedOptions

--- a/src/lib/constants/EnvVariables.ts
+++ b/src/lib/constants/EnvVariables.ts
@@ -1,3 +1,10 @@
 export enum EnvVariablesConstants {
+  // Activate child_process debugging: Instead of creating non-blocking child processes
+  // it will create processes with stdio attached to the parent's stdio streams
+  // Setting this to any string value will work: `DEBUG_CP=* vtex whoami`
   DEBUG_CP = 'DEBUG_CP',
+
+  // Ignore CLIPreTasks checks: All checks made on CLIPreTasks will be skipped.
+  // Setting this to any string value will work: `IGNORE_CLIPRETASKS=* vtex whoami`
+  IGNORE_CLIPRETASKS = 'IGNORE_PRECHECKS',
 }

--- a/src/lib/error/ErrorKinds.ts
+++ b/src/lib/error/ErrorKinds.ts
@@ -4,6 +4,7 @@ export const enum ErrorKinds {
   EVOLUTION_MANAGER_REPORT_ERROR = 'EvolutionManagerReportError',
   GENERIC_ERROR = 'GenericError',
   INVALID_OR_EXPIRED_TOKEN_ERROR = 'InvalidOrExpiredTokenError',
+  OUTDATED_CHECK_ERROR = 'OutdatedCheckError',
   REQUEST_ERROR = 'RequestError',
   SETUP_TOOLING_ERROR = 'SetupToolingError',
   SETUP_TSCONFIG_ERROR = 'SetupTSConfigError',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1066,10 +1066,27 @@
     tar-fs "^2.0.0"
     xss "^1.0.6"
 
-"@wry/equality@^0.1.2", "@wry/equality@^0.1.9":
+"@vtex/toolbelt-message-renderer@^0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@vtex/toolbelt-message-renderer/-/toolbelt-message-renderer-0.0.1.tgz#0506c8aada71ccf19b419502eb787ef596d773d1"
+  integrity sha512-TPP7dAEVjEUKXEkeHlodzwnAAsJSjFEEVpsHt/TZuhvovSiChY1xi1rc/DwpXJkvaPbB4GpAQbIGlkrpCaBELg==
+  dependencies:
+    boxen "^4.2.0"
+    chalk "^3.0.0"
+    emojic "^1.1.15"
+    mustache "^4.0.1"
+
+"@wry/equality@^0.1.2":
   version "0.1.11"
   resolved "https://registry.yarnpkg.com/@wry/equality/-/equality-0.1.11.tgz#35cb156e4a96695aa81a9ecc4d03787bc17f1790"
   integrity sha512-mwEVBDUVODlsQQ5dfuLUS5/Tf7jqUKyhKYHmVi4fPB6bDMOfWvUPJmKgS1Z7Za/sOI3vzWt4+O7yCiL/70MogA==
+  dependencies:
+    tslib "^1.9.3"
+
+"@wry/equality@^0.1.9":
+  version "0.1.9"
+  resolved "https://registry.yarnpkg.com/@wry/equality/-/equality-0.1.9.tgz#b13e18b7a8053c6858aa6c85b54911fb31e3a909"
+  integrity sha512-mB6ceGjpMGz1ZTza8HYnrPGos2mC6So4NhS1PtZ8s4Qt0K7fBiIGhpSxUbQmhwcSWE3no+bYxmI2OL6KuXYmoQ==
   dependencies:
     tslib "^1.9.3"
 
@@ -5905,10 +5922,20 @@ ms@2.0.0:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
   integrity sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
 
-ms@^2.0.0, ms@^2.1.1:
+ms@^2.0.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
+
+ms@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
+  integrity sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
+
+mustache@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/mustache/-/mustache-4.0.1.tgz#d99beb031701ad433338e7ea65e0489416c854a2"
+  integrity sha512-yL5VE97+OXn4+Er3THSmTdCFCtx5hHWzrolvH+JObZnUYwuaG7XV+Ch4fR2cIrcYI0tFHxS7iyFYl14bW8y2sA==
 
 mute-stream@0.0.7:
   version "0.0.7"


### PR DESCRIPTION
#### What is the purpose of this pull request?
- Create `OutdatedChecker` which will ask `toolbelt-config-server` about the latest version.

#### How should this be manually tested?
```
cd /tmp && rm -rf toolbelt && \
git clone https://github.com/vtex/toolbelt.git && \
cd toolbelt && \
git checkout feat/use-toolbelt-config-server && \
yarn && yarn watch
```

- Run `vtex-test`. Check the file created on `~/.vtex/pretasks/outdated-checking.json`
- Change the version on `package.json` to an older version.
- Run `vtex-test` - the first one shouldn't block the execution.
- Run `vtex-test` again, it now should block the execution.

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [x] Update `CHANGELOG.md`