### PR TITLE
Fix workspace promote reporting

### DIFF
--- a/src/lib/error/ErrorKinds.ts
+++ b/src/lib/error/ErrorKinds.ts
@@ -1,5 +1,6 @@
 export const enum ErrorKinds {
   DEPRECATION_CHECK_ERROR = 'DeprecationCheckError',
+  EVOLUTION_MANAGER_REPORT_ERROR = 'EvolutionManagerReportError',
   GENERIC_ERROR = 'GenericError',
   INVALID_OR_EXPIRED_TOKEN_ERROR = 'InvalidOrExpiredTokenError',
   REQUEST_ERROR = 'RequestError',


### PR DESCRIPTION
#### What is the purpose of this pull request?
- Handle evolution-manager not installed error

#### How should this be manually tested?
- Checkout to this branch
- `yarn watch`
- Run `vtex-test promote` on a created production workspace

Running `vtex-test promote` on basedevmkp, which doesn't have evolution-manager installed will help testing for this case

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [x] Update `CHANGELOG.md`
(no need to update changelog, this is a fix to an unreleased change)