### PR TITLE
Improve vtex logout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - [oclif:entrypoint] Only run oclif command when the entrypoint is the main script.
 - [vtex settings set] Cast value before setting field.
+- [vtex logout] Local token is now invalidated before deleting local data. Also a URL is opened on the browser to invalidate the auth cookie stored.
 
 ### Changed
 - [vtex edition] Refactor command to use as oclif plugin.

--- a/src/api/clients/IOClients/external/VTEXID.ts
+++ b/src/api/clients/IOClients/external/VTEXID.ts
@@ -1,5 +1,7 @@
 import { InstanceOptions, IOClient, IOContext } from '@vtex/api'
+import opn from 'opn'
 import querystring from 'querystring'
+import { storeUrl } from '../../../domain'
 import { IOClientFactory } from '../IOClientFactory'
 
 export class VTEXID extends IOClient {
@@ -7,9 +9,17 @@ export class VTEXID extends IOClient {
   private static readonly BASE_URL = 'https://vtexid.vtex.com.br'
   private static readonly API_PATH_PREFIX = '/api/vtexid'
   private static readonly TOOLBELT_API_PATH_PREFIX = `${VTEXID.API_PATH_PREFIX}/toolbelt`
+  private static readonly VTEX_ID_AUTH_COOKIE = 'VtexIdClientAutCookie'
 
   public static createClient(customContext: Partial<IOContext> = {}, customOptions: Partial<InstanceOptions> = {}) {
     return IOClientFactory.createClient<VTEXID>(VTEXID, customContext, customOptions, { requireAuth: false })
+  }
+
+  public static invalidateBrowserAuthCookie(account: string) {
+    return opn(
+      storeUrl({ account, addWorkspace: false, path: `${VTEXID.API_PATH_PREFIX}/pub/single-sign-out?scope=` }),
+      { wait: false }
+    )
   }
 
   constructor(ioContext: IOContext, opts: InstanceOptions) {
@@ -37,6 +47,14 @@ export class VTEXID extends IOClient {
     })
 
     return this.http.post<{ token: string }>(`${VTEXID.TOOLBELT_API_PATH_PREFIX}/validate?an=${account}`, body)
+  }
+
+  public invalidateToolbeltToken(token: string) {
+    return this.http.get(`/api/vtexid/pub/logout?scope=`, {
+      headers: {
+        Cookie: `${VTEXID.VTEX_ID_AUTH_COOKIE}=${token}`,
+      },
+    })
   }
 }
 

--- a/src/api/clients/IOClients/external/VTEXID.ts
+++ b/src/api/clients/IOClients/external/VTEXID.ts
@@ -1,7 +1,7 @@
 import { InstanceOptions, IOClient, IOContext } from '@vtex/api'
 import opn from 'opn'
 import querystring from 'querystring'
-import { storeUrl } from '../../../domain'
+import { storeUrl } from '../../../storeUrl'
 import { IOClientFactory } from '../IOClientFactory'
 
 export class VTEXID extends IOClient {

--- a/src/api/clients/IOClients/external/VTEXID.ts
+++ b/src/api/clients/IOClients/external/VTEXID.ts
@@ -24,9 +24,10 @@ export class VTEXID extends IOClient {
 
   constructor(ioContext: IOContext, opts: InstanceOptions) {
     super(ioContext, {
+      timeout: VTEXID.DEFAULT_TIMEOUT,
+      retries: 2,
       ...opts,
       baseURL: VTEXID.BASE_URL,
-      timeout: VTEXID.DEFAULT_TIMEOUT,
     })
   }
 

--- a/src/api/clients/IOClients/external/VTEXID.ts
+++ b/src/api/clients/IOClients/external/VTEXID.ts
@@ -6,6 +6,7 @@ import { IOClientFactory } from '../IOClientFactory'
 
 export class VTEXID extends IOClient {
   private static readonly DEFAULT_TIMEOUT = 10000
+  private static readonly DEFAULT_RETRIES = 2
   private static readonly BASE_URL = 'https://vtexid.vtex.com.br'
   private static readonly API_PATH_PREFIX = '/api/vtexid'
   private static readonly TOOLBELT_API_PATH_PREFIX = `${VTEXID.API_PATH_PREFIX}/toolbelt`
@@ -25,7 +26,7 @@ export class VTEXID extends IOClient {
   constructor(ioContext: IOContext, opts: InstanceOptions) {
     super(ioContext, {
       timeout: VTEXID.DEFAULT_TIMEOUT,
-      retries: 2,
+      retries: VTEXID.DEFAULT_RETRIES,
       ...opts,
       baseURL: VTEXID.BASE_URL,
     })

--- a/src/api/session/SessionManager.ts
+++ b/src/api/session/SessionManager.ts
@@ -179,7 +179,7 @@ export class SessionManager implements ISessionManager {
   public async logout(logoutOptions?: LogoutOptions) {
     const opts: LogoutOptions = { invalidateBrowserAuthCookie: false, ...logoutOptions }
     if (this.token) {
-      this.invalidateTokens(opts)
+      await this.invalidateTokens(opts)
     }
 
     this.sessionPersister.clearData()
@@ -262,6 +262,7 @@ export class SessionManager implements ISessionManager {
     const vtexId = VTEXID.createClient()
     try {
       await vtexId.invalidateToolbeltToken(this.token)
+      logger.info('Invalidated local token')
     } catch (err) {
       const errReport = ErrorReport.createAndMaybeRegisterOnTelemetry({ originalError: err })
       logger.error('Unable to invalidate local token')

--- a/src/api/session/__mocks__/SessionManager.ts
+++ b/src/api/session/__mocks__/SessionManager.ts
@@ -45,7 +45,7 @@ export class SessionManagerMock implements ISessionManager {
     return Promise.resolve()
   }
 
-  public logout() {}
+  public async logout() {}
 
   public async workspaceSwitch({ targetWorkspace }: WorkspaceSwitchInput): Promise<WorkspaceSwitchResult> {
     this.workspace = targetWorkspace

--- a/src/commands/logout.ts
+++ b/src/commands/logout.ts
@@ -12,7 +12,7 @@ export default class Logout extends CustomCommand {
 
   static args = []
 
-  async run() {
-    authLogout()
+  run() {
+    return authLogout()
   }
 }

--- a/src/modules/auth/logout.ts
+++ b/src/modules/auth/logout.ts
@@ -4,6 +4,6 @@ import log from '../../api/logger'
 export default () => {
   log.debug('Clearing config file')
   const sessionManager = SessionManager.getSingleton()
-  sessionManager.logout()
+  sessionManager.logout({ invalidateBrowserAuthCookie: true })
   log.info('See you soon!')
 }

--- a/src/modules/auth/logout.ts
+++ b/src/modules/auth/logout.ts
@@ -1,9 +1,9 @@
 import { SessionManager } from '../../api/session/SessionManager'
 import log from '../../api/logger'
 
-export default () => {
+export default async () => {
   log.debug('Clearing config file')
   const sessionManager = SessionManager.getSingleton()
-  sessionManager.logout({ invalidateBrowserAuthCookie: true })
+  await sessionManager.logout({ invalidateBrowserAuthCookie: true })
   log.info('See you soon!')
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

Now `vtex logout`:
- Invalidates local token before deleting it.
- Opens URL to invalidate auth cookie stored on browser.

#### How should this be manually tested?

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [X] Update `CHANGELOG.md`