### PR TITLE
Update space separated commands plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.99.4-beta] - 2020-05-07
+
 ## [2.99.3] - 2020-05-05
 ### Fixed
 - [telemetry] Sanitize jwt tokens and simplify buffers serializtion.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.99.4-beta.0] - 2020-05-07
+
 ## [2.99.4-beta] - 2020-05-07
 
 ## [2.99.3] - 2020-05-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.99.4-beta.1] - 2020-05-07
+
 ## [2.99.4-beta.0] - 2020-05-07
 
 ## [2.99.4-beta] - 2020-05-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
-## [2.99.4-beta.1] - 2020-05-07
-
-## [2.99.4-beta.0] - 2020-05-07
-
-## [2.99.4-beta] - 2020-05-07
+### Updated
+- [oclif] `oclif-plugin-spaced-commands` to fix alias documentation.
 
 ## [2.99.3] - 2020-05-05
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.99.3",
+  "version": "2.99.4-beta",
   "description": "The platform for e-commerce apps",
   "bin": "bin/run",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.99.4-beta",
+  "version": "2.99.4-beta.0",
   "description": "The platform for e-commerce apps",
   "bin": "bin/run",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@oclif/command": "^1.0.0",
     "@oclif/config": "^1.0.0",
     "@oclif/plugin-help": "^2.0.0",
-    "@tiagonapoli/oclif-plugin-spaced-commands": "^0.0.5",
+    "@tiagonapoli/oclif-plugin-spaced-commands": "^0.0.6",
     "@vtex/api": "3.71.1",
     "@vtex/toolbelt-message-renderer": "^0.0.1",
     "@yarnpkg/lockfile": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.99.4-beta.0",
+  "version": "2.99.4-beta.1",
   "description": "The platform for e-commerce apps",
   "bin": "bin/run",
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -586,10 +586,10 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
-"@tiagonapoli/oclif-plugin-spaced-commands@^0.0.5":
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/@tiagonapoli/oclif-plugin-spaced-commands/-/oclif-plugin-spaced-commands-0.0.5.tgz#a3cf570ea0f8a4bde2d17804160b0ad6ef2de1b1"
-  integrity sha512-S7vyXRFoBCI+EknaIbp8QqvaXzHVUaVGLUa37MmbcDQmG3wlecGq3X8iUrIxd8O6iqYwBBWnC1X89wKXP8vFww==
+"@tiagonapoli/oclif-plugin-spaced-commands@^0.0.6":
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/@tiagonapoli/oclif-plugin-spaced-commands/-/oclif-plugin-spaced-commands-0.0.6.tgz#c1fef84cd4066b75871ea5405f44f2efbd680151"
+  integrity sha512-3CLDT46LQsXU+O0UpE/FG7FtdG8HOtOK8HyIzcdxJ/CY4dRDRX+BH0zWNqVprCh1DV/fcm7TrLA3X2FIJhj7UQ==
   dependencies:
     "@oclif/command" "^1.0.0"
     "@oclif/config" "^1.0.0"


### PR DESCRIPTION
#### What is the purpose of this pull request?
Update plugin for space separated commands. The new version of this plugin fix the alias documentation for subcommand alias that before where still being displayed with `:`.

#### What problem is this solving?
Fix minor issue in help documentation.

#### How should this be manually tested?
With the beta version released, try `vtex workspace list --help` and see if the `ALIASES` field display the alias with space instead of `:`.

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [x] Update `CHANGELOG.md`