### PR TITLE
Create command config reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- [vtex config] Config reset command.
 - [welcome, login, switch] Add welcome command.
 
 ### Changed

--- a/src/commands/config/reset.ts
+++ b/src/commands/config/reset.ts
@@ -1,0 +1,24 @@
+import { CustomCommand } from '../../oclif/CustomCommand'
+import configReset from '../../modules/config/reset'
+
+export default class ConfigReset extends CustomCommand {
+  static description = 'Reset the requested configuration to the default value'
+
+  static aliases = []
+
+  static examples = ['vtex config reset env', 'vtex config reset cluster']
+
+  static flags = {
+    ...CustomCommand.globalFlags,
+  }
+
+  static args = [{ name: 'configName', required: true, options: ['env', 'cluster'] }]
+
+  async run() {
+    const {
+      args: { configName },
+    } = this.parse(ConfigReset)
+
+    configReset(configName)
+  }
+}

--- a/src/conf.ts
+++ b/src/conf.ts
@@ -11,6 +11,10 @@ export enum Environment {
   Production = 'prod',
 }
 
+export const CLUSTER_DEFAULT_VALUE = ''
+
+export const ENV_DEFAULT_VALUE = Environment.Production
+
 export const saveEnvironment = (env: Environment) => conf.set('env', env)
 
 export const saveStickyHost = (appName: string, stickyHost: string) =>
@@ -31,7 +35,7 @@ const envFromProcessEnv = {
 
 export const getEnvironment = (): Environment => {
   const env = envFromProcessEnv[process.env.VTEX_ENV]
-  const persisted = conf.get('env') || Environment.Production
+  const persisted = conf.get('env') || ENV_DEFAULT_VALUE
   return env || persisted
 }
 
@@ -44,5 +48,5 @@ export const saveCluster = (cluster: string) => {
 }
 
 export const getCluster = () => {
-  return conf.get('cluster') || ''
+  return conf.get('cluster') || CLUSTER_DEFAULT_VALUE
 }

--- a/src/modules/config/reset.ts
+++ b/src/modules/config/reset.ts
@@ -1,0 +1,17 @@
+import chalk from 'chalk'
+
+import { CommandError } from '../../errors'
+import { saveEnvironment, saveCluster, ENV_DEFAULT_VALUE, CLUSTER_DEFAULT_VALUE } from '../../conf'
+
+export default (name: string) => {
+  switch (name) {
+    case 'env':
+      saveEnvironment(ENV_DEFAULT_VALUE)
+      break
+    case 'cluster':
+      saveCluster(CLUSTER_DEFAULT_VALUE)
+      break
+    default:
+      throw new CommandError(`The supported configurations are: ${chalk.blue('env')}, ${chalk.blue('cluster')}`)
+  }
+}


### PR DESCRIPTION
#### What is the purpose of this pull request?
Create a toolbelt command to reset the config values.

#### What problem is this solving?
Lack of a way to reset the config values to their default automatically.

#### How should this be manually tested?
In a test workspace, try `vtex-test config reset env` and `vtex-test config reset cluster`. The new value for `cluster` should be ` ` and the new value for `env` should be `prod`.

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [x] Update `CHANGELOG.md`