### PR TITLE
Customize help format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - [redirects] Encode delimiter before exporing `.csv` file to avoid conflicts.
 
+### Added
+- [hooks:init] Allow to customize help.
+
 ## [2.98.0] - 2020-04-22
 ### Added
 - [telemetry:reporter] Create and send reporter meta metrics.

--- a/src/commands/switch.ts
+++ b/src/commands/switch.ts
@@ -6,7 +6,7 @@ import authSwitch from '../modules/auth/switch'
 export default class Switch extends CustomCommand {
   static description = 'Switch to another VTEX account'
 
-  static examples = ['vtex switch storecomponents', 'vtex switch storecomponents/myworkspace']
+  static examples = ['vtex switch storecomponents']
 
   static flags = {
     ...CustomCommand.globalFlags,

--- a/src/commands/switch.ts
+++ b/src/commands/switch.ts
@@ -6,7 +6,7 @@ import authSwitch from '../modules/auth/switch'
 export default class Switch extends CustomCommand {
   static description = 'Switch to another VTEX account'
 
-  static examples = ['vtex switch storecomponents', 'vtex switch storecomponents myworkspace']
+  static examples = ['vtex switch storecomponents', 'vtex switch storecomponents/myworkspace']
 
   static flags = {
     ...CustomCommand.globalFlags,

--- a/src/oclif/hooks/init.ts
+++ b/src/oclif/hooks/init.ts
@@ -158,12 +158,12 @@ export const onError = async (e: any) => {
 
 export default async function(options: HookKeyOrOptions<'init'>) {
   // overwrite Help#showCommandHelp to customize help formating
-  help.prototype.showCommandHelp = function (command: Config.Command, topics: Config.Topic[]) {
+  help.prototype.showCommandHelp = function(command: Config.Command, topics: Config.Topic[]) {
     const name = command.id
     const depth = name.split(':').length
-    topics = topics.filter(t => t.name.startsWith(name + ':') && t.name.split(':').length === depth + 1)
+    topics = topics.filter(t => t.name.startsWith(`${name}:`) && t.name.split(':').length === depth + 1)
     const title = command.description && this.render(command.description).split('\n')[0]
-    if (title) console.log('\n' + title + '\n')
+    if (title) console.log(`\n${title}\n`)
     console.log(this.command(command))
     console.log('')
     if (topics.length > 0) {

--- a/src/oclif/hooks/init.ts
+++ b/src/oclif/hooks/init.ts
@@ -1,5 +1,7 @@
 import axios from 'axios'
 import os from 'os'
+import help from '@oclif/plugin-help'
+import * as Config from '@oclif/config'
 import { HookKeyOrOptions } from '@oclif/config/lib/hooks'
 
 import { Token } from '../../lib/auth/Token'
@@ -155,6 +157,21 @@ export const onError = async (e: any) => {
 }
 
 export default async function(options: HookKeyOrOptions<'init'>) {
+  // overwrite Help#showCommandHelp to customize help formating
+  help.prototype.showCommandHelp = function (command: Config.Command, topics: Config.Topic[]) {
+    const name = command.id
+    const depth = name.split(':').length
+    topics = topics.filter(t => t.name.startsWith(name + ':') && t.name.split(':').length === depth + 1)
+    const title = command.description && this.render(command.description).split('\n')[0]
+    if (title) console.log('\n' + title + '\n')
+    console.log(this.command(command))
+    console.log('')
+    if (topics.length > 0) {
+      console.log(this.topics(topics))
+      console.log('')
+    }
+  }
+
   axios.interceptors.request.use(config => {
     if (envCookies()) {
       config.headers.Cookie = `${envCookies()}; ${config.headers.Cookie || ''}`


### PR DESCRIPTION
#### What is the purpose of this pull request?
Allow to customize help format. Add a blank line between command and description in help.

#### What problem is this solving?
Improving help format.

#### How should this be manually tested?
With this branch, just use `--help` with any command and see if there is a blank line between the command and its description.

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [x] Update `CHANGELOG.md`