### PR TITLE
Fix vtex browse not adding workspace to url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- [vtex browse] Fix workspace not being added to url. 
 
 ## [2.105.1] - 2020-07-16
 ### Fixed

--- a/src/api/storeUrl.ts
+++ b/src/api/storeUrl.ts
@@ -22,7 +22,8 @@ export function storeUrl(opts: StoreUrlOptions) {
     path = opts.path.startsWith('/') ? opts.path : `/${opts.path}`
   }
 
-  if (opts.addWorkspace) {
+  const addWorkspace = opts.addWorkspace ?? true
+  if (addWorkspace) {
     return `https://${workspace}--${account}.${publicEndpoint()}${path}`
   }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
- Fix addWorkspace option on storeUrl util that affected `vtex browse`

To test check if `vtex browse` opens the url for your account/workspace.

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [X] Update `CHANGELOG.md`