### PR TITLE
Improve logging in billingClient errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,24 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
-## [2.98.0-beta.5] - 2020-04-20
-
-## [2.98.0-beta.4] - 2020-04-17
-
-## [2.98.0-beta.3] - 2020-04-17
-
-## [2.98.0-beta.2] - 2020-04-17
-
-## [2.98.0-beta.1] - 2020-04-17
-
-## [2.98.0-beta.0] - 2020-04-17
-
-## [2.98.0-beta] - 2020-04-17
-
-## [2.97.2-beta] - 2020-04-17
-
-## [2.97.1-0] - 2020-04-17
+### Changed
+- Improve error logging in install command.
 
 ## [2.97.0] - 2020-04-09
 ### Changed

--- a/src/clients/billingClient.ts
+++ b/src/clients/billingClient.ts
@@ -23,6 +23,9 @@ export default class Billing {
       data: { data, errors },
     } = await this.http.postRaw<any>(`/_v/graphql`, { query: graphQLQuery })
     if (errors) {
+      if (errors.length === 1 && errors[0].extensions?.exception?.response?.data) {
+        throw errors[0].extensions.exception.response.data
+      }
       throw new GraphQlError(errors)
     }
     return data.install


### PR DESCRIPTION
#### What is the purpose of this pull request?
This is an interesting bug. The log in install errors before were very unhelpful. That because billingClient, responsible to proxy the install request from toolbelt to Apps, use a graphql endpoint, and the way toolbelt handled these errors made obscure to the user what was the original error in the Apps API (what made it difficult to solve them). This PR should fix the issue making it easier for the users to fix install errors by themselves.

Screenshots with the error message logged: 
- before:
<img width="1680" alt="Screen Shot 2020-04-20 at 9 19 58 PM" src="https://user-images.githubusercontent.com/13456990/79812192-8fb65380-834e-11ea-906a-0213291c419e.png">
 
- with this PR:
<img width="1680" alt="Screen Shot 2020-04-20 at 9 20 14 PM" src="https://user-images.githubusercontent.com/13456990/79812200-9644cb00-834e-11ea-8501-880b606a57cf.png">

#### How should this be manually tested?
Use this version of toolbelt:
```
cd /tmp && rm -rf toolbelt && \
git clone https://github.com/vtex/toolbelt.git && \
cd toolbelt && \
git checkout feature/improve-error-logging-in-checkout && \
yarn && yarn watch
```
and try to install an app with peer dependencies like `gocommerce.vtexlocal`, making sure its peer dependence (`vtex.vtex-payment-graphql@0.x`) is not installed in the workspace. The message showed should be like the one in the second image.

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [x] Update `CHANGELOG.md`