### PR TITLE
Save workspace promotion info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [hooks:init] Allow to customize help.
 - [child-processes] `DEBUG_CP` environment variable for debugging child processes.
 - Command `vtex lighthouse` for vtex internal Google's Lighthouse tool
+- [vtex promote] Save workspace promotion info in evolution manager.
 
 ### Changed
 - Update release notes message.

--- a/src/clients/evolutionManager.ts
+++ b/src/clients/evolutionManager.ts
@@ -6,8 +6,8 @@ export class EvolutionManager extends AppGraphQLClient {
     super('vtex.evolution-manager-graphql@0.x', context, options)
   }
 
-  public saveWorkspacePromotion = (user: string, workspace: string): Promise<boolean> =>
-    this.graphql
+  public saveWorkspacePromotion(user: string, workspace: string): Promise<boolean> {
+    return this.graphql
       .mutate<{ saveWorkspacePromotion: boolean }, { user: string; workspace: string }>(
         {
           mutate: `mutation {
@@ -32,4 +32,5 @@ export class EvolutionManager extends AppGraphQLClient {
         }
         throw new GraphQlError(errors)
       })
+  }
 }

--- a/src/clients/evolutionManager.ts
+++ b/src/clients/evolutionManager.ts
@@ -1,0 +1,35 @@
+import { InstanceOptions, IOContext, AppGraphQLClient } from '@vtex/api'
+import { GraphQlError } from '../errors'
+
+export class EvolutionManager extends AppGraphQLClient {
+  constructor(context: IOContext, options: InstanceOptions) {
+    super('vtex.evolution-manager-graphql@0.x', context, options)
+  }
+
+  public saveWorkspacePromotion = (user: string, workspace: string): Promise<boolean> =>
+    this.graphql
+      .mutate<{ saveWorkspacePromotion: boolean }, { user: string; workspace: string }>(
+        {
+          mutate: `mutation {
+            saveWorkspacePromotion(workspace: "${workspace}", agent: ${user})
+          }`,
+          variables: { user, workspace },
+        },
+        {
+          metric: 'evolution-manager-workspace-promote',
+        }
+      )
+      .then(res => {
+        return res.data?.saveWorkspacePromotion
+      })
+      .catch(res => {
+        const errors = res.response?.data?.errors
+        if (!errors) {
+          throw new Error('Unknown error while saving promotion in evolution manager.')
+        }
+        if (errors.length === 1 && errors[0].extensions?.exception?.response?.data) {
+          throw errors[0].extensions.exception.response.data
+        }
+        throw new GraphQlError(errors)
+      })
+}

--- a/src/clients/index.ts
+++ b/src/clients/index.ts
@@ -8,6 +8,7 @@ import { dummyLogger } from './dummyLogger'
 import { Rewriter } from './rewriter'
 import { Tester } from './Tester'
 import { Lighthouse } from './Lighthouse'
+import { EvolutionManager } from './evolutionManager'
 import { envTimeout } from '../env'
 
 const DEFAULT_TIMEOUT = 15000
@@ -60,7 +61,7 @@ const createClients = (customContext: Partial<IOContext> = {}, customOptions: In
   }
 }
 
-const [apps, router, workspaces, logger, events, billing, rewriter, tester, lighthouse] = getToken()
+const [apps, router, workspaces, logger, events, billing, rewriter, tester, lighthouse, evolutionManager] = getToken()
   ? [
       new Apps(context, options),
       new Router(context, options),
@@ -71,6 +72,7 @@ const [apps, router, workspaces, logger, events, billing, rewriter, tester, ligh
       new Rewriter(context, options),
       new Tester(context, options),
       new Lighthouse(context, options),
+      new EvolutionManager(context, options),
     ]
   : [
       interceptor<Apps>('apps'),
@@ -82,6 +84,19 @@ const [apps, router, workspaces, logger, events, billing, rewriter, tester, ligh
       interceptor<Rewriter>('rewriter'),
       interceptor<Tester>('Tester'),
       interceptor<Lighthouse>('Lighthouse'),
+      interceptor<EvolutionManager>('EvolutionManager'),
     ]
 
-export { apps, router, workspaces, logger, events, createClients, billing, rewriter, tester, lighthouse }
+export {
+  apps,
+  router,
+  workspaces,
+  logger,
+  events,
+  createClients,
+  billing,
+  rewriter,
+  tester,
+  lighthouse,
+  evolutionManager,
+}

--- a/src/modules/workspace/promote.ts
+++ b/src/modules/workspace/promote.ts
@@ -1,11 +1,12 @@
 import chalk from 'chalk'
 
-import { workspaces } from '../../clients'
+import { evolutionManager, workspaces } from '../../clients'
 import { getAccount, getWorkspace } from '../../conf'
 import { CommandError } from '../../errors'
 import log from '../../logger'
 import { promptConfirm } from '../prompts'
 import useCmd from './use'
+import { SessionManager } from '../../lib/session/SessionManager'
 
 const { promote, get } = workspaces
 const [account, currentWorkspace] = [getAccount(), getWorkspace()]
@@ -40,6 +41,10 @@ export default async () => {
     return
   }
   await promote(account, currentWorkspace)
+
+  const sessionManager = SessionManager.getSessionManager()
+  const userEmail = sessionManager.userLogged
+  await evolutionManager.saveWorkspacePromotion(userEmail, currentWorkspace)
 
   log.info(`Workspace ${chalk.green(currentWorkspace)} promoted successfully`)
   await useCmd('master')


### PR DESCRIPTION
#### What is the purpose of this pull request?
Now evolution manager have an api to save info about workspace promotions (to allow some audit). This PR makes toolbelt call this api when a `promote` command is used successfully.

#### What problem is this solving?
Lack of audibility in workspace promotions.

#### How should this be manually tested?
This is a bit complicated since you will need to promote a workspace. My suggestion is to create a production workspace in a test account like `basedevmkp` and immediately promote it. Wait some seconds, then go to GraphiQL in that account admin, select `evolution-manager-graphql` as your app and try the query:
```
query getPromotions {
  promotions { account, agent, workspace, createdIn }
}
``` 
The result should show your workspace promotion.

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [x] Update `CHANGELOG.md`