### PR TITLE
Update @vtex/api to 3.76.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Update @vtex/api
 
 ## [2.115.1] - 2020-10-07
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.115.3-beta] - 2020-10-09
+
 ## [2.115.2-beta] - 2020-10-09
 ### Changed
 - Update @vtex/api

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.115.2-beta] - 2020-10-09
 ### Changed
 - Update @vtex/api
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.115.2-beta",
+  "version": "2.115.3-beta",
   "description": "The platform for e-commerce apps",
   "bin": "bin/run",
   "main": "lib/api/index.js",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@oclif/config": "^1.0.0",
     "@oclif/plugin-help": "^2.0.0",
     "@tiagonapoli/oclif-plugin-spaced-commands": "^0.0.6",
-    "@vtex/api": "3.71.1",
+    "@vtex/api": "^3.76.0",
     "@vtex/cli-plugin-abtest": "^0.0.5",
     "@vtex/cli-plugin-autoupdate": "^0.0.1",
     "@vtex/cli-plugin-deploy": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.115.1",
+  "version": "2.115.2-beta",
   "description": "The platform for e-commerce apps",
   "bin": "bin/run",
   "main": "lib/api/index.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1145,10 +1145,10 @@
     semver "^6.3.0"
     tsutils "^3.17.1"
 
-"@vtex/api@3.71.1":
-  version "3.71.1"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-3.71.1.tgz#996a9148cceadb8cd68939f47ce739b88b6bad97"
-  integrity sha512-CurrRU1U/svHbbyvhsICD8/IqtSQplH/AzS9q0iQ0OC6AH4H8hLUvaNuFMIDW4jSMInqepqKkcS3BQsw9wBxBQ==
+"@vtex/api@^3.76.0":
+  version "3.76.0"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-3.76.0.tgz#3ef58dc030517e75885bf11448ed21a6ba54ed3f"
+  integrity sha512-X3NGq6ErcTqJWhJN4WPfkmaw7oT1w5RqQ0NlyARwS3KXUqR4FKvWeXl+uC/1mxllrmVcDZwtb1n+2HuxpZgDBg==
   dependencies:
     "@types/koa" "^2.0.48"
     "@types/koa-compose" "^3.2.3"
@@ -8189,7 +8189,7 @@ static-extend@^0.1.1, static-extend@^0.1.2:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-stats-lite@vtex/node-stats-lite#dist:
+"stats-lite@github:vtex/node-stats-lite#dist":
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:


### PR DESCRIPTION
#### What is the purpose of this pull request?
To update `@vtex/api` to `3.76.0`.

#### What problem is this solving?
Changes on https://github.com/vtex/toolbelt/pull/963 don't work without this D:

#### How should this be manually tested?
Checking if promote with `--conflict` flag sends the flag to `kube-router-api`.

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [x] Update `CHANGELOG.md`