### PR TITLE
Sanitize jwt tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- [telemetry] Sanitize jwt tokens.
 
 ## [2.99.2] - 2020-04-30
 ### Fixed

--- a/src/lib/error/ErrorReport.ts
+++ b/src/lib/error/ErrorReport.ts
@@ -6,7 +6,7 @@ import logger from '../../logger'
 import { SessionManager } from '../session/SessionManager'
 import { EventSourceError } from '../sse/EventSourceError'
 import { getPlatform } from '../utils/getPlatform'
-import { truncateStringsFromObject } from '../utils/truncateStringsFromObject'
+import { truncateAndSanitizeStringsFromObject } from '../utils/truncateAndSanitizeStringsFromObject'
 import { ErrorKinds } from './ErrorKinds'
 
 export interface ErrorCreationArguments {
@@ -189,7 +189,7 @@ export class ErrorReport extends Error {
       ...(this.originalError.code ? { code: this.originalError.code } : null),
     }
 
-    return truncateStringsFromObject(
+    return truncateAndSanitizeStringsFromObject(
       errorReportObj,
       ErrorReport.MAX_ERROR_STRING_LENGTH,
       ErrorReport.MAX_SERIALIZATION_DEPTH

--- a/src/lib/utils/__snapshots__/truncateAndSanitizeStringsFromObject.test.ts.snap
+++ b/src/lib/utils/__snapshots__/truncateAndSanitizeStringsFromObject.test.ts.snap
@@ -92,3 +92,29 @@ Object {
   "b": Symbol(symbol description 2),
 }
 `;
+
+exports[`Works on testcase 11 - String limit 5 1`] = `
+Object {
+  "b": "any",
+  "token": "a.b",
+}
+`;
+
+exports[`Works on testcase 12 - String limit 20 1`] = `
+Object {
+  "AuThOrIzAtIoN": "Bearer aa.bb",
+  "AuthToken": "!jwt",
+  "auth": "b.c",
+  "authToken": "a.b",
+}
+`;
+
+exports[`Works on testcase 13 - String limit 20 1`] = `
+Object {
+  "auth": Object {
+    "authToken": "m.n",
+  },
+}
+`;
+
+exports[`Works on testcase 14 - String limit 5 1`] = `"12345[...TRUNCATED]"`;


### PR DESCRIPTION
#### What is the purpose of this pull request?
Sanitize jwt tokens before sending to telemetry 

#### How should this be manually tested?
```
git checkout fix/telemetry-sanitize-tokens
yarn watch
```
Run `vtex-test workspace reset` on master.
It will give an error and an ErrorID
Check the errorId on splunk and check the authorization key - it should have the format:
```
Bearer aaaaaa.bbbbb
```
You can go to jwt.io to check it

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [x] Update `CHANGELOG.md`