### PR TITLE
Auto-switch to edition-store when creating new workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update release notes message.
 - Improve SSE errors logs.
 - [vtex setup] Add GraphQL files to `lint-staged` config.
+- [vtex workspace] Auto-switch to edition-store when creating new workspace
 
 ## [2.98.0] - 2020-04-22
 ### Added
@@ -47,7 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [clients:sponsor, vtex support] Use HTTPS and new URL `app.io.vtex.com` format.
 - [telemetry:collector] Flush just before exiting process.
 - [sse] Check if token is valid before creating connection.
-- [sse] Abort process on 401 or 403 server errors. 
+- [sse] Abort process on 401 or 403 server errors.
 - [sse:telemetry] Register sse errors with errorKind `SSEError`.
 - Update release notes message.
 
@@ -67,7 +68,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
  - Command `vtex test e2e` for end-to-end testing.
- 
+
 ## [2.94.0] - 2020-03-31
 ### Added
 - [vtex init] Show `checkout-ui-settings` template for users outside VTEX.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update release notes message.
 - Improve SSE errors logs.
 - [vtex setup] Add GraphQL files to `lint-staged` config.
-- [vtex workspace] Auto-switch to edition-store when creating new workspace
+- [vtex workspace] Auto-switch to edition-store when creating new workspace.
 
 ## [2.98.0] - 2020-04-22
 ### Added

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+# This repository is owned by the Dev Tools team and they are usually the ones that should review a pull request opened
+here.
+*	@vtex/io-devtools

