### PR TITLE
Fix setup not running without any flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Increase ErrorReport serialization depth.
-- [vtex setup] Not running when flag `--all` was omited.
+- [vtex setup] Not running when flag `--all` is omitted.
 
 ## [2.97.0] - 2020-04-09
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Increase ErrorReport serialization depth.
+- [vtex setup] Not running when flag `--all` was omited.
 
 ## [2.97.0] - 2020-04-09
 ### Changed

--- a/src/modules/setup/index.ts
+++ b/src/modules/setup/index.ts
@@ -16,9 +16,9 @@ interface SetupOpts {
 
 export default async (opts: SetupOpts) => {
   const all = opts.all || (!opts.tooling && !opts.typings && !opts.tsconfig)
-  const tooling = opts.tooling || opts.all
-  const typings = opts.typings || opts.all
-  const tsconfig = opts.tsconfig || opts.all
+  const tooling = opts.tooling || all
+  const typings = opts.typings || all
+  const tsconfig = opts.tsconfig || all
   const ignoreLinked = opts.i || opts['ignore-linked']
 
   if (ignoreLinked && !(all || typings)) {
@@ -28,6 +28,7 @@ export default async (opts: SetupOpts) => {
   }
 
   const manifest = await getManifest()
+
   if (tooling) {
     setupTooling(manifest)
   }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix a condition where `opts.all` were used instead of the local variable `all`.

#### What problem is this solving?
The command `vtex setup` wasn't doing anything when no flags were passed.

#### How should this be manually tested?
Run `vtex-test setup` and it should correctly run all steps.

#### Screenshots or example usage

Before:

<img width="663" alt="image" src="https://user-images.githubusercontent.com/10223856/79575206-cc0c5a00-8097-11ea-9988-b525b05cd38d.png">

After:

<img width="631" alt="image" src="https://user-images.githubusercontent.com/10223856/79575234-d9294900-8097-11ea-9c8b-4d7f7a7776e2.png">

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [x] Update `CHANGELOG.md`