### PR TITLE
Add docs location message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- [vtex publish] message referencing location of the published docs if any
+- [vtex publish] Message referencing location of the published docs if any.
 
 ## [2.100.1] - 2020-05-12
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- [vtex publish] message referencing location of the published docs if any
 
 ## [2.100.1] - 2020-05-12
 ### Changed

--- a/src/modules/apps/publish.ts
+++ b/src/modules/apps/publish.ts
@@ -104,7 +104,9 @@ const publisher = (workspace = 'master') => {
       log.info(`You can deploy it with: ${chalk.blueBright(`vtex deploy ${appId}`)}`)
 
       if (manifest.builders?.docs) {
-        log.info(`Your app documentation will be available at: ${chalk.yellowBright(`https://vtex.io/docs/app/${appId}`)}`)
+        log.info(
+          `Your app documentation will be available at: ${chalk.yellowBright(`https://vtex.io/docs/app/${appId}`)}`
+        )
       }
     } catch (e) {
       log.error(`Failed to publish ${appId}`)

--- a/src/modules/apps/publish.ts
+++ b/src/modules/apps/publish.ts
@@ -104,7 +104,7 @@ const publisher = (workspace = 'master') => {
       log.info(`You can deploy it with: ${chalk.blueBright(`vtex deploy ${appId}`)}`)
 
       if (manifest.builders?.docs) {
-        log.info(`Your documentation will be available at: ${chalk.yellowBright(`https://vtex.io/docs/app/${appId}`)}`)
+        log.info(`Your app documentation will be available at: ${chalk.yellowBright(`https://vtex.io/docs/app/${appId}`)}`)
       }
     } catch (e) {
       log.error(`Failed to publish ${appId}`)

--- a/src/modules/apps/publish.ts
+++ b/src/modules/apps/publish.ts
@@ -68,7 +68,6 @@ const publisher = (workspace = 'master') => {
   const publishApps = async (path: string, tag: string, force: boolean): Promise<void | never> => {
     const session = SessionManager.getSingleton()
     const manifest = await ManifestEditor.getManifestEditor()
-
     const builderHubMessage = await checkBuilderHubMessage('publish')
     if (builderHubMessage != null) {
       await showBuilderHubMessage(builderHubMessage.message, builderHubMessage.prompt, manifest)
@@ -102,6 +101,10 @@ const publisher = (workspace = 'master') => {
 
       log.info(`${appId} was published successfully!`)
       log.info(`You can deploy it with: ${chalk.blueBright(`vtex deploy ${appId}`)}`)
+
+      if (manifest.builders?.docs) {
+        log.info(`Your documentation will be available at: ${chalk.yellowBright(`https://vtex.io/docs/app/${appId}`)}`)
+      }
     } catch (e) {
       log.error(`Failed to publish ${appId}`)
     }

--- a/src/modules/apps/publish.ts
+++ b/src/modules/apps/publish.ts
@@ -68,6 +68,7 @@ const publisher = (workspace = 'master') => {
   const publishApps = async (path: string, tag: string, force: boolean): Promise<void | never> => {
     const session = SessionManager.getSingleton()
     const manifest = await ManifestEditor.getManifestEditor()
+
     const builderHubMessage = await checkBuilderHubMessage('publish')
     if (builderHubMessage != null) {
       await showBuilderHubMessage(builderHubMessage.message, builderHubMessage.prompt, manifest)


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
To make it clear for the community of VTEX IO developers that their docs are available in vtex.io/docs

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
Most VTEX IO developers outside VTEX are not aware of this feature. I've aligned with Bia to also announce it in the next Release Notes.

#### How should this be manually tested?
Publish an app with and without docs to see (or not) the message

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/11340665/81953604-428c7100-95de-11ea-89a9-79a6f1fcae4e.png)

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [x] Update `CHANGELOG.md`