### PR TITLE
chore: missing plugins folder after npm publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "files": [
     "/scripts/closeChrome.scpt",
+    "/plugins",
     "/lib",
     "/bin",
     "/oclif.manifest.json"


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add missing `plugins` folder to `package.json`'s `"files"`.
<!--- Describe your changes in detail. -->

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
Currently when following the "Customize your prompt" section on README the plugins folder don't exist, because after npm's publish the folder isn't copied to the final installation folder.

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
