### PR TITLE
Fix settings set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - [oclif:entrypoint] Only run oclif command when the entrypoint is the main script.
+- [vtex settings set] Cast value before setting field.
 
 ### Changed
 - [vtex edition] Refactor command to use as oclif plugin.

--- a/src/modules/apps/settings/set.ts
+++ b/src/modules/apps/settings/set.ts
@@ -1,11 +1,23 @@
 import { merge, __ } from 'ramda'
 import { createAppsClient } from '../../../api/clients/IOClients/infra/Apps'
 
+const castValue = (value: string) => {
+  let parsedValue: any
+  try {
+    parsedValue = JSON.parse(value)
+  } catch (err) {
+    parsedValue = value
+  }
+
+  const numberCast = Number(value)
+  return Number.isNaN(numberCast) ? parsedValue : numberCast
+}
+
 export default async (app: string, field, value) => {
   const apps = createAppsClient()
 
   const newSetting = {}
-  newSetting[field] = value
+  newSetting[field] = castValue(value)
   const newSettingsJson = await apps
     .getAppSettings(app)
     .then(merge(__, newSetting))


### PR DESCRIPTION
#### What is the purpose of this pull request?
A lot of releases ago this command was changed, removing the value cast before setting it to a field. This PR reverts it, since the desired behavior is to cast the value before setting.

#### How should this be manually tested?
```
 vtex-test settings set vtex.service-example@0.x boolean false
```
You should see:
```json
{
  "fieldName": "fieldValue",
  "teste": 1,
  "boolean": false
}
```
Instead of:
```
{
  "fieldName": "fieldValue",
  "teste": 1,
  "boolean": "false"
}
```

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [x] Update `CHANGELOG.md`