### PR TITLE
Create workspace when logging in into a non-existent one

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
+**/__mocks__
 **/*.test.ts
 /src/__tests__

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- [vtex login, vtex switch] Prompt workspace creation if it doesn't exist.
+
+### Changed
+- [ErrorReport] Do not send wrong usage errors to telemetry.
 
 ## [2.101.0] - 2020-05-19
 ### Added

--- a/src/commands/workspace/create.ts
+++ b/src/commands/workspace/create.ts
@@ -1,6 +1,6 @@
 import { flags as oclifFlags } from '@oclif/command'
 
-import workspaceCreate from '../../modules/workspace/create'
+import { workspaceCreator } from '../../modules/workspace/create'
 import { CustomCommand } from '../../oclif/CustomCommand'
 
 export default class WorkspaceCreate extends CustomCommand {
@@ -21,6 +21,11 @@ export default class WorkspaceCreate extends CustomCommand {
       flags: { production },
     } = this.parse(WorkspaceCreate)
 
-    await workspaceCreate(workspaceName, { production })
+    await workspaceCreator({
+      targetWorkspace: workspaceName,
+      promptCreation: false,
+      logIfAlreadyExists: true,
+      productionWorkspace: production,
+    })
   }
 }

--- a/src/lib/clients/eventSources/AppLogsEventSource.ts
+++ b/src/lib/clients/eventSources/AppLogsEventSource.ts
@@ -67,7 +67,7 @@ export class AppLogsEventSource {
     }
 
     es.onerror = err => {
-      const rep = ErrorReport.createAndRegisterOnTelemetry({
+      const rep = ErrorReport.createAndMaybeRegisterOnTelemetry({
         kind: ErrorKinds.APP_LOGS_SSE_ERROR,
         originalError: err,
       })
@@ -79,7 +79,7 @@ export class AppLogsEventSource {
         log.info(inspect(JSON.parse(msg.data).data, true, 4, true))
       } catch (e) {
         log.error(e, msg.data)
-        ErrorReport.createAndRegisterOnTelemetry({
+        ErrorReport.createAndMaybeRegisterOnTelemetry({
           kind: ErrorKinds.APP_LOGS_PARSE_ERROR,
           originalError: e,
         })

--- a/src/lib/error/ErrorReport.ts
+++ b/src/lib/error/ErrorReport.ts
@@ -11,6 +11,15 @@ import logger from '../../logger'
 import { SessionManager } from '../session/SessionManager'
 import { getPlatform } from '../utils/getPlatform'
 import { TelemetryCollector } from '../telemetry/TelemetryCollector'
+import { CommandError } from '../../errors'
+
+interface CustomErrorReportCreateArgs extends ErrorReportCreateArgs {
+  shouldRemoteReport?: boolean
+}
+
+interface CustomErrorReportBaseConstructorArgs extends ErrorReportBaseConstructorArgs {
+  shouldRemoteReport: boolean
+}
 
 interface ErrorEnv {
   account: string
@@ -39,15 +48,27 @@ interface LogToUserOptions {
 }
 
 export class ErrorReport extends ErrorReportBase {
-  public static create(args: ErrorReportCreateArgs) {
-    return new ErrorReport(createErrorReportBaseArgs(args))
+  public static checkIfShouldRemoteReport(err: Error | any) {
+    if (err instanceof CommandError) {
+      return false
+    }
+
+    return true
   }
 
-  public static createAndRegisterOnTelemetry(args: ErrorReportCreateArgs) {
-    return ErrorReport.create(args).sendToTelemetry()
+  public static create(args: CustomErrorReportCreateArgs) {
+    return new ErrorReport({
+      shouldRemoteReport: args.shouldRemoteReport ?? ErrorReport.checkIfShouldRemoteReport(args.originalError),
+      ...createErrorReportBaseArgs(args),
+    })
   }
 
-  constructor(args: ErrorReportBaseConstructorArgs) {
+  public static createAndMaybeRegisterOnTelemetry(args: CustomErrorReportCreateArgs) {
+    return ErrorReport.create(args).maybeSendToTelemetry()
+  }
+
+  public shouldRemoteReport: boolean
+  constructor(args: CustomErrorReportBaseConstructorArgs) {
     const { workspace, account } = SessionManager.getSingleton()
 
     const env: ErrorEnv = {
@@ -66,6 +87,8 @@ export class ErrorReport extends ErrorReportBase {
         env,
       },
     })
+
+    this.shouldRemoteReport = args.shouldRemoteReport
   }
 
   public logErrorForUser(opts?: LogToUserOptions) {
@@ -89,7 +112,10 @@ export class ErrorReport extends ErrorReportBase {
 
     logger[coreLogLevels.errorKind](chalk`{bold ErrorKind:} ${this.kind}`)
     logger[coreLogLevels.errorMessage](chalk`{bold Message:} ${this.message}`)
-    logger[coreLogLevels.errorId](chalk`{bold ErrorID:} ${this.metadata.errorId}`)
+
+    if (this.shouldRemoteReport) {
+      logger[coreLogLevels.errorId](chalk`{bold ErrorID:} ${this.metadata.errorId}`)
+    }
 
     if (isRequestInfo(this.parsedInfo)) {
       const { method, url } = this.parsedInfo.requestConfig
@@ -104,8 +130,8 @@ export class ErrorReport extends ErrorReportBase {
     return this
   }
 
-  public sendToTelemetry() {
-    if (!this.isErrorReported()) {
+  public maybeSendToTelemetry() {
+    if (this.shouldRemoteReport && !this.isErrorReported()) {
       TelemetryCollector.getCollector().registerError(this)
     }
 

--- a/src/lib/session/SessionManager.ts
+++ b/src/lib/session/SessionManager.ts
@@ -13,14 +13,14 @@ interface WorkspaceCreation {
   onError: (targetWorkspace: string, err: Error | any) => void
 }
 
-interface LoginInput {
+export interface LoginInput {
   targetWorkspace?: string
   authMethod?: string
   useCachedToken?: boolean
   workspaceCreation: WorkspaceCreation
 }
 
-interface WorkspaceSwitchInput {
+export interface WorkspaceSwitchInput {
   targetWorkspace: string
   workspaceCreation: WorkspaceCreation
 }

--- a/src/lib/session/SessionManager.ts
+++ b/src/lib/session/SessionManager.ts
@@ -4,11 +4,37 @@ import { Token } from '../auth/Token'
 import { ErrorKinds } from '../error/ErrorKinds'
 import { ErrorReport } from '../error/ErrorReport'
 import { SessionsPersister, SessionsPersisterBase } from './SessionsPersister'
+import { WorkspaceCreateResult, WorkspaceCreator } from './WorkspaceCreator'
 
-export interface LoginOptions {
+interface WorkspaceCreation {
+  production?: boolean
+  promptCreation: boolean
+  creator: WorkspaceCreator
+  onError: (targetWorkspace: string, err: Error | any) => void
+}
+
+interface LoginInput {
   targetWorkspace?: string
   authMethod?: string
   useCachedToken?: boolean
+  workspaceCreation: WorkspaceCreation
+}
+
+interface WorkspaceSwitchInput {
+  targetWorkspace: string
+  workspaceCreation: WorkspaceCreation
+}
+
+interface WorkspaceSwitchMasterInput {
+  targetWorkspace: 'master'
+}
+
+export type WorkspaceSwitchResult = WorkspaceCreateResult | 'not-changed'
+
+function isWorkspaceSwitchMaster(
+  el: WorkspaceSwitchInput | WorkspaceSwitchMasterInput
+): el is WorkspaceSwitchMasterInput {
+  return el.targetWorkspace === 'master'
 }
 
 export interface ISessionManager {
@@ -21,9 +47,9 @@ export interface ISessionManager {
   lastUsedWorkspace: string
   checkValidCredentials: () => boolean
   checkAndGetToken: (exitOnInvalid?: boolean) => string
-  login: (newAccount: string, opts: LoginOptions) => Promise<void>
+  login: (newAccount: string, opts: LoginInput) => Promise<void>
   logout: () => void
-  workspaceSwitch: (newWorkspace: string) => void
+  workspaceSwitch: (input: WorkspaceSwitchInput) => Promise<WorkspaceSwitchResult>
 }
 
 interface SessionManagerArguments {
@@ -118,7 +144,7 @@ export class SessionManager implements ISessionManager {
 
   public async login(
     newAccount: string,
-    { targetWorkspace = 'master', authMethod = 'oauth', useCachedToken = true }: LoginOptions
+    { targetWorkspace = 'master', authMethod = 'oauth', useCachedToken = true, workspaceCreation }: LoginInput
   ) {
     if (this.account !== newAccount) {
       this.state.lastAccount = this.account
@@ -127,20 +153,18 @@ export class SessionManager implements ISessionManager {
 
     const cachedToken = new Token(this.sessionPersister.getAccountToken(newAccount))
     if (useCachedToken && cachedToken.isValid()) {
-      this.state.account = newAccount
-      this.state.workspace = targetWorkspace
       this.state.tokenObj = cachedToken
-      this.saveState()
-      return
+    } else {
+      // Tokens are scoped by workspace - logging into master will grant cacheability
+      const { token } = await this.authProviders[authMethod].login(newAccount, 'master')
+      this.state.tokenObj = new Token(token)
+      this.sessionPersister.saveAccountToken(newAccount, this.state.tokenObj.token)
     }
 
-    // Tokens are scoped by workspace - logging into master will grant cacheability
-    const { token } = await this.authProviders[authMethod].login(newAccount, 'master')
     this.state.account = newAccount
-    this.state.workspace = targetWorkspace
-    this.state.tokenObj = new Token(token)
+    this.state.workspace = 'master'
     this.saveState()
-    this.sessionPersister.saveAccountToken(newAccount, this.state.tokenObj.token)
+    await this.workspaceSwitch({ targetWorkspace, workspaceCreation })
   }
 
   public logout() {
@@ -151,14 +175,43 @@ export class SessionManager implements ISessionManager {
     return this.tokenObj.isValid() && !!this.state.account && !!this.state.workspace
   }
 
-  public workspaceSwitch(newWorkspace: string) {
-    if (this.state.workspace === newWorkspace) {
-      return
+  public async workspaceSwitch(
+    input: WorkspaceSwitchInput | WorkspaceSwitchMasterInput
+  ): Promise<WorkspaceSwitchResult> {
+    const { targetWorkspace } = input
+    if (this.state.workspace === targetWorkspace) {
+      return 'not-changed'
     }
 
-    this.state.lastWorkspace = this.state.workspace
-    this.state.workspace = newWorkspace
-    this.saveWorkspaceData()
+    let result: WorkspaceCreateResult
+    if (!isWorkspaceSwitchMaster(input)) {
+      try {
+        result = await input.workspaceCreation.creator({
+          targetWorkspace,
+          productionWorkspace: input.workspaceCreation.production,
+          promptCreation: input.workspaceCreation.promptCreation,
+          logIfAlreadyExists: false,
+          clientContext: {
+            account: this.account,
+            token: this.token,
+            workspace: this.workspace,
+          },
+        })
+      } catch (err) {
+        input.workspaceCreation.onError(targetWorkspace, err)
+        result = 'error'
+      }
+    } else {
+      result = 'exists'
+    }
+
+    if (result === 'created' || result === 'exists') {
+      this.state.lastWorkspace = this.state.workspace
+      this.state.workspace = targetWorkspace
+      this.saveWorkspaceData()
+    }
+
+    return result
   }
 
   /* This should not be used - implement another login method instead */

