### PR TITLE
test e2e Screenshot and video assets updated according to tester-hub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [vtex test e2e] Show screenshot and videos assets URLs received from `vtex.tester-hub` new API.
 
 ## Fixed
-- Show screenshot and videos assets URLs received from `vtex.tester-hub` new API.
+- [vtex test e2e] Show screenshot and videos assets URLs received from `vtex.tester-hub` new API.
 
 ## [2.99.3] - 2020-05-05
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Fixed
 - [vtex test e2e] Show screenshot and videos assets URLs received from `vtex.tester-hub` new API.
 
-## Fixed
-- [vtex test e2e] Show screenshot and videos assets URLs received from `vtex.tester-hub` new API.
-
 ## [2.99.3] - 2020-05-05
 ### Fixed
 - [telemetry] Sanitize jwt tokens and simplify buffers serializtion.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Updated
 - [oclif] `oclif-plugin-spaced-commands` to fix alias documentation.
 
+## Fixed
+- [vtex test e2e] Screenshot and video assets updated according to tester-hub.
+
 ## [2.99.3] - 2020-05-05
 ### Fixed
 - [telemetry] Sanitize jwt tokens and simplify buffers serializtion.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [vtex test e2e] Show screenshot and videos assets URLs received from `vtex.tester-hub` new API.
 
 ## Fixed
-- [vtex test e2e] Screenshot and video assets updated according to tester-hub.
+- Show screenshot and videos assets URLs received from `vtex.tester-hub` new API.
 
 ## [2.99.3] - 2020-05-05
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Fixed
 - [vtex test e2e] Show screenshot and videos assets URLs received from `vtex.tester-hub` new API.
 
+## Fixed
+- [vtex test e2e] Screenshot and video assets updated according to tester-hub.
+
 ## [2.99.3] - 2020-05-05
 ### Fixed
 - [telemetry] Sanitize jwt tokens and simplify buffers serializtion.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [oclif] `oclif-plugin-spaced-commands` to fix alias documentation.
 
 ## Fixed
-- Show screenshot and videos assets URLs received from `vtex.tester-hub` new API.
+- [vtex test e2e] Show screenshot and videos assets URLs received from `vtex.tester-hub` new API.
 
 ## [2.99.3] - 2020-05-05
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [oclif] `oclif-plugin-spaced-commands` to fix alias documentation.
 
 ## Fixed
-- [vtex test e2e] Screenshot and video assets updated according to tester-hub.
+- Show screenshot and videos assets URLs received from `vtex.tester-hub` new API.
 
 ## [2.99.3] - 2020-05-05
 ### Fixed

--- a/src/clients/Tester.ts
+++ b/src/clients/Tester.ts
@@ -14,7 +14,7 @@ export interface Screenshot {
   name?: string
   testId: string
   takenAt: string
-  path: string
+  path?: string
   height: number
   width: number
 }
@@ -33,10 +33,10 @@ export interface SpecReport {
     }
     tests: SpecTestReport[]
     video?: string
-    logs?: string
     screenshots: Screenshot[]
   }
   logId?: string
+  specId?: string
   lastUpdate: number
 }
 

--- a/src/modules/apps/e2e/report/completedApps.tsx
+++ b/src/modules/apps/e2e/report/completedApps.tsx
@@ -19,7 +19,7 @@ interface SpecResult {
   specReport: SpecReport
 }
 
