### PR TITLE
Simplify buffer serialization on error reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed
-- [telemetry] Sanitize jwt tokens.
+- [telemetry] Sanitize jwt tokens and simplify buffers serializtion.
 
 ## [2.99.2] - 2020-04-30
 ### Fixed

--- a/src/lib/utils/__snapshots__/truncateAndSanitizeStringsFromObject.test.ts.snap
+++ b/src/lib/utils/__snapshots__/truncateAndSanitizeStringsFromObject.test.ts.snap
@@ -118,3 +118,13 @@ Object {
 `;
 
 exports[`Works on testcase 14 - String limit 5 1`] = `"12345[...TRUNCATED]"`;
+
+exports[`Works on testcase 15 - String limit 5 1`] = `
+Object {
+  "b": "a str[...TRUNCATED]",
+  "buf": Object {
+    "byteLength": 14,
+    "type": "buffer",
+  },
+}
+`;

--- a/src/lib/utils/truncateAndSanitizeStringsFromObject.test.ts
+++ b/src/lib/utils/truncateAndSanitizeStringsFromObject.test.ts
@@ -22,6 +22,7 @@ it.each([
   [20, { AuThOrIzAtIoN: 'Bearer aa.bb.cc', authToken: 'a.b.c', auth: 'b.c.d', AuthToken: '!jwt' }],
   [20, { auth: { authToken: 'm.n.o' } }],
   [5, '123456'],
+  [5, { buf: Buffer.from('this is a test'), b: 'a string' }],
 ])('Works on testcase %# - String limit %d', (limit: number, obj: any) => {
   expect(truncateAndSanitizeStringsFromObject(obj, limit)).toMatchSnapshot()
 })

--- a/src/lib/utils/truncateAndSanitizeStringsFromObject.ts
+++ b/src/lib/utils/truncateAndSanitizeStringsFromObject.ts
@@ -29,6 +29,10 @@ export function truncateAndSanitizeStringsFromObject(
       return '[circular]'
     }
 
+    if (Buffer.isBuffer(element)) {
+      return { type: 'buffer', byteLength: Buffer.byteLength(element) }
+    }
+
     if (depth === 0) {
       return Array.isArray(element) ? `[array]` : `[object]`
     }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Buffers will now be serialized as `{byteLength: 123, type: "buffer"}` instead of a giant array of bytes.

#### How should this be manually tested?
```
git checkout fix/sanitize-buffers

yarn watch
```
- Disconnect from internet
- Run `vtex-test workspace reset` to trigger an error
- Telemetry will try to report the error by sending a buffer to the backend - this operation will fail
- Reconnect to internet
- Run `vtex-test workspace reset` when on master to trigger an error and a flush
- After some time check splunk for the error with buffer:
```
index=io_vtex_logs app=vtex.toolbelt-telemetry@* data.errorDetails.requestConfig.data.byteLength!=NULL
```

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [x] Update `CHANGELOG.md`