### PR TITLE
Use binding instead of bindings in redirect sheet

### DIFF
--- a/src/clients/rewriter.ts
+++ b/src/clients/rewriter.ts
@@ -6,7 +6,7 @@ export interface RedirectInput {
   to: string
   endDate: string
   type: RedirectTypes
-  bindings: string[] | null
+  binding: string
 }
 
 export interface Redirect {
@@ -14,7 +14,7 @@ export interface Redirect {
   to: string
   endDate: string
   type: RedirectTypes
-  bindings: string[] | null
+  binding: string
 }
 
 export enum RedirectTypes {
@@ -47,7 +47,7 @@ export class Rewriter extends AppGraphQLClient {
           listRedirects(next: $next) {
             next
             routes {
-              bindings
+              binding
               from
               to
               type

--- a/src/modules/rewriter/export.ts
+++ b/src/modules/rewriter/export.ts
@@ -24,7 +24,7 @@ const EXPORTS = 'exports'
 const [account, workspace] = accountAndWorkspace
 
 const COLORS = ['cyan', 'black', 'red', 'green', 'yellow', 'blue', 'magenta', 'cyan', 'white', 'gray']
-const FIELDS = ['from', 'to', 'type', 'endDate', 'bindings']
+const FIELDS = ['from', 'to', 'type', 'endDate', 'binding']
 
 const handleExport = async (csvPath: string) => {
   const indexHash = createHash('md5')

--- a/src/modules/rewriter/import.ts
+++ b/src/modules/rewriter/import.ts
@@ -48,6 +48,9 @@ const inputSchema = {
         type: 'string',
         enum: ['PERMANENT', 'TEMPORARY'],
       },
+      binding: {
+        type: 'string',
+      },
     },
     additionalProperties: false,
     required: ['from', 'to', 'type'],


### PR DESCRIPTION
#### What is the purpose of this pull request?
Our redirects are currently being scoped by the binding this route is in. More info can be found in [this PR](https://github.com/vtex/rewriter/pull/101). 

The only missing pice in this refactor was to change how toolbelt import/export redirects. This PR makes this missing pice

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [ ] Update `CHANGELOG.md`