### PR TITLE
enables vtex components to work on render8

### DIFF
--- a/src/api/modules/apps/file.ts
+++ b/src/api/modules/apps/file.ts
@@ -32,7 +32,7 @@ const vtexComponentsAdapterEnabled = () => {
   try {
     const manifest = readJsonSync('./manifest.json')
     return manifest.vtexComponentsEnabled === true
-  } catch(e) {
+  } catch (e) {
     return false
   }
 }
@@ -62,13 +62,13 @@ const loadVtexComponentsPackageJsonChanges = () => {
     const pkg = readJsonSync('./package.json')
     adaptPackageJsonForRender(pkg)
     writeJsonSync('./react/package.json', pkg)
-  } catch(e) {
-    console.log("Failed to link VTEX Components package.json")
+  } catch (e) {
+    console.log('Failed to link VTEX Components package.json')
   }
 }
 
 export const listLocalFiles = (root: string, test = false, folder?: string): Promise<string[]> => {
-  if(vtexComponentsAdapterEnabled()) {
+  if (vtexComponentsAdapterEnabled()) {
     loadVtexComponentsPackageJsonChanges()
   }
 

--- a/src/api/modules/apps/file.ts
+++ b/src/api/modules/apps/file.ts
@@ -53,7 +53,7 @@ export const getIgnoredPaths = (root: string, test = false): string[] => {
       .filter(vtexComponentsAdapterEnabledFilter)
     return test ? reject(isTestOrMockPath, filesToIgnore) : filesToIgnore
   } catch (e) {
-    return defaultIgnored
+    return defaultIgnored.filter(vtexComponentsAdapterEnabledFilter)
   }
 }
 

--- a/src/api/modules/apps/vtexComponentsAdapter.ts
+++ b/src/api/modules/apps/vtexComponentsAdapter.ts
@@ -1,0 +1,61 @@
+interface StrMap {
+    [key: string]: string;
+  }
+  
+  interface PackageJson {
+    [key: string]: string | StrMap | boolean;
+  }
+  
+  const removeUnecessaryKeys = (pkg: PackageJson): void => {
+    let removeList: string[] = [];
+    for (let key of Object.keys(pkg)) {
+      if (key !== 'devDependencies') {
+        removeList.push(key);
+      }
+    }
+    for (let key of removeList) {
+      if (typeof pkg[key] == 'string') {
+        delete pkg[key];
+      }
+      if (typeof pkg[key] == 'object' && key !== 'devDependencies' && key !== 'peerDependencies' && key !== 'dependencies') {
+        delete pkg[key];
+      }
+    }
+  };
+  
+  export const blackListed = (key: string): boolean => {
+    const patterns = ['typescript', 'tsdx', '@storybook'];
+    const validator = new RegExp(patterns.join('|'), 'i');
+  
+    return validator.test(key);
+  };
+  
+  const removeBlackListedDevDependencies = (pkg: PackageJson): void => {
+    let removeList = [];
+  
+    for (let key in pkg['devDependencies'] as StrMap) {
+      if (blackListed(key)) {
+        removeList.push(key);
+      }
+    }
+  
+    for (let key of removeList) {
+      delete (pkg['devDependencies'] as StrMap)[key];
+    }
+  };
+  
+  const addIOScripts = (pkg: PackageJson): void => {
+    const IOScripts: StrMap = {
+      test: 'vtex-test-tools test',
+    };
+  
+    pkg['scripts'] = IOScripts;
+  };
+  
+  export const adaptPackageJsonForRender = (pkg: PackageJson): void => {
+    removeUnecessaryKeys(pkg);
+    removeBlackListedDevDependencies(pkg);
+    addIOScripts(pkg);
+    return;
+  };
+  

--- a/src/api/modules/apps/vtexComponentsAdapter.ts
+++ b/src/api/modules/apps/vtexComponentsAdapter.ts
@@ -1,61 +1,64 @@
 interface StrMap {
-    [key: string]: string;
+  [key: string]: string
+}
+
+interface PackageJson {
+  [key: string]: string | StrMap | boolean
+}
+
+const removeUnecessaryKeys = (pkg: PackageJson): void => {
+  const removeList: string[] = []
+  for (const key of Object.keys(pkg)) {
+    if (key !== 'devDependencies') {
+      removeList.push(key)
+    }
   }
-  
-  interface PackageJson {
-    [key: string]: string | StrMap | boolean;
+  for (const key of removeList) {
+    if (typeof pkg[key] === 'string') {
+      delete pkg[key]
+    }
+    if (
+      typeof pkg[key] === 'object' &&
+      key !== 'devDependencies' &&
+      key !== 'peerDependencies' &&
+      key !== 'dependencies'
+    ) {
+      delete pkg[key]
+    }
   }
-  
-  const removeUnecessaryKeys = (pkg: PackageJson): void => {
-    let removeList: string[] = [];
-    for (let key of Object.keys(pkg)) {
-      if (key !== 'devDependencies') {
-        removeList.push(key);
-      }
+}
+
+export const blackListed = (key: string): boolean => {
+  const patterns = ['typescript', 'tsdx', '@storybook']
+  const validator = new RegExp(patterns.join('|'), 'i')
+
+  return validator.test(key)
+}
+
+const removeBlackListedDevDependencies = (pkg: PackageJson): void => {
+  const removeList = []
+
+  for (const key in pkg.devDependencies as StrMap) {
+    if (blackListed(key)) {
+      removeList.push(key)
     }
-    for (let key of removeList) {
-      if (typeof pkg[key] == 'string') {
-        delete pkg[key];
-      }
-      if (typeof pkg[key] == 'object' && key !== 'devDependencies' && key !== 'peerDependencies' && key !== 'dependencies') {
-        delete pkg[key];
-      }
-    }
-  };
-  
-  export const blackListed = (key: string): boolean => {
-    const patterns = ['typescript', 'tsdx', '@storybook'];
-    const validator = new RegExp(patterns.join('|'), 'i');
-  
-    return validator.test(key);
-  };
-  
-  const removeBlackListedDevDependencies = (pkg: PackageJson): void => {
-    let removeList = [];
-  
-    for (let key in pkg['devDependencies'] as StrMap) {
-      if (blackListed(key)) {
-        removeList.push(key);
-      }
-    }
-  
-    for (let key of removeList) {
-      delete (pkg['devDependencies'] as StrMap)[key];
-    }
-  };
-  
-  const addIOScripts = (pkg: PackageJson): void => {
-    const IOScripts: StrMap = {
-      test: 'vtex-test-tools test',
-    };
-  
-    pkg['scripts'] = IOScripts;
-  };
-  
-  export const adaptPackageJsonForRender = (pkg: PackageJson): void => {
-    removeUnecessaryKeys(pkg);
-    removeBlackListedDevDependencies(pkg);
-    addIOScripts(pkg);
-    return;
-  };
-  
+  }
+
+  for (const key of removeList) {
+    delete (pkg.devDependencies as StrMap)[key]
+  }
+}
+
+const addIOScripts = (pkg: PackageJson): void => {
+  const IOScripts: StrMap = {
+    test: 'vtex-test-tools test',
+  }
+
+  pkg.scripts = IOScripts
+}
+
+export const adaptPackageJsonForRender = (pkg: PackageJson): void => {
+  removeUnecessaryKeys(pkg)
+  removeBlackListedDevDependencies(pkg)
+  addIOScripts(pkg)
+}


### PR DESCRIPTION
#### What is the purpose of this pull request?
This pull request applies changes so that for VTEX Components (https://github.com/vtex-components), the root package.json can be uploaded and linked. It also adds a step when uploading files to adapt this package.json, more specifically when the vtexComponentsEnabled property on the manifest.json is set to true.

#### What problem is this solving?
This pull request enables VTEX Components  to work in the render 8.

#### How should this be manually tested?
Installing this version of the CLI used to install the vtex template, running `vtex link` and checking if the template is working properly on render 8.

#### Screenshots or example usage


#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [ ] Update `CHANGELOG.md`