### PR TITLE
Handle error on unlinked apps when running `vtex test e2e`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- [vtex test e2e] Handle error when executed on an unlinked app.
 
 ### Added
 - [All Commands] new flag `--trace` that sets the `jaeger-debug-id` header automatically on all requests.

--- a/src/modules/apps/e2e/index.tsx
+++ b/src/modules/apps/e2e/index.tsx
@@ -29,7 +29,7 @@ class EndToEndCommand {
     const { data: workspaceAppsList } = await apps.listApps()
     const appItem = workspaceAppsList.find(({ app }) => app.startsWith(cleanAppId))
 
-    if (appItem.id === undefined) {
+    if (appItem === undefined) {
       throw new Error(`App "${cleanAppId}" was not found in the current workspace!`)
     }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?

Raise the proper error when running `vtex test e2e` on an app that isn't linked. Without this fix, it might be not so clear why the script is breaking. Motivation for this PR: https://github.com/vtex-apps/checkout-io-tests/pull/5#issuecomment-638850876

Before:

![image](https://user-images.githubusercontent.com/26108090/83768602-60854880-a655-11ea-9db1-fb86bfc4d0e2.png)

After:

![Screen Shot 2020-06-04 at 11 21 30](https://user-images.githubusercontent.com/26108090/83768744-8c083300-a655-11ea-87bb-76fc730331dc.png)

#### How should this be manually tested?

1. Clone vtex-apps/checkout-io-tests#5
2. Go to `checkoutio` account on `wdsrocha` workspace
3. Run `yarn e2e:run:remote`

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [x] Update `CHANGELOG.md`