-export const Completed: React.FunctionComponent<AppProps> = ({ appId, specs }) => {
+export const Completed: React.FunctionComponent<AppProps> = ({ appId, specs, testId }) => {
   const failedSpecs = Object.keys(specs).reduce((acum, curSpecName) => {
     if (specs[curSpecName].state !== 'passed') {
       acum.push({ specName: curSpecName, specReport: specs[curSpecName] })
@@ -40,7 +40,7 @@ export const Completed: React.FunctionComponent<AppProps> = ({ appId, specs }) =
       </Box>
       <Box flexDirection="column" marginLeft={2}>
         {failedSpecs.map(({ specReport, specName }) => (
-          <FailedSpec key={specName} spec={specName} report={specReport} />
+          <FailedSpec key={specName} spec={specName} report={specReport} hubTestId={testId} />
         ))}
       </Box>
     </Box>

--- a/src/modules/apps/e2e/report/failedApps.tsx
+++ b/src/modules/apps/e2e/report/failedApps.tsx
@@ -113,7 +113,7 @@ const ErrorVisualization: React.FunctionComponent<ErrorVisualizationProps> = ({
       {testScreenshots.length > 0 && (
         <FailedSpecDetail label="Screenshots" text={testScreenshotsUrl} indented={testScreenshots.length > 1} />
       )}
-      {testVideo && <FailedSpecDetail label="Video" text={videoUrl} indented={false} />}
+      {testVideo === 'true' && <FailedSpecDetail label="Video" text={videoUrl} indented={false} />}
     </Box>
   )
 }

--- a/src/modules/apps/e2e/report/failedApps.tsx
+++ b/src/modules/apps/e2e/report/failedApps.tsx
@@ -35,8 +35,8 @@ interface SpecProps {
 }
 
 export const FailedSpec: React.FunctionComponent<SpecProps> = ({ spec, report, hubTestId }) => {
-  const logId = report.logId
-  const specId = report.specId
+  const { logId } = report
+  const { specId } = report
 
   const video = report.report?.video
   const screenshots = report.report?.screenshots
@@ -92,10 +92,15 @@ const ErrorVisualization: React.FunctionComponent<ErrorVisualizationProps> = ({
   testScreenshots,
   testVideo,
   specId,
-  testId
+  testId,
 }) => {
   const { account, workspace } = SessionManager.getSingleton()
-  const testScreenshotsUrl = testScreenshots.map(curScreenshot => `${workspace}--${account}.myvtex.com/_v/screenshot/${testId}/${specId}/${curScreenshot.screenshotId}`).join('\n')
+  const testScreenshotsUrl = testScreenshots
+    .map(
+      curScreenshot =>
+        `${workspace}--${account}.myvtex.com/_v/screenshot/${testId}/${specId}/${curScreenshot.screenshotId}`
+    )
+    .join('\n')
   const videoUrl = testVideo === 'true' ? `${workspace}--${account}.myvtex.com/_v/video/${testId}/${specId}` : 'false'
   return (
     <Box key={title.join('')} flexDirection="column">

--- a/src/modules/apps/e2e/report/failedApps.tsx
+++ b/src/modules/apps/e2e/report/failedApps.tsx
@@ -3,6 +3,7 @@ import { Box, Color, Text } from 'ink'
 
 import { SpecReport, SpecTestReport, Screenshot } from '../../../../clients/Tester'
 import { SessionManager } from '../../../../lib/session/SessionManager'
+import { publicEndpoint } from '../../../../env'
 
 interface SpecDetailProps {
   label: string
@@ -35,8 +36,7 @@ interface SpecProps {
 }
 
 export const FailedSpec: React.FunctionComponent<SpecProps> = ({ spec, report, hubTestId }) => {
-  const { logId } = report
-  const { specId } = report
+  const { logId, specId } = report
 
   const video = report.report?.video
   const screenshots = report.report?.screenshots
@@ -72,6 +72,11 @@ export const FailedSpec: React.FunctionComponent<SpecProps> = ({ spec, report, h
   )
 }
 
+const workspaceBaseURL = () => {
+  const { account, workspace } = SessionManager.getSingleton()
+  return `${workspace}--${account}.${publicEndpoint()}`
+}
+
 interface ErrorVisualizationProps {
   title: SpecTestReport['title']
   body: SpecTestReport['body']
@@ -94,14 +99,11 @@ const ErrorVisualization: React.FunctionComponent<ErrorVisualizationProps> = ({
   specId,
   testId,
 }) => {
-  const { account, workspace } = SessionManager.getSingleton()
+  const baseURL = workspaceBaseURL()
   const testScreenshotsUrl = testScreenshots
-    .map(
-      curScreenshot =>
-        `${workspace}--${account}.myvtex.com/_v/screenshot/${testId}/${specId}/${curScreenshot.screenshotId}`
-    )
+    .map(curScreenshot => `${baseURL}/_v/screenshot/${testId}/${specId}/${curScreenshot.screenshotId}`)
     .join('\n')
-  const videoUrl = testVideo === 'true' ? `${workspace}--${account}.myvtex.com/_v/video/${testId}/${specId}` : 'false'
+  const videoUrl = testVideo === 'true' ? `${baseURL}/_v/video/${testId}/${specId}` : ''
   return (
     <Box key={title.join('')} flexDirection="column">
       <FailedSpecDetail label="Test" text={title.join(' ')} indented={false} />

--- a/src/modules/apps/e2e/report/failedApps.tsx
+++ b/src/modules/apps/e2e/report/failedApps.tsx
@@ -2,6 +2,7 @@ import * as React from 'react'
 import { Box, Color, Text } from 'ink'
 
 import { SpecReport, SpecTestReport, Screenshot } from '../../../../clients/Tester'
+import { SessionManager } from '../../../../lib/session/SessionManager'
 
 interface SpecDetailProps {
   label: string
@@ -30,11 +31,14 @@ const FailedSpecDetail: React.FunctionComponent<SpecDetailProps> = ({ label, tex
 interface SpecProps {
   spec: string
   report: SpecReport
+  hubTestId: string
 }
 
-export const FailedSpec: React.FunctionComponent<SpecProps> = ({ spec, report }) => {
+export const FailedSpec: React.FunctionComponent<SpecProps> = ({ spec, report, hubTestId }) => {
+  const logId = report.logId
+  const specId = report.specId
+
   const video = report.report?.video
-  const logs = report.report?.logs
   const screenshots = report.report?.screenshots
   const notPassedSpecs = (report.report?.tests ?? []).filter(({ state }) => state !== 'passed')
 
@@ -48,6 +52,9 @@ export const FailedSpec: React.FunctionComponent<SpecProps> = ({ spec, report })
         error={error}
         stack={stack}
         testScreenshots={testScreenshots}
+        testVideo={video}
+        specId={specId}
+        testId={hubTestId}
       />
     )
   })
@@ -58,8 +65,8 @@ export const FailedSpec: React.FunctionComponent<SpecProps> = ({ spec, report })
       <Box flexDirection="column" marginLeft={2}>
         {report.error && <FailedSpecDetail label="Error" text={report.error} indented />}
         {errorsVisualization}
-        {video && <FailedSpecDetail label="Video" text={video} indented={false} />}
-        {logs && <FailedSpecDetail label="Logs" text={logs} indented={false} />}
+        {specId && <FailedSpecDetail label="SpecId" text={specId} indented={false} />}
+        {logId && <FailedSpecDetail label="LogId" text={logId} indented={false} />}
       </Box>
     </Box>
   )
@@ -72,6 +79,9 @@ interface ErrorVisualizationProps {
   stack: SpecTestReport['stack']
 
   testScreenshots: Screenshot[]
+  testVideo: string
+  specId: string
+  testId: string
 }
 
 const ErrorVisualization: React.FunctionComponent<ErrorVisualizationProps> = ({
@@ -80,8 +90,13 @@ const ErrorVisualization: React.FunctionComponent<ErrorVisualizationProps> = ({
   error,
   stack,
   testScreenshots,
+  testVideo,
+  specId,
+  testId
 }) => {
-  const testScreenshotsText = testScreenshots.map(curScreenshot => ` ${curScreenshot.path}`).join('\n')
+  const { account, workspace } = SessionManager.getSingleton()
+  const testScreenshotsUrl = testScreenshots.map(curScreenshot => `${workspace}--${account}.myvtex.com/_v/screenshot/${testId}/${specId}/${curScreenshot.screenshotId}`).join('\n')
+  const videoUrl = testVideo === 'true' ? `${workspace}--${account}.myvtex.com/_v/video/${testId}/${specId}` : 'false'
   return (
     <Box key={title.join('')} flexDirection="column">
       <FailedSpecDetail label="Test" text={title.join(' ')} indented={false} />
@@ -89,8 +104,9 @@ const ErrorVisualization: React.FunctionComponent<ErrorVisualizationProps> = ({
       {stack && <FailedSpecDetail label="Stack" text={stack} indented />}
       {error && <FailedSpecDetail label="Error" text={error} indented />}
       {testScreenshots.length > 0 && (
-        <FailedSpecDetail label="Screenshots" text={testScreenshotsText} indented={testScreenshots.length > 1} />
+        <FailedSpecDetail label="Screenshots" text={testScreenshotsUrl} indented={testScreenshots.length > 1} />
       )}
+      {testVideo && <FailedSpecDetail label="Video" text={videoUrl} indented={false} />}
     </Box>
   )
 }

--- a/src/modules/apps/e2e/report/index.tsx
+++ b/src/modules/apps/e2e/report/index.tsx
@@ -24,19 +24,21 @@ interface AppTest {
 export interface ReportProps {
   completedAppTests: AppTest[]
   runningAppTests: AppTest[]
+  testId?: string
 }
 
 export interface AppProps {
   appId: string
   specs: AppReport
+  testId?: string
 }
 
-const Report: React.FunctionComponent<ReportProps> = ({ completedAppTests, runningAppTests }) => {
+const Report: React.FunctionComponent<ReportProps> = ({ completedAppTests, runningAppTests, testId }) => {
   return (
     <Box flexDirection="column">
       <Static>
         {completedAppTests.map(({ appId, specs }) => (
-          <Completed key={appId} appId={appId} specs={specs} />
+          <Completed key={appId} appId={appId} specs={specs} testId={testId} />
         ))}
       </Static>
 
@@ -110,7 +112,7 @@ export const RealTimeReport: React.FunctionComponent<RealTimeReport> = ({
 
   return (
     <Box flexDirection="column">
-      <Report {...report} />
+      <Report {...report} testId={testId} />
       <Box marginTop={1}>
         <Summary {...report} testId={testId} requestedAt={requestedAt} />
       </Box>


### PR DESCRIPTION
#### What is the purpose of this pull request?

tester-hub was updated, changing the way the test results assets are accessed by the user. So the toolbelt `vtex test e2e` must be changed accordingly.

#### How should this be manually tested?

An app with cypress tests must be used, I recommend `shipping-preview`
add `"cypress": "0.x"` builder to its manifest
ensure that there is no   `"video": false` parameter on `cypress.json`
The app must be linked first then you should use the command `vtex tet e2e`

it should appear a working link to the video and screenshot assets at the test results

#### Screenshots or example usage

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [x] Update `CHANGELOG.md`