### PR TITLE
Enabled login on `vtex link`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- [vtex link] Parameters to enable login singleline
+
 ## [2.102.1] - 2020-06-16
 ### Changed
 - [docs] Update session about development.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- [vtex link] Parameters to enable login singleline
+- [vtex link] Parameters to enable login singleline.
 
 ## [2.102.1] - 2020-06-16
 ### Changed

--- a/src/commands/link.ts
+++ b/src/commands/link.ts
@@ -11,7 +11,7 @@ export default class Link extends CustomCommand {
 
   static flags = {
     ...CustomCommand.globalFlags,
-    account: oclifFlags.string({ char: 'a', description: 'Account to login' }),
+    account: oclifFlags.string({ char: 'a', description: 'Account to login', required: false }),
     clean: oclifFlags.boolean({ char: 'c', description: 'Clean builder cache', default: false }),
     setup: oclifFlags.boolean({
       char: 's',
@@ -20,7 +20,7 @@ export default class Link extends CustomCommand {
     }),
     'no-watch': oclifFlags.boolean({ description: "Don't watch for file changes after initial link", default: false }),
     unsafe: oclifFlags.boolean({ char: 'u', description: 'Allow links with Typescript errors', default: false }),
-    workspace: oclifFlags.string({ char: 'w', description: 'Workspace to login into' }),
+    workspace: oclifFlags.string({ char: 'w', description: 'Workspace to login into', required: false }),
   }
 
   static args = []
@@ -32,7 +32,10 @@ export default class Link extends CustomCommand {
     } = this.parse(Link)
     const noWatch = flags['no-watch']
 
-    await authLogin({ account, workspace })
+    if (account && workspace) {
+      await authLogin({ account, workspace })
+    }
+
     await appsLink({ setup, clean, unsafe, noWatch })
   }
 }

--- a/src/commands/link.ts
+++ b/src/commands/link.ts
@@ -1,8 +1,6 @@
 import { flags as oclifFlags } from '@oclif/command'
-
+import { appLink } from '../modules/apps/link'
 import { CustomCommand } from '../oclif/CustomCommand'
