### PR TITLE
Fix undeprecate 403. Add telemetry on deprecate and undeprecate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Fixed
 - [clients:billing] Use new URL format.
 - [vtex test e2e] Show screenshot and videos assets URLs received from `vtex.tester-hub` new API.
+- [vtex undeprecate] 403 error when account switch is necessary.
 
 ### Updated
 - [oclif] `oclif-plugin-spaced-commands` to fix alias documentation.

--- a/src/modules/apps/deprecate.ts
+++ b/src/modules/apps/deprecate.ts
@@ -1,7 +1,9 @@
 import chalk from 'chalk'
 import { createRegistryClient } from '../../lib/clients/IOClients/infra/Registry'
+import { ErrorReport } from '../../lib/error/ErrorReport'
 import { ManifestEditor, ManifestValidator } from '../../lib/manifest'
 import { SessionManager } from '../../lib/session/SessionManager'
+import { TelemetryCollector } from '../../lib/telemetry/TelemetryCollector'
 import { parseLocator } from '../../locator'
 import log from '../../logger'
 import { returnToPreviousAccount, switchAccount } from '../auth/switch'
@@ -46,15 +48,21 @@ const prepareAndDeprecateApps = async (appsList: string[]): Promise<any> => {
       await deprecateApp(app)
       log.info('Successfully deprecated', app)
     } catch (e) {
+      const errReport = ErrorReport.create({ originalError: e })
+
       if (e.response && e.response.status && e.response.status === 404) {
         log.error(`Error deprecating ${app}. App not found`)
+        errReport.logErrorForUser({ coreLogLevelDefault: 'debug' })
+        TelemetryCollector.getCollector().registerError(errReport)
       } else if (e.message && e.response.statusText) {
         log.error(`Error deprecating ${app}. ${e.message}. ${e.response.statusText}`)
+        errReport.logErrorForUser({ coreLogLevelDefault: 'debug' })
+        TelemetryCollector.getCollector().registerError(errReport)
         return returnToPreviousAccount({ previousAccount: originalAccount, previousWorkspace: originalWorkspace })
       } else {
         // eslint-disable-next-line no-await-in-loop
         await returnToPreviousAccount({ previousAccount: originalAccount, previousWorkspace: originalWorkspace })
-        throw e
+        throw errReport
       }
     }
   }

--- a/src/modules/apps/undeprecate.ts
+++ b/src/modules/apps/undeprecate.ts
@@ -49,7 +49,7 @@ const prepareUndeprecate = async (appsList: string[]): Promise<void> => {
       log.info('Successfully undeprecated', app)
     } catch (e) {
       const errReport = ErrorReport.create({ originalError: e })
-      
+
       if (e.response && e.response.status && e.response.status === 404) {
         log.error(`Error undeprecating ${app}. App not found.`)
         errReport.logErrorForUser({ coreLogLevelDefault: 'debug' })
@@ -68,6 +68,8 @@ const prepareUndeprecate = async (appsList: string[]): Promise<void> => {
       }
     }
   }
+
+  await returnToPreviousAccount({ previousAccount: originalAccount, previousWorkspace: originalWorkspace })
 }
 
 export default async (optionalApps: string[], options) => {

--- a/src/modules/apps/undeprecate.ts
+++ b/src/modules/apps/undeprecate.ts
@@ -1,5 +1,6 @@
 import chalk from 'chalk'
 import { createRegistryClient } from '../../lib/clients/IOClients/infra/Registry'
+import { ErrorReport } from '../../lib/error/ErrorReport'
 import { ManifestEditor, ManifestValidator } from '../../lib/manifest'
 import { SessionManager } from '../../lib/session/SessionManager'
 import { parseLocator } from '../../locator'
@@ -46,17 +47,23 @@ const prepareUndeprecate = async (appsList: string[]): Promise<void> => {
       await undeprecateApp(app)
       log.info('Successfully undeprecated', app)
     } catch (e) {
+      const errReport = ErrorReport.create({
+        originalError: e,
+      })
+
       if (e.response && e.response.status && e.response.status === 404) {
-        log.error(`Error undeprecating ${app}. App not found`)
+        log.error(`Error undeprecating ${app}. App not found.`)
+        log.error(`ErrorID: ${errReport.errorId}`)
       } else if (e.message && e.response.statusText) {
         log.error(`Error undeprecating ${app}. ${e.message}. ${e.response.statusText}`)
+        log.error(`ErrorID: ${errReport.errorId}`)
         // eslint-disable-next-line no-await-in-loop
         await returnToPreviousAccount({ previousAccount: originalAccount, previousWorkspace: originalWorkspace })
         return
       } else {
         // eslint-disable-next-line no-await-in-loop
         await returnToPreviousAccount({ previousAccount: originalAccount, previousWorkspace: originalWorkspace })
-        throw e
+        throw errReport
       }
     }
   }


### PR DESCRIPTION
#### What is the purpose of this pull request?
The token used by `vtex deprecate` was the one from the previous account (when switching is necessary for deprecating an app) - this was fixed.

Also, telemetry was added on `vtex deprecate` and `vtex undeprecate` errors.

#### How should this be manually tested?
```
git checkout chore/telemetry-undeprecate

yarn watch
```
 
From an account different than `vtex`, run:
```
vtex-test deprecate vtex.service-example@0.1.0-beta.0
vtex-test undeprecate vtex.service-example@0.1.0-beta.0
```

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [x] Update `CHANGELOG.md`