### PR TITLE
Report sticky host errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - [docs] Update session about development.
+- [vtex link/relink] Add telemetry on builder-hub host changes.
 
 ## [2.102.0] - 2020-06-08
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@oclif/plugin-help": "^2.0.0",
     "@tiagonapoli/oclif-plugin-spaced-commands": "^0.0.6",
     "@vtex/api": "3.71.1",
-    "@vtex/node-error-report": "^0.0.1",
+    "@vtex/node-error-report": "^0.0.2",
     "@vtex/toolbelt-message-renderer": "^0.0.1",
     "@yarnpkg/lockfile": "^1.1.0",
     "ajv": "~6.10.2",

--- a/src/lib/constants/Headers.ts
+++ b/src/lib/constants/Headers.ts
@@ -17,4 +17,8 @@ export enum Headers {
 
   // Header to ensure that the request trace will be sampled
   VTEX_TRACE = 'jaeger-debug-id',
+
+  // When the backend **IO App** decides to sample the trace of a request, this
+  // header will be defined
+  VTEX_TRACE_ID = 'x-trace-id',
 }

--- a/src/lib/error/ErrorKinds.ts
+++ b/src/lib/error/ErrorKinds.ts
@@ -14,4 +14,5 @@ export const ErrorKinds = {
   TOOLBELT_CONFIG_MESSAGES_ERROR: 'ToolbeltConfigMessagesError',
   APP_LOGS_SSE_ERROR: 'LogsSSEError',
   APP_LOGS_PARSE_ERROR: 'LogsParseError',
+  STICKY_HOST_ERROR: 'StickyHostError',
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1066,10 +1066,10 @@
     tar-fs "^2.0.0"
     xss "^1.0.6"
 
-"@vtex/node-error-report@^0.0.1":
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/@vtex/node-error-report/-/node-error-report-0.0.1.tgz#a3d950c33cc831ce248d5e822894e0e85f63761f"
-  integrity sha512-Qt75bBYx0Ig13o8M6xpNgz6OkEUjWScsiOeZc+SXLCHZcTQVQrWn5MxMz+baXSmiN6v1ut0Kq/MwheQi9U/+Cw==
+"@vtex/node-error-report@^0.0.2":
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/@vtex/node-error-report/-/node-error-report-0.0.2.tgz#edf15095d6bb543d28b46f86bc109e6214149dfe"
+  integrity sha512-Q6V8E1IR/U0H6uTB1G+gH4ugL4Kw1l/WsK7W46LQBsxv4ISlZcO7dXPlWrL4RzRcVam5yzGAwNkv2wJdW61tAA==
   dependencies:
     is-stream "^2.0.0"
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
We don't have visibility on when sticky host errors start to happen for IO developers. This PR adds telemetry to it.

#### How should this be manually tested?
Testing the errors scenarios is kinda difficult, so just make sure `vtex link` and relinks are working properly. 

Here are some errors logged on splunk when I was testing the error format:
https://splunk72.vtex.com/en-US/app/vtex_io_apps/search?earliest=1592321400.000&latest=1592321700&q=search%20index%3Dio_vtex_logs%20level%3Derror%20app%3Dvtex.toolbelt-telemetry%40*%20data.kind!%3DNULL%20data.kind!%3DTelemetryReporterError%20data.kind!%3DSSEError%20%20%22data.kind%22%3DStickyHostError&display.page.search.mode=fast&dispatch.sample_ratio=1&display.general.type=events&display.page.search.tab=visualizations&sid=1592322428.1459595_3DDE77BC-1901-4189-B912-ADE751E100F6&workload_pool=

#### Types of changes
- [X] Telemetry
- [ ] Refactor (non-breaking change that only makes the code better)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [X] Update `CHANGELOG.md`