--- a/src/clients/sponsor.ts
+++ b/src/clients/sponsor.ts
@@ -1,4 +1,4 @@
-import { AuthType, InstanceOptions, IOClient, IOContext } from '@vtex/api'
+import { AuthType, InstanceOptions, IOClient, IOContext, AppManifest } from '@vtex/api'
 
 export class Sponsor extends IOClient {
   private account: string
@@ -14,11 +14,16 @@ export class Sponsor extends IOClient {
     this.workspace = workspace
   }
 
-  public getSponsorAccount = async () => this.http.get(this.routes.getSponsorAccount, { metric: 'get-sponsor-account' })
+  public async getSponsorAccount() {
+    const res = await this.http.get(this.routes.getSponsorAccount, { metric: 'get-sponsor-account' })
+    return res?.sponsorAccount as string
+  }
 
-  public getEdition = async () => this.http.get(this.routes.getEdition, { metric: 'get-edition' })
+  public getEdition() {
+    return this.http.get<AppManifest>(this.routes.getEdition, { metric: 'get-edition' })
+  }
 
-  public setEdition = async (account: string, workspace: string, editionApp: string) => {
+  public setEdition(account: string, workspace: string, editionApp: string) {
     const [edition, version] = editionApp.split('@')
     const [sponsor, editionName] = edition.split('.')
     return this.http.post(
@@ -28,15 +33,12 @@ export class Sponsor extends IOClient {
     )
   }
 
-  public runHouseKeeper = async () => this.http.post(this.routes.runHouseKeeper, {}, { metric: 'run-house-keeper' })
-
   private get routes() {
     return {
       getSponsorAccount: `https://platform.io.vtex.com/_account/${this.account}`,
       getEdition: `https://infra.io.vtex.com/apps/v0/${this.account}/${this.workspace}/edition`,
       setEdition: (account: string, workspace: string) =>
         `https://app.io.vtex.com/vtex.tenant-provisioner/v0/${this.account}/master/tenants/${account}/migrate?tenantWorkspace=${workspace}`,
-      runHouseKeeper: `https://infra.io.vtex.com/housekeeper/v0/${this.account}/master/_housekeeping/perform`,
     }
   }
 }

--- a/src/modules/sponsor/setEdition.ts
+++ b/src/modules/sponsor/setEdition.ts
@@ -19,10 +19,10 @@ const promptSwitchToAccount = async (account: string, initial: boolean) => {
   await switchAccount(account, {})
 }
 
-export default async (edition: string) => {
+export default async function setEdition(edition: string, workspace?: string, autoSwitchBack: boolean = false) {
   const previousConf = conf.getAll()
   const targetAccount = previousConf.account
-  const targetWorkspace = previousConf.workspace
+  const targetWorkspace = workspace ?? previousConf.workspace
 
   const workspaceNotice = targetWorkspace === 'master' ? '' : ` in workspace ${chalk.blue(targetWorkspace)}`
   log.info(`Changing edition of account ${chalk.blue(targetAccount)}${workspaceNotice}.`)
@@ -51,6 +51,10 @@ export default async (edition: string) => {
     log.error(`Failed to change edition of account ${chalk.blue(targetAccount)}.`)
     throw ex
   } finally {
-    await switchToPreviousAccount(previousConf)
+    if (autoSwitchBack) {
+      conf.saveAll(previousConf)
+    } else {
+      await switchToPreviousAccount(previousConf)
+    }
   }
 }

--- a/src/modules/sponsor/setEdition.ts
+++ b/src/modules/sponsor/setEdition.ts
@@ -19,7 +19,7 @@ const promptSwitchToAccount = async (account: string, initial: boolean) => {
   await switchAccount(account, {})
 }
 
-export default async function setEdition(edition: string, workspace?: string, autoSwitchBack: boolean = false) {
+export default async function setEdition(edition: string, workspace?: string, autoSwitchBack = false) {
   const previousConf = conf.getAll()
   const targetAccount = previousConf.account
   const targetWorkspace = workspace ?? previousConf.workspace

--- a/src/modules/sponsor/setEdition.ts
+++ b/src/modules/sponsor/setEdition.ts
@@ -1,5 +1,4 @@
 import chalk from 'chalk'
-import R from 'ramda'
 import { Sponsor } from '../../clients/sponsor'
 import * as conf from '../../conf'
 import { CommandError } from '../../errors'
@@ -29,8 +28,7 @@ export default async (edition: string) => {
   log.info(`Changing edition of account ${chalk.blue(previousAccount)}${workspaceNotice}.`)
 
   const sponsorClient = new Sponsor(getIOContext(), IOClientOptions)
-  const data = await sponsorClient.getSponsorAccount()
-  const sponsorAccount = R.prop('sponsorAccount', data)
+  const sponsorAccount = await sponsorClient.getSponsorAccount()
 
   if (!sponsorAccount) {
     if (previousWorkspace !== 'master') {

--- a/src/modules/sponsor/setEdition.ts
+++ b/src/modules/sponsor/setEdition.ts
@@ -21,34 +21,34 @@ const promptSwitchToAccount = async (account: string, initial: boolean) => {
 
 export default async (edition: string) => {
   const previousConf = conf.getAll()
-  const previousAccount = previousConf.account
-  const previousWorkspace = previousConf.workspace
+  const targetAccount = previousConf.account
+  const targetWorkspace = previousConf.workspace
 
-  const workspaceNotice = previousWorkspace === 'master' ? '' : ` in workspace ${chalk.blue(previousWorkspace)}`
-  log.info(`Changing edition of account ${chalk.blue(previousAccount)}${workspaceNotice}.`)
+  const workspaceNotice = targetWorkspace === 'master' ? '' : ` in workspace ${chalk.blue(targetWorkspace)}`
+  log.info(`Changing edition of account ${chalk.blue(targetAccount)}${workspaceNotice}.`)
 
   const sponsorClient = new Sponsor(getIOContext(), IOClientOptions)
   const sponsorAccount = await sponsorClient.getSponsorAccount()
 
   if (!sponsorAccount) {
-    if (previousWorkspace !== 'master') {
+    if (targetWorkspace !== 'master') {
       throw new CommandError('Can only set initial edition in master workspace')
     }
     await promptSwitchToAccount('vtex', true)
   } else {
-    if (previousWorkspace === 'master') {
-      await promptWorkspaceMaster(previousAccount)
+    if (targetWorkspace === 'master') {
+      await promptWorkspaceMaster(targetWorkspace)
     }
     await promptSwitchToAccount(sponsorAccount, false)
   }
 
   try {
     const sponsorClientForSponsorAccount = new Sponsor(getIOContext(), IOClientOptions)
-    await sponsorClientForSponsorAccount.setEdition(previousAccount, previousWorkspace, edition)
+    await sponsorClientForSponsorAccount.setEdition(targetAccount, targetWorkspace, edition)
 
-    log.info(`Successfully changed edition${workspaceNotice} of account ${chalk.blue(previousAccount)}.`)
+    log.info(`Successfully changed edition${workspaceNotice} of account ${chalk.blue(targetAccount)}.`)
   } catch (ex) {
-    log.error(`Failed to change edition of account ${chalk.blue(previousAccount)}.`)
+    log.error(`Failed to change edition of account ${chalk.blue(targetAccount)}.`)
     throw ex
   } finally {
     await switchToPreviousAccount(previousConf)

--- a/src/modules/workspace/common/edition.ts
+++ b/src/modules/workspace/common/edition.ts
@@ -23,12 +23,12 @@ const promptSwitchEdition = (currEditionId: string) => {
   return promptConfirm(`Would you like to change the edition to ${chalk.blue(recommendedEdition)} now?`, false)
 }
 
-export async function ensureValidEdition() {
+export async function ensureValidEdition(workspace: string) {
   const edition = await getCurrEdition()
   if (edition && edition.vendor === 'vtex' && edition.name === 'edition-business') {
     const shouldSwitch = await promptSwitchEdition(edition.id)
     if (shouldSwitch) {
-      await setEditionCmd(recommendedEdition)
+      await setEditionCmd(recommendedEdition, workspace, true)
     }
   }
 }

--- a/src/modules/workspace/common/edition.ts
+++ b/src/modules/workspace/common/edition.ts
@@ -1,0 +1,34 @@
+import { getIOContext, IOClientOptions } from "../../utils"
+import { Sponsor } from '../../../clients/sponsor'
+import log from '../../../logger'
+import chalk from 'chalk'
+import { promptConfirm } from '../../prompts'
+import setEditionCmd from '../../sponsor/setEdition'
+
+const recommendedEdition = "vtex.edition-store@2.x"
+
+const getCurrEdition = () => {
+  const ctx = {
+    ...getIOContext(),
+    workspace: 'master',
+  }
+  const sponsor = new Sponsor(ctx, IOClientOptions)
+  return sponsor.getEdition()
+}
+
+const promptSwitchEdition = (currEditionId: string) => {
+  log.warn(`This account is using the edition ${chalk.blue(currEditionId)}.`)
+  log.warn(`If you are developing your store in IO, it is strongly recommended that you switch to the ${chalk.blue(recommendedEdition)}.`)
+  log.warn(`For more information, visit ${chalk.blue('https://some.doc/about/edition/store')}`)
+  return promptConfirm(`Would you like to change the edition to ${chalk.blue(recommendedEdition)} now?`, false)
+}
+
+export async function ensureValidEdition() {
+  const edition = await getCurrEdition()
+  if (edition && edition.vendor === 'vtex' && edition.name === 'edition-business') {
+    const shouldSwitch = await promptSwitchEdition(edition.id)
+    if (shouldSwitch) {
+      await setEditionCmd(recommendedEdition)
+    }
+  }
+}

--- a/src/modules/workspace/common/edition.ts
+++ b/src/modules/workspace/common/edition.ts
@@ -23,7 +23,7 @@ const promptSwitchEdition = (currEditionId: string) => {
       recommendedEdition
     )}.`
   )
-  log.warn(`For more information, visit ${chalk.blue('https://some.doc/about/edition/store')}`)
+  log.warn(`For more information about editions, check ${chalk.blue('https://vtex.io/docs/concepts/edition-app/')}`)
   return promptConfirm(`Would you like to change the edition to ${chalk.blue(recommendedEdition)} now?`, false)
 }
 

--- a/src/modules/workspace/common/edition.ts
+++ b/src/modules/workspace/common/edition.ts
@@ -1,11 +1,11 @@
-import { getIOContext, IOClientOptions } from "../../utils"
+import { getIOContext, IOClientOptions } from '../../utils'
 import { Sponsor } from '../../../clients/sponsor'
 import log from '../../../logger'
 import chalk from 'chalk'
 import { promptConfirm } from '../../prompts'
 import setEditionCmd from '../../sponsor/setEdition'
 
-const recommendedEdition = "vtex.edition-store@2.x"
+const recommendedEdition = 'vtex.edition-store@2.x'
 
 const getCurrEdition = () => {
   const ctx = {
@@ -18,7 +18,11 @@ const getCurrEdition = () => {
 
 const promptSwitchEdition = (currEditionId: string) => {
   log.warn(`This account is using the edition ${chalk.blue(currEditionId)}.`)
-  log.warn(`If you are developing your store in IO, it is strongly recommended that you switch to the ${chalk.blue(recommendedEdition)}.`)
+  log.warn(
+    `If you are developing your store in IO, it is strongly recommended that you switch to the ${chalk.blue(
+      recommendedEdition
+    )}.`
+  )
   log.warn(`For more information, visit ${chalk.blue('https://some.doc/about/edition/store')}`)
   return promptConfirm(`Would you like to change the edition to ${chalk.blue(recommendedEdition)} now?`, false)
 }

--- a/src/modules/workspace/create.ts
+++ b/src/modules/workspace/create.ts
@@ -33,7 +33,7 @@ export default async (name: string, options: any) => {
         `production=${production}`
       )}`
     )
-    await ensureValidEdition()
+    await ensureValidEdition(name)
     // First request on a brand new workspace takes very long because of route map generation, so we warm it up.
     await warmUpRouteMap(name)
   } catch (err) {

--- a/src/modules/workspace/create.ts
+++ b/src/modules/workspace/create.ts
@@ -5,6 +5,7 @@ import { workspaces, createClients } from '../../clients'
 import { getAccount } from '../../conf'
 import { CommandError } from '../../errors'
 import log from '../../logger'
+import { ensureValidEdition } from './common/edition'
 
 const VALID_WORKSPACE = /^[a-z][a-z0-9]{0,126}[a-z0-9]$/
 
@@ -32,6 +33,7 @@ export default async (name: string, options: any) => {
         `production=${production}`
       )}`
     )
+    await ensureValidEdition()
     // First request on a brand new workspace takes very long because of route map generation, so we warm it up.
     await warmUpRouteMap(name)
   } catch (err) {

--- a/src/modules/workspace/reset.ts
+++ b/src/modules/workspace/reset.ts
@@ -30,7 +30,7 @@ export default async (name: string, options) => {
           `production=${production}`
         )}`
       )
-      await ensureValidEdition()
+      await ensureValidEdition(workspace)
     } catch (err) {
       log.warn(`Workspace ${chalk.green(workspace)} was ${chalk.red('not')} reset`)
       if (err.response) {

--- a/src/modules/workspace/reset.ts
+++ b/src/modules/workspace/reset.ts
@@ -3,6 +3,7 @@ import { workspaces } from '../../clients'
 import { getAccount, getWorkspace } from '../../conf'
 import log from '../../logger'
 import { promptConfirm } from '../prompts'
+import { ensureValidEdition } from './common/edition'
 
 const promptWorkspaceReset = (name: string, account: string) =>
   promptConfirm(`Are you sure you want to reset workspace ${chalk.green(name)} on account ${chalk.blue(account)}?`)
@@ -29,6 +30,7 @@ export default async (name: string, options) => {
           `production=${production}`
         )}`
       )
+      await ensureValidEdition()
     } catch (err) {
       log.warn(`Workspace ${chalk.green(workspace)} was ${chalk.red('not')} reset`)
       if (err.response) {

--- a/src/modules/workspace/use.ts
+++ b/src/modules/workspace/use.ts
@@ -25,7 +25,11 @@ const shouldPromptProduction = (production: boolean): boolean => {
 const recommendedEdition = "vtex.edition-store@2.x"
 
 const getCurrEdition = () => {
-  const sponsor = new Sponsor(getIOContext(), IOClientOptions)
+  const ctx = {
+    ...getIOContext(),
+    workspace: 'master',
+  }
+  const sponsor = new Sponsor(ctx, IOClientOptions)
   return sponsor.getEdition()
 }
 

--- a/src/modules/workspace/use.ts
+++ b/src/modules/workspace/use.ts
@@ -7,9 +7,6 @@ import log from '../../logger'
 import { promptConfirm } from '../prompts'
 import createCmd from './create'
 import resetWks from './reset'
-import { Sponsor } from '../../clients/sponsor'
-import { getIOContext, IOClientOptions } from '../utils'
-import setEditionCmd from '../sponsor/setEdition'
 
 const promptWorkspaceCreation = (name: string) => {
   console.log(chalk.blue('!'), `Workspace ${chalk.green(name)} doesn't exist`)
@@ -20,24 +17,6 @@ const promptWorkspaceProductionFlag = () => promptConfirm('Should the workspace 
 
 const shouldPromptProduction = (production: boolean): boolean => {
   return production === undefined || production === null
-}
-
-const recommendedEdition = "vtex.edition-store@2.x"
-
-const getCurrEdition = () => {
-  const ctx = {
-    ...getIOContext(),
-    workspace: 'master',
-  }
-  const sponsor = new Sponsor(ctx, IOClientOptions)
-  return sponsor.getEdition()
-}
-
-const promptSwitchEdition = (currEditionId: string) => {
-  log.warn(`This account is using the edition ${chalk.blue(currEditionId)}.`)
-  log.warn(`If you are developing your store in IO, it is strongly recommended that you switch to the ${chalk.blue(recommendedEdition)}.`)
-  log.warn(`For more information, visit ${chalk.blue('https://some.doc/about/edition/store')}`)
-  return promptConfirm(`Would you like to change the edition to ${chalk.blue(recommendedEdition)} now?`, false)
 }
 
 export default async (name: string, options?) => {
@@ -76,14 +55,4 @@ export default async (name: string, options?) => {
     await resetWks(name, { production })
   }
   log.info(`You're now using the workspace ${chalk.green(name)} on account ${chalk.blue(accountName)}!`)
-
-  if (reset || created) {
-    const edition = await getCurrEdition()
-    if (edition && edition.vendor === 'vtex' && edition.name === 'edition-business') {
-      const shouldSwitch = await promptSwitchEdition(edition.id)
-      if (shouldSwitch) {
-        await setEditionCmd(recommendedEdition)
-      }
-    }
-  }
 }

--- a/src/modules/workspace/use.ts
+++ b/src/modules/workspace/use.ts
@@ -7,6 +7,9 @@ import log from '../../logger'
 import { promptConfirm } from '../prompts'
 import createCmd from './create'
 import resetWks from './reset'
+import { Sponsor } from '../../clients/sponsor'
+import { getIOContext, IOClientOptions } from '../utils'
+import setEditionCmd from '../sponsor/setEdition'
 
 const promptWorkspaceCreation = (name: string) => {
   console.log(chalk.blue('!'), `Workspace ${chalk.green(name)} doesn't exist`)
@@ -17,6 +20,20 @@ const promptWorkspaceProductionFlag = () => promptConfirm('Should the workspace 
 
 const shouldPromptProduction = (production: boolean): boolean => {
   return production === undefined || production === null
+}
+
+const recommendedEdition = "vtex.edition-store@2.x"
+
+const getCurrEdition = () => {
+  const sponsor = new Sponsor(getIOContext(), IOClientOptions)
+  return sponsor.getEdition()
+}
+
+const promptSwitchEdition = (currEditionId: string) => {
+  log.warn(`This account is using the edition ${chalk.blue(currEditionId)}.`)
+  log.warn(`If you are developing your store in IO, it is strongly recommended that you switch to the ${chalk.blue(recommendedEdition)}.`)
+  log.warn(`For more information, visit ${chalk.blue('https://some.doc/about/edition/store')}`)
+  return promptConfirm(`Would you like to change the edition to ${chalk.blue(recommendedEdition)} now?`, false)
 }
 
 export default async (name: string, options?) => {
@@ -54,4 +71,12 @@ export default async (name: string, options?) => {
     await resetWks(name, { production })
   }
   log.info(`You're now using the workspace ${chalk.green(name)} on account ${chalk.blue(accountName)}!`)
+
+  const edition = await getCurrEdition()
+  if (edition && edition.vendor === 'vtex' && edition.name === 'edition-business') {
+    const shouldSwitch = await promptSwitchEdition(edition.id)
+    if (shouldSwitch) {
+      await setEditionCmd(recommendedEdition)
+    }
+  }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
This is to reduce the noise about our current editions, by creating some
logic in toolbelt to automatically switch to the `edition-store` when the
current account is in the default edition `edition-business`.

The whole context is: 
 - Stores have to be created with the initial edition `edition-business`, as we don't have any
information on whether it is going to be implemented in IO or Portal, and we don't want to
affect the provision experience of accounts running in the legacy/current platform. 
 - If it is going to be developed in IO though, some user in the account will necessarily need to
create a workspace on it for development/test purposes.
 - With that, we got to the realisation that the moment the user creates a workspace is the
ideal time to prompt them to switch their account's edition.

This basically implements that logic, by prompting the user to switch the edition when
they either create or reset a workspacce.

I had implemented it initially on the `vtex use` command, and only later realised that it
should be in the create/reset commands instead. I still kept the whole commit history as
I think the iteration still makes sense for the reviewer, so I think it whole change is still
good for being reviewed commit-by-commit (if the reviewer likes that 😛). 

#### What problem is this solving?
Trying to amend the confusion about our editions and when to switch from the default
edition (business) to the one for stores.

#### How should this be manually tested?
 - `vtex workspace create/reset` should now prompt for switching the account edition if it is in the `edition-business` (e.g. `basedevmkp`)
 - `vtex use` should give that prompt only when the workspace is being created or reset
 - Accounts not in `edition-business` (or without any edition) should not be affected by this
 - Ensure user always end up in a valid context (e.g. should not get stuck in the sponsor account after the update) 
   * For that, play around with the prompts by testing answering `no` to some of them.

#### Screenshots or example usage
![Screen Shot 2020-04-23 at 20 11 02](https://user-images.githubusercontent.com/1613383/80158312-90452900-859e-11ea-8375-6b6204e5b3fb.png)

#### Types of change
- [ ] Refactor (non-breaking change that only makes the code better)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [x] Update `CHANGELOG.md`