### PR TITLE
Fix error on edition-less accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
 - Treat errors when checking edition of account on a workspace command.
 
 ## [2.99.0] - 2020-04-29

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Treat errors when checking edition of account on a workspace command.
 
 ## [2.99.0] - 2020-04-29
 ### Fixed

--- a/src/lib/error/ErrorKinds.ts
+++ b/src/lib/error/ErrorKinds.ts
@@ -1,5 +1,6 @@
 export const enum ErrorKinds {
   DEPRECATION_CHECK_ERROR = 'DeprecationCheckError',
+  EDITION_REQUEST_ERROR = 'EditionRequestError',
   EVOLUTION_MANAGER_REPORT_ERROR = 'EvolutionManagerReportError',
   GENERIC_ERROR = 'GenericError',
   INVALID_OR_EXPIRED_TOKEN_ERROR = 'InvalidOrExpiredTokenError',

--- a/src/modules/workspace/common/edition.ts
+++ b/src/modules/workspace/common/edition.ts
@@ -4,6 +4,8 @@ import log from '../../../logger'
 import chalk from 'chalk'
 import { promptConfirm } from '../../prompts'
 import setEditionCmd from '../../sponsor/setEdition'
+import { TelemetryCollector } from '../../../lib/telemetry/TelemetryCollector'
+import { ErrorKinds } from '../../../lib/error/ErrorKinds'
 
 const recommendedEdition = 'vtex.edition-store@2.x'
 
@@ -17,8 +19,14 @@ const getCurrEdition = async () => {
     return await sponsor.getEdition()
   } catch (err) {
     if (err.response?.status !== 404) {
+      TelemetryCollector.createAndRegisterErrorReport({
+        kind: ErrorKinds.EDITION_REQUEST_ERROR,
+        originalError: err,
+      })
+
       log.warn(`Non-fatal error checking account edition: ${err.message}`)
     }
+
     return null
   }
 }

--- a/src/modules/workspace/common/edition.ts
+++ b/src/modules/workspace/common/edition.ts
@@ -7,13 +7,20 @@ import setEditionCmd from '../../sponsor/setEdition'
 
 const recommendedEdition = 'vtex.edition-store@2.x'
 
-const getCurrEdition = () => {
+const getCurrEdition = async () => {
   const ctx = {
     ...getIOContext(),
     workspace: 'master',
   }
   const sponsor = new Sponsor(ctx, IOClientOptions)
-  return sponsor.getEdition()
+  try {
+    return await sponsor.getEdition()
+  } catch (err) {
+    if (err.response?.status !== 404) {
+      log.warn(`Non-fatal error checking account edition: ${err.message}`)
+    }
+    return null
+  }
 }
 
 const promptSwitchEdition = (currEditionId: string) => {


### PR DESCRIPTION
#### What is the purpose of this pull request?
We were throwing a 404 exception on the code for
checking if the account edition was business.

We want to simply ignore any errors there, as this
is a non-crucial operation that should have no effect
if any error occurs. Especially if it is a 404, which means
that the account has no edition set.

We only need to do anything when the account is in the
`vtex.edition-business`, so a 404 should be 100% ok here.
Other errors will still be logged as non-fatal warnings, but
we will eat the exception.

#### What problem is this solving?
Misleading error when creating or resetting workspaces.

#### How should this be manually tested?
 - Go to account that has no edition
 - Create or reset a workspace
 - Should not get any error
 - If some error occurs, should get a non-threatening warn log

#### Screenshots or example usage
Before and after:
<img width="876" alt="Screen Shot 2020-04-29 at 13 08 13" src="https://user-images.githubusercontent.com/1613383/80619013-7da57680-8a1a-11ea-9c3a-54f593294af8.png">

Simulating a non-404 error (I actually inverted the condition in the code to log the warn for 404s. The actual code here won't log 404s):
<img width="1000" alt="Screen Shot 2020-04-29 at 13 09 45" src="https://user-images.githubusercontent.com/1613383/80619174-b47b8c80-8a1a-11ea-8a96-8943bf0b1eb5.png">


#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [x] Update `CHANGELOG.md`