--- a/src/lib/session/WorkspaceCreator.ts
+++ b/src/lib/session/WorkspaceCreator.ts
@@ -1,0 +1,15 @@
+interface WorkspaceCreatorInput {
+  targetWorkspace: string
+  productionWorkspace?: boolean
+  promptCreation?: boolean
+  logIfAlreadyExists?: boolean
+  clientContext?: {
+    token: string
+    workspace: string
+    account: string
+  }
+}
+
+export type WorkspaceCreateResult = 'exists' | 'created' | 'cancelled' | 'error'
+
+export type WorkspaceCreator = (input: WorkspaceCreatorInput) => Promise<WorkspaceCreateResult>

--- a/src/lib/session/__mocks__/SessionManager.ts
+++ b/src/lib/session/__mocks__/SessionManager.ts
@@ -1,5 +1,5 @@
 import { Token } from '../../auth/Token'
-import { ISessionManager, LoginOptions } from '../SessionManager'
+import { ISessionManager, LoginInput, WorkspaceSwitchInput, WorkspaceSwitchResult } from '../SessionManager'
 
 export class SessionManagerMock implements ISessionManager {
   private static singleton: SessionManagerMock
@@ -39,7 +39,7 @@ export class SessionManagerMock implements ISessionManager {
     return this.token
   }
 
-  public login(newAccount: string, { targetWorkspace = 'master' }: LoginOptions) {
+  public login(newAccount: string, { targetWorkspace = 'master' }: LoginInput) {
     this.account = newAccount
     this.workspace = targetWorkspace
     return Promise.resolve()
@@ -47,8 +47,9 @@ export class SessionManagerMock implements ISessionManager {
 
   public logout() {}
 
-  public workspaceSwitch(newWorkspace: string) {
-    this.workspace = newWorkspace
+  public async workspaceSwitch({ targetWorkspace }: WorkspaceSwitchInput): Promise<WorkspaceSwitchResult> {
+    this.workspace = targetWorkspace
+    return 'exists'
   }
 }
 

--- a/src/lib/sse/index.ts
+++ b/src/lib/sse/index.ts
@@ -16,7 +16,7 @@ const onOpen = (type: string) => () => log.debug(`Connected to ${type} server`)
 
 const onError = (type: string) => (err: EventSourceError) => {
   log.error(`Connection to ${type} server has failed with status ${err.event.status}`)
-  ErrorReport.createAndRegisterOnTelemetry({
+  ErrorReport.createAndMaybeRegisterOnTelemetry({
     kind: ErrorKinds.SSE_ERROR,
     originalError: err,
   }).logErrorForUser({ coreLogLevelDefault: 'debug', logLevels: { core: { errorId: 'error' } } })
@@ -174,7 +174,7 @@ export const onAuth = (
       const errMessage = `Connection to login server has failed${
         err.event.status ? ` with status ${err.event.status}` : ''
       }`
-      ErrorReport.createAndRegisterOnTelemetry({
+      ErrorReport.createAndMaybeRegisterOnTelemetry({
         kind: ErrorKinds.SSE_ERROR,
         originalError: err,
       }).logErrorForUser({ coreLogLevelDefault: 'debug', logLevels: { core: { errorId: 'error' } } })

--- a/src/modules/auth/switch.ts
+++ b/src/modules/auth/switch.ts
@@ -4,6 +4,7 @@ import { CommandError } from '../../errors'
 import { SessionManager } from '../../lib/session/SessionManager'
 import log from '../../logger'
 import { promptConfirm } from '../prompts'
+import { handleErrorCreatingWorkspace, workspaceCreator } from '../workspace/create'
 import welcome from './welcome'
 
 interface SwitchOptions {
@@ -34,7 +35,15 @@ const checkAndSwitch = async (targetAccount: string, targetWorkspace: string) =>
     throw new CommandError(`You're already using the account ${chalk.blue(targetAccount)}`)
   }
 
-  await session.login(targetAccount, { targetWorkspace })
+  await session.login(targetAccount, {
+    targetWorkspace,
+    workspaceCreation: {
+      promptCreation: true,
+      creator: workspaceCreator,
+      onError: handleErrorCreatingWorkspace,
+    },
+  })
+
   const { account, workspace, userLogged } = session
 
   log.info(`Logged into ${chalk.blue(account)} as ${chalk.green(userLogged)} at workspace ${chalk.green(workspace)}`)

--- a/src/modules/auth/welcome.ts
+++ b/src/modules/auth/welcome.ts
@@ -73,7 +73,7 @@ const getEditionStatus = async (): Promise<EditionStatus> => {
     if (err.response?.data?.code === 'resource_not_found') {
       isEditionSet = false
     } else {
-      ErrorReport.createAndRegisterOnTelemetry({
+      ErrorReport.createAndMaybeRegisterOnTelemetry({
         kind: ErrorKinds.EDITION_REQUEST_ERROR,
         originalError: err,
       }).logErrorForUser({ coreLogLevelDefault: 'debug' })
@@ -116,7 +116,7 @@ export default async () => {
     const { data } = await apps.listApps()
     appArray = data
   } catch (err) {
-    ErrorReport.createAndRegisterOnTelemetry({
+    ErrorReport.createAndMaybeRegisterOnTelemetry({
       originalError: err,
     }).logErrorForUser({ coreLogLevelDefault: 'debug' })
 

--- a/src/modules/lighthouse/auditUrl.ts
+++ b/src/modules/lighthouse/auditUrl.ts
@@ -37,7 +37,7 @@ export default async (url: string, option: any) => {
   } catch (error) {
     spinner.stop()
 
-    ErrorReport.createAndRegisterOnTelemetry({ originalError: error })
+    ErrorReport.createAndMaybeRegisterOnTelemetry({ originalError: error })
     log.error(error)
   }
 }

--- a/src/modules/lighthouse/showReports.ts
+++ b/src/modules/lighthouse/showReports.ts
@@ -37,7 +37,7 @@ export async function showReports(app: string | undefined, url: string | undefin
   } catch (error) {
     spinner.stop()
 
-    ErrorReport.createAndRegisterOnTelemetry({ originalError: error })
+    ErrorReport.createAndMaybeRegisterOnTelemetry({ originalError: error })
     log.error(error)
   }
 }

--- a/src/modules/setup/setupTSConfig.ts
+++ b/src/modules/setup/setupTSConfig.ts
@@ -61,7 +61,7 @@ export const setupTSConfig = async (manifest: Manifest, warnOnNoBuilderCandidate
     log.info('Finished setting up tsconfig.json')
   } catch (err) {
     log.error('Failed setting up tsconfig.json')
-    ErrorReport.createAndRegisterOnTelemetry({
+    ErrorReport.createAndMaybeRegisterOnTelemetry({
       kind: ErrorKinds.SETUP_TSCONFIG_ERROR,
       originalError: err,
     }).logErrorForUser()

--- a/src/modules/setup/setupTooling.ts
+++ b/src/modules/setup/setupTooling.ts
@@ -160,7 +160,7 @@ export function setupTooling(manifest: Manifest, buildersWithTooling = BUILDERS_
     setupBuilderTools(builders)
     logger.info('Finished setting up tooling')
   } catch (err) {
-    ErrorReport.createAndRegisterOnTelemetry({
+    ErrorReport.createAndMaybeRegisterOnTelemetry({
       kind: ErrorKinds.SETUP_TOOLING_ERROR,
       originalError: err,
     }).logErrorForUser()

--- a/src/modules/setup/setupTypings.ts
+++ b/src/modules/setup/setupTypings.ts
@@ -52,7 +52,7 @@ const appsWithTypingsURLs = async (appDependencies: Record<string, any>, ignoreL
         result[appName] = await appTypingsURL(appName, appVersion, ignoreLinked)
       } catch (err) {
         log.error(`Unable to generate typings URL for ${appName}@${appVersion}.`)
-        ErrorReport.createAndRegisterOnTelemetry({
+        ErrorReport.createAndMaybeRegisterOnTelemetry({
           kind: ErrorKinds.SETUP_TYPINGS_ERROR,
           originalError: err,
         }).logErrorForUser({
@@ -105,7 +105,7 @@ const injectTypingsInPackageJson = async (appDeps: Record<string, any>, ignoreLi
       runYarn(builder, true)
     } catch (e) {
       log.error(`Error running Yarn in ${builder}.`)
-      ErrorReport.createAndRegisterOnTelemetry({
+      ErrorReport.createAndMaybeRegisterOnTelemetry({
         kind: ErrorKinds.SETUP_TSCONFIG_ERROR,
         originalError: e,
       })
@@ -146,7 +146,7 @@ export const setupTypings = async (
     )
     log.info('Finished setting up typings')
   } catch (err) {
-    ErrorReport.createAndRegisterOnTelemetry({
+    ErrorReport.createAndMaybeRegisterOnTelemetry({
       kind: ErrorKinds.SETUP_TYPINGS_ERROR,
       originalError: err,
     }).logErrorForUser()

--- a/src/modules/support/login.ts
+++ b/src/modules/support/login.ts
@@ -65,7 +65,7 @@ const assertToken = (raw: string): void => {
 const saveSupportCredentials = (account: string, token: string): void => {
   const session = SessionManager.getSingleton()
   session.DEPRECATEDchangeAccount(account)
-  session.workspaceSwitch('master')
+  session.workspaceSwitch({ targetWorkspace: 'master' })
   session.DEPRECATEDchangeToken(token)
 }
 

--- a/src/modules/workspace/common/edition.ts
+++ b/src/modules/workspace/common/edition.ts
@@ -14,7 +14,7 @@ const getCurrEdition = async () => {
     return await sponsor.getEdition()
   } catch (err) {
     if (err.response?.status !== 404) {
-      ErrorReport.createAndRegisterOnTelemetry({
+      ErrorReport.createAndMaybeRegisterOnTelemetry({
         kind: ErrorKinds.EDITION_REQUEST_ERROR,
         originalError: err,
       })

--- a/src/modules/workspace/create.ts
+++ b/src/modules/workspace/create.ts
@@ -1,12 +1,21 @@
+import { Workspaces } from '@vtex/api'
 import chalk from 'chalk'
 import { CommandError } from '../../errors'
 import { Builder } from '../../lib/clients/IOClients/apps/Builder'
 import { createWorkspacesClient } from '../../lib/clients/IOClients/infra/Workspaces'
+import { ErrorReport } from '../../lib/error/ErrorReport'
 import { SessionManager } from '../../lib/session/SessionManager'
+import { WorkspaceCreator } from '../../lib/session/WorkspaceCreator'
 import log from '../../logger'
+import { promptConfirm } from '../prompts'
 import { ensureValidEdition } from './common/edition'
 
 const VALID_WORKSPACE = /^[a-z][a-z0-9]{0,126}[a-z0-9]$/
+
+const promptWorkspaceCreation = (name: string) => {
+  console.log(chalk.blue('!'), `Workspace ${chalk.green(name)} doesn't exist`)
+  return promptConfirm('Do you wish to create it?')
+}
 
 const warmUpRouteMap = async (workspace: string) => {
   try {
@@ -16,31 +25,87 @@ const warmUpRouteMap = async (workspace: string) => {
   } catch (err) {} // eslint-disable-line no-empty
 }
 
-export default async (name: string, options: any) => {
-  if (!VALID_WORKSPACE.test(name)) {
+const promptWorkspaceProductionFlag = () => promptConfirm('Should the workspace be in production mode?', false)
+
+const maybeLogWorkspaceAlreadyExists = (targetWorkspace: string, logIfAlreadyExists: boolean) => {
+  if (!logIfAlreadyExists) {
+    return
+  }
+
+  log.error(`Workspace '${targetWorkspace}' already exists.`)
+}
+
+export const handleErrorCreatingWorkspace = (targetWorkspace: string, err: Error | ErrorReport | any) => {
+  log.error(`Failed to create workspace '${targetWorkspace}': ${err.message}`)
+  const rep = ErrorReport.createAndMaybeRegisterOnTelemetry({ originalError: err })
+  if (rep.shouldRemoteReport) {
+    log.error(`ErrorID: ${rep.metadata.errorId}`)
+  }
+}
+
+export const workspaceExists = async (account: string, workspace: string, workspacesClient: Workspaces) => {
+  try {
+    await workspacesClient.get(account, workspace)
+    return true
+  } catch (err) {
+    if (err.response?.status === 404) {
+      return false
+    }
+
+    throw err
+  }
+}
+
+export const workspaceCreator: WorkspaceCreator = async ({
+  targetWorkspace,
+  clientContext,
+  productionWorkspace,
+  promptCreation,
+  logIfAlreadyExists = true,
+}) => {
+  if (!VALID_WORKSPACE.test(targetWorkspace)) {
     throw new CommandError("Whoops! That's not a valid workspace name. Please use only lowercase letters and numbers.")
   }
-  log.debug('Creating workspace', name)
-  let production = false
-  if (options.p || options.production) {
-    production = true
+
+  const { account, workspace, token } = clientContext ?? SessionManager.getSingleton()
+  const workspaces = createWorkspacesClient({ workspace, account, authToken: token })
+
+  if (await workspaceExists(account, targetWorkspace, workspaces)) {
+    maybeLogWorkspaceAlreadyExists(targetWorkspace, logIfAlreadyExists)
+    return 'exists'
   }
+
+  if (promptCreation && !(await promptWorkspaceCreation(targetWorkspace))) {
+    return 'cancelled'
+  }
+
+  if (productionWorkspace == null) {
+    productionWorkspace = await promptWorkspaceProductionFlag()
+  }
+
+  log.debug('Creating workspace', targetWorkspace)
+
   try {
-    const workspaces = createWorkspacesClient()
-    await workspaces.create(SessionManager.getSingleton().account, name, production)
+    await workspaces.create(account, targetWorkspace, productionWorkspace)
+
     log.info(
-      `Workspace ${chalk.green(name)} created ${chalk.green('successfully')} with ${chalk.green(
-        `production=${production}`
+      `Workspace ${chalk.green(targetWorkspace)} created ${chalk.green('successfully')} with ${chalk.green(
+        `production=${productionWorkspace}`
       )}`
     )
-    await ensureValidEdition(name)
+
+    await ensureValidEdition(targetWorkspace)
+
     // First request on a brand new workspace takes very long because of route map generation, so we warm it up.
-    await warmUpRouteMap(name)
+    warmUpRouteMap(targetWorkspace)
+
+    return 'created'
   } catch (err) {
-    if (err.response && err.response.data.code === 'WorkspaceAlreadyExists') {
-      log.error(err.response.data.message)
+    if (err.response?.data.code === 'WorkspaceAlreadyExists') {
+      maybeLogWorkspaceAlreadyExists(targetWorkspace, logIfAlreadyExists)
       return
     }
+
     throw err
   }
 }

--- a/src/modules/workspace/use.ts
+++ b/src/modules/workspace/use.ts
@@ -12,7 +12,7 @@ interface WorkspaceUseOptions {
 
 export default async (name: string, options?: WorkspaceUseOptions) => {
   const session = SessionManager.getSingleton()
-  const production = options.production ?? undefined
+  const production = options?.production
   const reset = options?.reset ?? false
 
   if (name === '-') {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,5 +14,5 @@
     "importHelpers": true
   },
   "include": ["src/**/*"],
-  "exclude": ["**/*.test.ts", "**/__tests__"]
+  "exclude": ["**/*.test.ts", "**/__tests__", "**/__mocks__"]
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
- Create workspace if the targetWorkspace doesn't exist when using `vtex switch` or `vtex login` 
- Do not send `CommandError`s (usually misusage errors) to telemetry.

#### How should this be manually tested?
```
yarn global add vtex@2.101.1-beta
```
Test around the commands:
```
vtex login account -w nonExistentWorkspace
vtex login account -w existentWorkspace

vtex switch account -w nonExistentWorkspace
vtex switch account -w existentWorkspace

vtex workspace create nonExistentWorkspace
vtex workspace create existentWorkspace

vtex workspace use existentWorkspace
vtex workspace use nonExistentWorkspace
```

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [ ] Update `CHANGELOG.md`