### PR TITLE
Convert remaining HTTP calls to HTTPS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [vtex rewriter] Use rewriter new redirects API with single binding support.
 
 ### Changed
+- [debugger:node, debugger:dotnet] Use `wss` protocol instead of `ws` and new `app.io.vtex.com` URL format.
+- [clients:sponsor, vtex support] Use HTTPS and new URL `app.io.vtex.com` format.
 - Update release notes message.
 
 ## [2.96.0] - 2020-04-06

--- a/src/clients/runtime.ts
+++ b/src/clients/runtime.ts
@@ -18,7 +18,7 @@ export class Runtime {
   }
 
   public async debugDotnetApp(appName: string, appVendor: string, appMajorRange: string, debugInst: string) {
-    const appMajor = appMajorRange.split('.', 2)[0]
+    const [appMajor] = appMajorRange.split('.', 2)
 
     const host = 'app.io.vtex.com'
     const path = `/${appVendor}.${appName}/v${appMajor}/${this.account}/${this.workspace}/_debug/dotnet`

--- a/src/clients/runtime.ts
+++ b/src/clients/runtime.ts
@@ -17,9 +17,7 @@ export class Runtime {
     this.workspace = workspace
   }
 
-  public async debugDotnetApp(appName: string, appVendor: string, appMajorRange: string, debugInst: string) {
-    const [appMajor] = appMajorRange.split('.', 2)
-
+  public async debugDotnetApp(appName: string, appVendor: string, appMajor: string, debugInst: string) {
     const host = 'app.io.vtex.com'
     const path = `/${appVendor}.${appName}/v${appMajor}/${this.account}/${this.workspace}/_debug/dotnet`
     const clusterHeader = cluster() ? { 'x-vtex-upstream-target': cluster() } : null

--- a/src/clients/runtime.ts
+++ b/src/clients/runtime.ts
@@ -8,20 +8,20 @@ import logger from '../logger'
 const EOT = '\x04'
 
 export class Runtime {
-  private region: string
   private account: string
   private workspace: string
 
   constructor(context: IOContext) {
-    const { region, account, workspace } = context
-    this.region = region
+    const { account, workspace } = context
     this.account = account
     this.workspace = workspace
   }
 
   public async debugDotnetApp(appName: string, appVendor: string, appMajorRange: string, debugInst: string) {
-    const host = `${appName}.${appVendor}.${this.region}.vtex.io`
-    const path = `/${this.account}/${this.workspace}/_debug/dotnet`
+    const appMajor = appMajorRange.split('.', 2)[0]
+
+    const host = 'app.io.vtex.com'
+    const path = `/${appVendor}.${appName}/v${appMajor}/${this.account}/${this.workspace}/_debug/dotnet`
     const clusterHeader = cluster() ? { 'x-vtex-upstream-target': cluster() } : null
 
     const clientOptions = {
@@ -38,7 +38,6 @@ export class Runtime {
       hostname: host,
       pathname: path,
       query: {
-        __v: appMajorRange,
         inst: debugInst.split(' '),
       },
     }

--- a/src/clients/runtime.ts
+++ b/src/clients/runtime.ts
@@ -34,7 +34,7 @@ export class Runtime {
     }
 
     const urlObject = {
-      protocol: 'ws',
+      protocol: 'wss',
       hostname: host,
       pathname: path,
       query: {

--- a/src/clients/sponsor.ts
+++ b/src/clients/sponsor.ts
@@ -1,7 +1,6 @@
 import { AuthType, InstanceOptions, IOClient, IOContext } from '@vtex/api'
 
 export class Sponsor extends IOClient {
-  private region: string
   private account: string
   private workspace: string
 
@@ -10,8 +9,7 @@ export class Sponsor extends IOClient {
       ...options,
       authType: AuthType.bearer,
     })
-    const { region, account, workspace } = context
-    this.region = region
+    const { account, workspace } = context
     this.account = account
     this.workspace = workspace
   }
@@ -34,11 +32,11 @@ export class Sponsor extends IOClient {
 
   private get routes() {
     return {
-      getSponsorAccount: `http://kube-router.${this.region}.vtex.io/_account/${this.account}`,
-      getEdition: `http://apps.${this.region}.vtex.io/${this.account}/${this.workspace}/edition`,
+      getSponsorAccount: `https://platform.io.vtex.com/_account/${this.account}`,
+      getEdition: `https://infra.io.vtex.com/apps/v0/${this.account}/${this.workspace}/edition`,
       setEdition: (account: string, workspace: string) =>
-        `http://tenant-provisioner.vtex.${this.region}.vtex.io/${this.account}/master/tenants/${account}/migrate?tenantWorkspace=${workspace}`,
-      runHouseKeeper: `http://housekeeper.${this.region}.vtex.io/${this.account}/master/_housekeeping/perform`,
+        `https://app.io.vtex.com/vtex.tenant-provisioner/v0/${this.account}/master/tenants/${account}/migrate?tenantWorkspace=${workspace}`,
+      runHouseKeeper: `https://infra.io.vtex.com/housekeeper/v0/${this.account}/master/_housekeeping/perform`,
     }
   }
 }

--- a/src/lib/manifest/ManifestEditor.ts
+++ b/src/lib/manifest/ManifestEditor.ts
@@ -77,8 +77,12 @@ export class ManifestEditor {
     return `${vendor}.${name}@${version}`
   }
 
+  public get major() {
+    return this.manifest.version.split('.', 2)[0]
+  }
+
   public get majorRange() {
-    return `${this.manifest.version.split('.', 2)[0]}.x`
+    return `${this.major}.x`
   }
 
   public flushChangesSync() {

--- a/src/locator.ts
+++ b/src/locator.ts
@@ -1,5 +1,9 @@
+export const versionMajor = (version: string): string => {
+  return version.split('.', 2)[0]
+}
+
 export const toMajorRange = (version: string): string => {
-  return `${version.split('.', 2)[0]}.x`
+  return `${versionMajor(version)}.x`
 }
 
 export const toMajorLocator = ({ vendor, name, version }: Manifest): string => {

--- a/src/modules/apps/debugger.ts
+++ b/src/modules/apps/debugger.ts
@@ -2,9 +2,9 @@ import streamToString from 'get-stream'
 import net from 'net'
 import WebSocket from 'ws'
 import { getAccount, getToken, getWorkspace } from '../../conf'
-import { region } from '../../env'
 import { ManifestEditor } from '../../lib/manifest'
-import { toMajorRange } from '../../locator'
+import { versionMajor } from '../../locator'
+import { cluster } from '../../env'
 import log from '../../logger'
 
 const keepAliveDelayMs = 3 * 60 * 1000
@@ -28,8 +28,9 @@ function webSocketTunnelHandler(host, path: string): (socket: net.Socket) => voi
   const options = {
     headers: {
       Authorization: getToken(),
-      Host: host,
+      Host: `app.io.vtex.com`,
       'X-Vtex-Runtime-Api': 'true',
+	  'x-vtex-upstream-target': cluster(),
     },
   }
 
@@ -98,9 +99,9 @@ export default function startDebuggerTunnel(
   if (!node && !serviceJs) {
     return
   }
-  const majorRange = toMajorRange(version)
-  const host = `${name}.${vendor}.${region()}.vtex.io`
-  const path = `/${getAccount()}/${getWorkspace()}/_debug/attach?__v=${majorRange}`
+  const appMajor = versionMajor(version)
+  const host = 'app.io.vtex.com'
+  const path = `/${vendor}.${name}/v${appMajor}/${getAccount()}/${getWorkspace()}/_debug/attach`
 
   return new Promise((resolve, reject) => {
     const server = net.createServer()

--- a/src/modules/apps/debugger.ts
+++ b/src/modules/apps/debugger.ts
@@ -36,7 +36,7 @@ function webSocketTunnelHandler(host, path: string): (socket: net.Socket) => voi
 
   return (socket: net.Socket) => {
     socket.setKeepAlive(true, keepAliveDelayMs)
-    const ws = new WebSocket(`ws://${host}${path}`, options)
+    const ws = new WebSocket(`wss://${host}${path}`, options)
 
     const interval = setInterval(ws.ping, THIRTY_SECONDS_MS)
 

--- a/src/modules/apps/debugger.ts
+++ b/src/modules/apps/debugger.ts
@@ -30,7 +30,7 @@ function webSocketTunnelHandler(host, path: string): (socket: net.Socket) => voi
       Authorization: getToken(),
       Host: `app.io.vtex.com`,
       'X-Vtex-Runtime-Api': 'true',
-      'x-vtex-upstream-target': cluster(),
+    ...cluster() ? { 'x-vtex-upstream-target': cluster() } : null,
     },
   }
 

--- a/src/modules/apps/debugger.ts
+++ b/src/modules/apps/debugger.ts
@@ -30,7 +30,7 @@ function webSocketTunnelHandler(host, path: string): (socket: net.Socket) => voi
       Authorization: getToken(),
       Host: `app.io.vtex.com`,
       'X-Vtex-Runtime-Api': 'true',
-    ...cluster() ? { 'x-vtex-upstream-target': cluster() } : null,
+      ...(cluster() ? { 'x-vtex-upstream-target': cluster() } : null),
     },
   }
 

--- a/src/modules/apps/debugger.ts
+++ b/src/modules/apps/debugger.ts
@@ -30,7 +30,7 @@ function webSocketTunnelHandler(host, path: string): (socket: net.Socket) => voi
       Authorization: getToken(),
       Host: `app.io.vtex.com`,
       'X-Vtex-Runtime-Api': 'true',
-	  'x-vtex-upstream-target': cluster(),
+      'x-vtex-upstream-target': cluster(),
     },
   }
 

--- a/src/modules/debug/dotnet.ts
+++ b/src/modules/debug/dotnet.ts
@@ -12,5 +12,5 @@ export default async (debugInst: string) => {
   }
 
   const runtimeClient = new Runtime(getIOContext())
-  await runtimeClient.debugDotnetApp(name, vendor, manifest.majorRange, debugInst)
+  await runtimeClient.debugDotnetApp(name, vendor, manifest.major, debugInst)
 }

--- a/src/modules/support/login.ts
+++ b/src/modules/support/login.ts
@@ -14,7 +14,7 @@ const getAvailableRoles = async (token: string, supportedAccount: string): Promi
       headers: {
         Authorization: token,
         'X-Vtex-Original-Credential': token,
-        'x-vtex-upstream-target': env.cluster(),
+    ...env.cluster() ? { 'x-vtex-upstream-target': env.cluster() } : null,
       },
     }
   )

--- a/src/modules/support/login.ts
+++ b/src/modules/support/login.ts
@@ -14,7 +14,7 @@ const getAvailableRoles = async (token: string, supportedAccount: string): Promi
       headers: {
         Authorization: token,
         'X-Vtex-Original-Credential': token,
-		'x-vtex-upstream-target': env.cluster(),
+        'x-vtex-upstream-target': env.cluster(),
       },
     }
   )
@@ -46,7 +46,7 @@ const loginAsRole = async (token: string, supportedAccount: string, role: string
       headers: {
         Authorization: token,
         'X-Vtex-Original-Credential': token,
-		'x-vtex-upstream-target': env.cluster(),
+        'x-vtex-upstream-target': env.cluster(),
       },
     }
   )

--- a/src/modules/support/login.ts
+++ b/src/modules/support/login.ts
@@ -46,7 +46,7 @@ const loginAsRole = async (token: string, supportedAccount: string, role: string
       headers: {
         Authorization: token,
         'X-Vtex-Original-Credential': token,
-        'x-vtex-upstream-target': env.cluster(),
+        ...(env.cluster() ? { 'x-vtex-upstream-target': env.cluster() } : null),
       },
     }
   )