-import appsLink from '../modules/apps/link'
-import authLogin from '../modules/auth/login'
 
 export default class Link extends CustomCommand {
   static description = 'Start a development session for this app'
@@ -11,7 +9,12 @@ export default class Link extends CustomCommand {
 
   static flags = {
     ...CustomCommand.globalFlags,
-    account: oclifFlags.string({ char: 'a', description: 'Account to login', required: false }),
+    account: oclifFlags.string({
+      char: 'a',
+      description: `Account to login before linking. This flag has to be paired with the 'workspace' flag.`,
+      required: false,
+      dependsOn: ['workspace'],
+    }),
     clean: oclifFlags.boolean({ char: 'c', description: 'Clean builder cache', default: false }),
     setup: oclifFlags.boolean({
       char: 's',
@@ -20,7 +23,11 @@ export default class Link extends CustomCommand {
     }),
     'no-watch': oclifFlags.boolean({ description: "Don't watch for file changes after initial link", default: false }),
     unsafe: oclifFlags.boolean({ char: 'u', description: 'Allow links with Typescript errors', default: false }),
-    workspace: oclifFlags.string({ char: 'w', description: 'Workspace to login into', required: false }),
+    workspace: oclifFlags.string({
+      char: 'w',
+      description: `Workspace to switch to. Can be paired with the 'account' flag to change account and switch to the provided workspace.`,
+      required: false,
+    }),
   }
 
   static args = []
@@ -31,11 +38,6 @@ export default class Link extends CustomCommand {
       flags: { account, setup, clean, unsafe, workspace },
     } = this.parse(Link)
     const noWatch = flags['no-watch']
-
-    if (account && workspace) {
-      await authLogin({ account, workspace })
-    }
-
-    await appsLink({ setup, clean, unsafe, noWatch })
+    await appLink({ account, workspace, setup, clean, unsafe, noWatch })
   }
 }

--- a/src/commands/link.ts
+++ b/src/commands/link.ts
@@ -11,7 +11,7 @@ export default class Link extends CustomCommand {
     ...CustomCommand.globalFlags,
     account: oclifFlags.string({
       char: 'a',
-      description: `Account to login before linking. This flag has to be paired with the 'workspace' flag.`,
+      description: `Account to login before linking the app. This flag has to be paired with the '--workspace' flag.`,
       required: false,
       dependsOn: ['workspace'],
     }),
@@ -25,7 +25,7 @@ export default class Link extends CustomCommand {
     unsafe: oclifFlags.boolean({ char: 'u', description: 'Allow links with Typescript errors', default: false }),
     workspace: oclifFlags.string({
       char: 'w',
-      description: `Workspace to switch to. Can be paired with the 'account' flag to change account and switch to the provided workspace.`,
+      description: `Workspace to switch to before linking the app. Can be paired with the '--account' flag to change account and switch to the given workspace.`,
       required: false,
     }),
   }

--- a/src/commands/link.ts
+++ b/src/commands/link.ts
@@ -2,14 +2,16 @@ import { flags as oclifFlags } from '@oclif/command'
 
 import { CustomCommand } from '../oclif/CustomCommand'
 import appsLink from '../modules/apps/link'
+import authLogin from '../modules/auth/login'
 
 export default class Link extends CustomCommand {
   static description = 'Start a development session for this app'
 
-  static examples = []
+  static examples = ['vtex link -a youraccount -w yourworkspace']
 
   static flags = {
     ...CustomCommand.globalFlags,
+    account: oclifFlags.string({ char: 'a', description: 'Account to login' }),
     clean: oclifFlags.boolean({ char: 'c', description: 'Clean builder cache', default: false }),
     setup: oclifFlags.boolean({
       char: 's',
@@ -18,6 +20,7 @@ export default class Link extends CustomCommand {
     }),
     'no-watch': oclifFlags.boolean({ description: "Don't watch for file changes after initial link", default: false }),
     unsafe: oclifFlags.boolean({ char: 'u', description: 'Allow links with Typescript errors', default: false }),
+    workspace: oclifFlags.string({ char: 'w', description: 'Workspace to login into' }),
   }
 
   static args = []
@@ -25,10 +28,11 @@ export default class Link extends CustomCommand {
   async run() {
     const {
       flags,
-      flags: { setup, clean, unsafe },
+      flags: { account, setup, clean, unsafe, workspace },
     } = this.parse(Link)
     const noWatch = flags['no-watch']
 
+    await authLogin({ account, workspace })
     await appsLink({ setup, clean, unsafe, noWatch })
   }
 }

--- a/src/modules/apps/link.ts
+++ b/src/modules/apps/link.ts
@@ -246,7 +246,7 @@ export async function appLink(options: LinkOptions) {
   await handlePreLinkLogin({ account: options.account, workspace: options.workspace })
 
   await validateAppAction('link')
-  const unsafe = options.unsafe
+  const unsafe = !!options.unsafe
   const manifest = await ManifestEditor.getManifestEditor()
   await manifest.writeSchema()
 

--- a/src/oclif/hooks/init.ts
+++ b/src/oclif/hooks/init.ts
@@ -28,9 +28,26 @@ const logToolbeltVersion = () => {
   log.debug(`Toolbelt version: ${pkg.version}`)
 }
 
-const checkLogin = async command => {
-  const whitelist = [undefined, 'config', 'login', 'logout', 'switch', 'whoami', 'init', '-v', '--version', 'release']
-  if (!SessionManager.getSingleton().checkValidCredentials() && whitelist.indexOf(command) === -1) {
+const checkLogin = async (command: string) => {
+  /**
+   * Commands for which previous login is not necessary. There's some exceptions:
+   * - link: It's necessary to be logged in, but there's some login logic there before running the link per se
+   */
+  const allowedList = [
+    undefined,
+    'config',
+    'login',
+    'logout',
+    'switch',
+    'whoami',
+    'init',
+    '-v',
+    '--version',
+    'release',
+    'link',
+  ]
+
+  if (!SessionManager.getSingleton().checkValidCredentials() && allowedList.indexOf(command) === -1) {
     log.debug('Requesting login before command:', command)
     await authLogin({})
   }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Enable a in a single line command, that wraps the `switch, use, link` or `login, link` command

#### Screenshots or example usage

`vtex link -a storecomponents -w savio`

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [x] Update `CHANGELOG.md`