### PR TITLE
Change evolution manager error report log level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - [ErrorReport] Use `@vtex/node-error-report`.
+- [vtex promote] Change log level on evolution manager report error from `error` to `debug`.
 
 ## [2.100.0] - 2020-05-11
 ### Added

--- a/src/modules/workspace/promote.ts
+++ b/src/modules/workspace/promote.ts
@@ -50,7 +50,7 @@ export default async () => {
   try {
     await evolutionManager.saveWorkspacePromotion(userEmail, currentWorkspace)
   } catch (err) {
-    log.error('Failed to report workspace promotion to Evolution Manager')
+    log.debug('Failed to report workspace promotion to Evolution Manager')
     ErrorReport.createAndRegisterOnTelemetry({
       originalError: err,
       kind: ErrorKinds.EVOLUTION_MANAGER_REPORT_ERROR,


### PR DESCRIPTION
#### What is the purpose of this pull request?
Change evolution manager error report log level from `error` to `debug`