### PR TITLE
Fix install when user cancel command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - [redirects] Encode delimiter before exporing `.csv` file to avoid conflicts.
+- [vtex install] Behaviour when action is cancelled by the user.
 
 ### Added
 - [hooks:init] Allow to customize help.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - [redirects] Encode delimiter before exporing `.csv` file to avoid conflicts.
-- [vtex install] Behaviour when action is cancelled by the user.
+- [vtex install, vtex uninstall] Behaviour when action is cancelled by the user.
 
 ### Added
 - [hooks:init] Allow to customize help.

--- a/src/modules/apps/install.ts
+++ b/src/modules/apps/install.ts
@@ -106,7 +106,8 @@ export const prepareInstall = async (appsList: string[], force: boolean): Promis
 
 export default async (optionalApps: string[], options) => {
   const force = options.f || options.force
-  await validateAppAction('install', optionalApps)
+  const confirm = await validateAppAction('install', optionalApps)
+  if (!confirm) return
   const appsList = optionalApps.length > 0 ? optionalApps : [(await ManifestEditor.getManifestEditor()).appLocator]
   log.debug(`Installing app${appsList.length > 1 ? 's' : ''}: ${appsList.join(', ')}`)
   return prepareInstall(appsList, force)

--- a/src/modules/apps/uninstall.ts
+++ b/src/modules/apps/uninstall.ts
@@ -31,7 +31,8 @@ const uninstallApps = async (appsList: string[]): Promise<void> => {
 }
 
 export default async (optionalApps: string[], options) => {
-  await validateAppAction('uninstall', optionalApps)
+  const confirm = await validateAppAction('uninstall', optionalApps)
+  if (!confirm) return
   const appsList = optionalApps.length > 0 ? optionalApps : [(await ManifestEditor.getManifestEditor()).appLocator]
   const preConfirm = options.y || options.yes
   let promptAnswer

--- a/src/modules/apps/utils.ts
+++ b/src/modules/apps/utils.ts
@@ -47,7 +47,7 @@ export const promptWorkspaceMaster = async account => {
     false
   )
   if (!confirm) {
-    return
+    return false
   }
   log.warn(`Using ${chalk.green('master')} workspace. I hope you know what you're doing. 💥`)
 }
@@ -60,7 +60,10 @@ export const validateAppAction = async (operation: string, app?) => {
     if (!contains(operation, workspaceMasterAllowedOperations)) {
       throw new CommandError(workspaceMasterMessage)
     } else {
-      await promptWorkspaceMaster(account)
+      const confirm = await promptWorkspaceMaster(account)
+      if (!confirm) {
+        return false
+      }
     }
   }
 

--- a/src/modules/apps/utils.ts
+++ b/src/modules/apps/utils.ts
@@ -50,9 +50,10 @@ export const promptWorkspaceMaster = async account => {
     return false
   }
   log.warn(`Using ${chalk.green('master')} workspace. I hope you know what you're doing. 💥`)
+  return true
 }
 
-export const validateAppAction = async (operation: string, app?) => {
+export const validateAppAction = async (operation: string, app?): Promise<boolean> => {
   const account = getAccount()
   const workspace = getWorkspace()
 
@@ -79,6 +80,7 @@ export const validateAppAction = async (operation: string, app?) => {
       `No app was found, please fix your manifest.json${app ? ' or use <vendor>.<name>[@<version>]' : ''}`
     )
   }
+  return true
 }
 
 export const wildVersionByMajor = compose<string, string[], string, string>(concat(__, '.x'), head, split('.'))


### PR DESCRIPTION
#### What is the purpose of this pull request?
When we killed `UserCancelledError`, we accidentally inserted a bug in the install command. When the user answered `no` to a prompt in the install command, the command continued.

![image](https://user-images.githubusercontent.com/13456990/80254986-782ee180-8652-11ea-8333-61f4f280a196.png)

This PR fix this bug.

#### How should this be manually tested?
Try to install an app in the master workspace of an account. A prompt will be showed asking if you are sure. Answer no to the prompt and check if the app was indeed **not installed**.

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [x] Update `CHANGELOG.md`