### PR TITLE
Encode delimiter redirects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed
-- [redirects] Encode delimiter before exporing `.csv` file to avoid conflicts
+- [redirects] Encode delimiter before exporing `.csv` file to avoid conflicts.
 
 ## [2.97.0] - 2020-04-09
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- [redirects] Encode delimiter before exporing `.csv` file to avoid conflicts
 
 ## [2.97.0] - 2020-04-09
 ### Changed

--- a/src/modules/rewriter/import.ts
+++ b/src/modules/rewriter/import.ts
@@ -25,6 +25,7 @@ import {
   validateInput,
   handleReadError,
   RETRY_INTERVAL_S,
+  DELIMITER,
 } from './utils'
 
 const IMPORTS = 'imports'
@@ -133,7 +134,7 @@ export default async (csvPath: string, options: any) => {
       log.info(
         `In case this step fails, run 'vtex redirects delete ${resolve(fileName)}' to finish deleting old redirects.`
       )
-      const json2csvParser = new Parser({ fields: ['from'], delimiter: ';', quote: '' })
+      const json2csvParser = new Parser({ fields: ['from'], delimiter: DELIMITER, quote: '' })
       const csv = json2csvParser.parse(map(route => ({ from: route }), routesToDelete))
       await writeFile(filePath, csv)
       await deleteRedirects(filePath)

--- a/src/modules/rewriter/utils.ts
+++ b/src/modules/rewriter/utils.ts
@@ -52,7 +52,9 @@ const sortFunction = (redirect: Redirect) =>
 
 export const readCSV = async (path: string) => {
   try {
-    const result = (await csv({ delimiter: DELIMITER, ignoreEmpty: true, checkType: true }).fromFile(path)) as Redirect[]
+    const result = (await csv({ delimiter: DELIMITER, ignoreEmpty: true, checkType: true }).fromFile(
+      path
+    )) as Redirect[]
     return sortBy(sortFunction, result)
   } catch (e) {
     handleReadError(path)(e)

--- a/src/modules/rewriter/utils.ts
+++ b/src/modules/rewriter/utils.ts
@@ -10,6 +10,7 @@ import { getAccount, getWorkspace } from '../../conf'
 import { Redirect } from '../../clients/rewriter'
 import log from '../../logger'
 
+export const DELIMITER = ';'
 export const LAST_CHANGE_DATE = 'lastChangeDate'
 export const MAX_ENTRIES_PER_REQUEST = 10
 export const METAINFO_FILE = '.vtex_redirects_metainfo.json'
@@ -51,7 +52,7 @@ const sortFunction = (redirect: Redirect) =>
 
 export const readCSV = async (path: string) => {
   try {
-    const result = (await csv({ delimiter: ';', ignoreEmpty: true, checkType: true }).fromFile(path)) as Redirect[]
+    const result = (await csv({ delimiter: DELIMITER, ignoreEmpty: true, checkType: true }).fromFile(path)) as Redirect[]
     return sortBy(sortFunction, result)
   } catch (e) {
     handleReadError(path)(e)
@@ -106,3 +107,10 @@ export const deleteMetainfo = (metainfo: any, metainfoType: string, fileHash: st
   delete metainfo[metainfoType][fileHash]
   writeJsonSync(METAINFO_FILE, metainfo, { spaces: 2 })
 }
+
+const createEncoder = (delimiter: string) => {
+  const encoded = encodeURIComponent(delimiter)
+  return (x: string) => x.replace(delimiter, encoded)
+}
+
+export const encode = createEncoder(DELIMITER)


### PR DESCRIPTION
#### What is the purpose of this pull request?
Some accounts have a `;` in their urls. This breaks the CSV, since we use `semicolon` as the separator (delimiter). To solve this issue, before exporting a `.csv` file, we need to encode the semicolon

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [x] Update `CHANGELOG.md`