### PR TITLE
Change version update notifier structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- [updateNotify] Display new version update based on `vtex` channel (e.g., stable and beta)
 
 ## [2.115.1] - 2020-10-07
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.115.2] - 2020-10-15
 ### Fixed
 - [updateNotify] Display new version update based on `vtex` channel (e.g., stable and beta)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.115.1",
+  "version": "2.115.2",
   "description": "The platform for e-commerce apps",
   "bin": "bin/run",
   "main": "lib/api/index.js",

--- a/package.json
+++ b/package.json
@@ -148,6 +148,7 @@
     "@types/randomstring": "^1.1.6",
     "@types/semver-diff": "2.1.1",
     "@types/tar": "4.0.3",
+    "@types/update-notifier": "^5.0.0",
     "@types/yarnpkg__lockfile": "^1.1.3",
     "aws-sdk": "^2.750.0",
     "eslint": "^6.8.0",

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -1,0 +1,19 @@
+import { getDistTag, getSimpleVersion } from '../modules/utils';
+
+test.each([
+  ['2.115.0-beta', 'beta'],
+  ['2.115.0-beta.randomhash', 'beta'],
+  ['2.115.1-internal.ced170aa', 'internal'],
+  ['2.115.1', 'latest'],
+])('validates a version tag: %s should be %s', (version: string, result: string) => {
+  expect(getDistTag(version)).toBe(result)
+})
+
+test.each([
+  ['2.115.0-beta', '2.115.0-beta'],
+  ['2.115.0-beta.randomhash', '2.115.0-beta'],
+  ['2.115.1-internal.ced170aa', '2.115.1-internal'],
+  ['2.115.1', '2.115.1'],
+])('validates a version simplifier: %s should be %s', (version: string, result: string) => {
+  expect(getSimpleVersion(version)).toBe(result)
+})

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -1,4 +1,4 @@
-import { getDistTag, getSimpleVersion } from '../modules/utils';
+import { getDistTag, getSimpleVersion } from '../modules/utils'
 
 test.each([
   ['2.115.0-beta', 'beta'],

--- a/src/lib/constants/Messages.ts
+++ b/src/lib/constants/Messages.ts
@@ -21,5 +21,5 @@ export const Messages = {
     `\n\n` +
     `• If you installed using our new method there is in alpha-version, update running ${ColorifyConstants.COMMAND_OR_VTEX_REF(
       `vtex autoupdate`
-    )}.`,
+    )}.\n`,
 }

--- a/src/modules/utils.ts
+++ b/src/modules/utils.ts
@@ -60,6 +60,22 @@ const cleanVersion = (appId: string) => {
   )(appId)
 }
 
+// Return version tag
+// Example: 2.115.0-beta.somehash   -> beta
+// Example: 2.115.0                 -> latest
+export const getDistTag = (version: string) => {
+  const distTag = version.split('-')[1]
+  return distTag ? distTag.split('.')[0] : 'latest'
+}
+
+// Return version and tag only
+// Example: 2.115.0-beta.somehash   -> 2.115.0-beta
+// Example: 2.115.0                 -> 2.115.0
+export const getSimpleVersion = (_version: string) => {
+  const [version, distTag] = _version.split('-')
+  return version.concat(distTag ? '-'.concat(distTag.split('.')[0]) : '')
+}
+
 export const matchedDepsDiffTable = (title1: string, title2: string, deps1: string[], deps2: string[]) => {
   const depsDiff = diffArrays(deps1, deps2)
   // Get deduplicated names (no version) of the changed deps.

--- a/src/modules/utils.ts
+++ b/src/modules/utils.ts
@@ -64,16 +64,17 @@ const cleanVersion = (appId: string) => {
 // Example: 2.115.0-beta.somehash   -> beta
 // Example: 2.115.0                 -> latest
 export const getDistTag = (version: string) => {
-  const distTag = version.split('-')[1]
-  return distTag ? distTag.split('.')[0] : 'latest'
+  const regex = /(?:-([0-9A-Za-z-]*))/g
+  const distTag = version.match(regex)
+  return distTag ? distTag[0].substring(1) : 'latest'
 }
 
 // Return version and tag only
 // Example: 2.115.0-beta.somehash   -> 2.115.0-beta
 // Example: 2.115.0                 -> 2.115.0
-export const getSimpleVersion = (_version: string) => {
-  const [version, distTag] = _version.split('-')
-  return version.concat(distTag ? '-'.concat(distTag.split('.')[0]) : '')
+export const getSimpleVersion = (version: string) => {
+  const regex = /^([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+))?/g
+  return version.match(regex)[0]
 }
 
 export const matchedDepsDiffTable = (title1: string, title2: string, deps1: string[], deps2: string[]) => {

--- a/src/update.ts
+++ b/src/update.ts
@@ -16,7 +16,7 @@ export function updateNotify() {
 
     notifier.notify({
       isGlobal: true,
-      //@ts-ignore
+      // @ts-ignore
       isYarnGlobal: true,
       message: [
         `There is a new Toolbelt version avaible: ${chalk.dim(oldVersion)} → ${chalk.green(latestVersion)}`,

--- a/src/update.ts
+++ b/src/update.ts
@@ -6,10 +6,13 @@ import { Messages } from './lib/constants/Messages'
 import * as pkg from '../package.json'
 import { getDistTag, getSimpleVersion } from './modules/utils'
 
+const ONE_HOUR = 1000 * 60 * 60 * 1
+
 export function updateNotify() {
   const distTag = getDistTag(pkg.version)
-  const notifier = updateNotifier({ pkg, distTag, updateCheckInterval: 1000 * 60 * 60 * 1 })
-  if (notifier.update && notifier.update.latest !== getSimpleVersion(pkg.version)) {
+  const notifier = updateNotifier({ pkg, distTag, updateCheckInterval: ONE_HOUR })
+
+  if (notifier.update?.latest !== getSimpleVersion(pkg.version)) {
     const oldVersion = getSimpleVersion(notifier.update.current)
     const latestVersion = notifier.update.latest
     const changelog = `https://github.com/vtex/toolbelt/blob/master/CHANGELOG.md`

--- a/src/update.ts
+++ b/src/update.ts
@@ -4,34 +4,24 @@ import { ColorifyConstants } from './api/constants/Colors'
 import { Messages } from './lib/constants/Messages'
 
 import * as pkg from '../package.json'
+import { getDistTag, getSimpleVersion } from './modules/utils'
 
 export function updateNotify() {
-  const notifier = updateNotifier({ pkg, updateCheckInterval: 1000 * 60 * 60 * 1 })
-  if (notifier.update && notifier.update.latest !== pkg.version) {
-    const oldVersion = notifier.update.current
+  const distTag = getDistTag(pkg.version)
+  const notifier = updateNotifier({ pkg, distTag, updateCheckInterval: 1000 * 60 * 60 * 1 })
+  if (notifier.update && notifier.update.latest !== getSimpleVersion(pkg.version)) {
+    const oldVersion = getSimpleVersion(notifier.update.current)
     const latestVersion = notifier.update.latest
     const changelog = `https://github.com/vtex/toolbelt/blob/master/CHANGELOG.md`
-    let { type } = notifier.update
-
-    switch (type) {
-      case 'major':
-        type = chalk.red(type)
-        break
-      case 'minor':
-        type = chalk.yellow(type)
-        break
-      case 'patch':
-        type = chalk.green(type)
-        break
-    }
 
     notifier.notify({
       isGlobal: true,
+      //@ts-ignore
       isYarnGlobal: true,
       message: [
         `There is a new Toolbelt version avaible: ${chalk.dim(oldVersion)} → ${chalk.green(latestVersion)}`,
         Messages.UPDATE_TOOLBELT(),
-        `\n` + `Changelog: ${ColorifyConstants.URL_INTERACTIVE(changelog)}`,
+        `Changelog: ${ColorifyConstants.URL_INTERACTIVE(changelog)}`,
       ].join('\n'),
     })
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -754,7 +754,7 @@
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
 
-"@types/configstore@^4.0.0":
+"@types/configstore@*", "@types/configstore@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/configstore/-/configstore-4.0.0.tgz#cb718f9507e9ee73782f40d07aaca1cd747e36fa"
   integrity sha512-SvCBBPzOIe/3Tu7jTl2Q8NjITjLmq9m7obzjSyb8PXWWZ31xVK6w4T6v8fOx+lrgQnqk3Yxc00LDolFsSakKCA==
@@ -1077,6 +1077,14 @@
   dependencies:
     "@types/minipass" "*"
     "@types/node" "*"
+
+"@types/update-notifier@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@types/update-notifier/-/update-notifier-5.0.0.tgz#7765369626e9f8c21ba0cf9a59e4a6eddf47997f"
+  integrity sha512-8CdLLv5ytMXEWfjSmWiuuZEffJJAsfNxSQbShZTmZD5picoci18VV1YqhKNTzlZvNCzt5WsnDQLyPSsj6xGuug==
+  dependencies:
+    "@types/configstore" "*"
+    boxen "^4.2.0"
 
 "@types/ws@^6.0.0":
   version "6.0.4"


### PR DESCRIPTION
#### What is the purpose of this pull request?
`updateNotify` method was not updating correctly `toolbelt` versions based on `channels`

#### What problem is this solving?
Now `toolbelt` will notify the CLI version update based on his own `channel`

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [x] Update `CHANGELOG.md`