--- a/src/modules/support/login.ts
+++ b/src/modules/support/login.ts
@@ -14,7 +14,7 @@ const getAvailableRoles = async (token: string, supportedAccount: string): Promi
       headers: {
         Authorization: token,
         'X-Vtex-Original-Credential': token,
-    ...env.cluster() ? { 'x-vtex-upstream-target': env.cluster() } : null,
+        ...(env.cluster() ? { 'x-vtex-upstream-target': env.cluster() } : null),
       },
     }
   )

--- a/src/modules/utils.ts
+++ b/src/modules/utils.ts
@@ -36,7 +36,7 @@ export const IOClientOptions = {
   timeout: (envTimeout || DEFAULT_TIMEOUT) as number,
   retries: 3,
   headers: {
-	'x-vtex-upstream-target': env.cluster()
+    'x-vtex-upstream-target': env.cluster(),
   },
 }
 

--- a/src/modules/utils.ts
+++ b/src/modules/utils.ts
@@ -36,7 +36,7 @@ export const IOClientOptions = {
   timeout: (envTimeout || DEFAULT_TIMEOUT) as number,
   retries: 3,
   headers: {
-    'x-vtex-upstream-target': env.cluster(),
+    ...env.cluster() ? { 'x-vtex-upstream-target': env.cluster() } : null,
   },
 }
 

--- a/src/modules/utils.ts
+++ b/src/modules/utils.ts
@@ -35,6 +35,9 @@ const DEFAULT_TIMEOUT = 10000
 export const IOClientOptions = {
   timeout: (envTimeout || DEFAULT_TIMEOUT) as number,
   retries: 3,
+  headers: {
+	'x-vtex-upstream-target': env.cluster()
+  },
 }
 
 export const getIOContext = () => ({

--- a/src/modules/utils.ts
+++ b/src/modules/utils.ts
@@ -36,7 +36,7 @@ export const IOClientOptions = {
   timeout: (envTimeout || DEFAULT_TIMEOUT) as number,
   retries: 3,
   headers: {
-    ...env.cluster() ? { 'x-vtex-upstream-target': env.cluster() } : null,
+    ...(env.cluster() ? { 'x-vtex-upstream-target': env.cluster() } : null),
   },
 }
 


### PR DESCRIPTION
We must not use HTTP from toolbelt. This PR converts the last of those into HTTPS by calling the new host. HTTP calls to `*.{{region}}.vtex.io` are deprecated and are soon going to stop working, which is also another reason to make this change now.

Another issue that is being fixed by this PR is the fact that we were not encrypting our websockets. Instead of `ws`, we should use `wss`. While this was a trickier change, as Kube Router had a bug that would not allow us to use the new URLs, this bug is fixed in `v6.2.3` and this can be updated here now.

There should be no other instances of `*.{{region}}.vtex.io` in this repo. I have looked for them and I believe I have updated the host everywhere. If any remains, please let me know and/or fix it.
