### PR TITLE
Fix/stickyhost change relink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.115.4] - 2020-11-03
 ### Fixed
 - [relink] Force app to `link` from scratch when `StickyHost` change on `relink`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- [relink] Force app to `link` from scratch when `StickyHost` change on `relink`
 
 ## [2.115.3] - 2020-10-16
 ### Fixed 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.115.3",
+  "version": "2.115.4",
   "description": "The platform for e-commerce apps",
   "bin": "bin/run",
   "main": "lib/api/index.js",

--- a/src/api/clients/IOClients/apps/Builder.ts
+++ b/src/api/clients/IOClients/apps/Builder.ts
@@ -199,7 +199,7 @@ export class Builder extends AppClient {
         })
       }
       if (relinkCall) {
-        throw new NewStickyHostError('New StickyHost on relink')
+        throw new NewStickyHostError('New StickyHost on relink', 'Relink')
       }
     }
 

--- a/src/api/clients/IOClients/apps/Builder.ts
+++ b/src/api/clients/IOClients/apps/Builder.ts
@@ -177,7 +177,12 @@ export class Builder extends AppClient {
     return data
   }
 
-  private updateStickyHost(sentStickyHostHeader: string, responseStickyHostHeader: string, traceID: string, relinkCall?: boolean) {
+  private updateStickyHost(
+    sentStickyHostHeader: string,
+    responseStickyHostHeader: string,
+    traceID: string,
+    relinkCall?: boolean
+  ) {
     if (!responseStickyHostHeader) {
       ErrorReport.createAndMaybeRegisterOnTelemetry({
         kind: ErrorKinds.STICKY_HOST_ERROR,
@@ -199,7 +204,7 @@ export class Builder extends AppClient {
         })
       }
       if (relinkCall) {
-        throw new NewStickyHostError('New StickyHost on relink', 'Relink')
+        throw new NewStickyHostError('Relink', 'New StickyHost on relink')
       }
     }
 

--- a/src/api/clients/IOClients/apps/Builder.ts
+++ b/src/api/clients/IOClients/apps/Builder.ts
@@ -4,6 +4,7 @@ import { Headers } from '../../../../lib/constants/Headers'
 import { ErrorKinds } from '../../../error/ErrorKinds'
 import { ErrorReport } from '../../../error/ErrorReport'
 import { IOClientFactory } from '../IOClientFactory'
+import { NewStickyHostError } from '../../../error/errors'
 
 interface StickyOptions {
   sticky?: boolean
@@ -44,7 +45,7 @@ const routes = {
 }
 
 export class Builder extends AppClient {
-  private static TOO_MANY_HOST_CHANGES = 3
+  private static TOO_MANY_HOST_CHANGES = 4
 
   public static createClient(customContext: Partial<IOContext> = {}, customOptions: Partial<InstanceOptions> = {}) {
     return IOClientFactory.createClient<Builder>(Builder, customContext, customOptions)
@@ -129,7 +130,7 @@ export class Builder extends AppClient {
       data,
       headers: { [Headers.VTEX_STICKY_HOST]: host, [Headers.VTEX_TRACE_ID]: traceID },
     } = await (this.http as any).request(putConfig)
-    this.updateStickyHost(this.stickyHost, host, traceID)
+    this.updateStickyHost(this.stickyHost, host, traceID, true)
     return data as BuildResult
   }
 
@@ -176,7 +177,7 @@ export class Builder extends AppClient {
     return data
   }
 
-  private updateStickyHost(sentStickyHostHeader: string, responseStickyHostHeader: string, traceID: string) {
+  private updateStickyHost(sentStickyHostHeader: string, responseStickyHostHeader: string, traceID: string, relinkCall?: boolean) {
     if (!responseStickyHostHeader) {
       ErrorReport.createAndMaybeRegisterOnTelemetry({
         kind: ErrorKinds.STICKY_HOST_ERROR,
@@ -196,6 +197,9 @@ export class Builder extends AppClient {
             hostChanges: this.hostChanges,
           },
         })
+      }
+      if (relinkCall) {
+        throw new NewStickyHostError('New StickyHost on relink')
       }
     }
 

--- a/src/api/error/ErrorReport.ts
+++ b/src/api/error/ErrorReport.ts
@@ -84,7 +84,7 @@ export class ErrorReport extends ErrorReportBase {
       },
     })
 
-    this.shouldRemoteReport = args.shouldRemoteReport
+    this.shouldRemoteReport = args.shouldRemoteReport ?? true
   }
 
   public logErrorForUser(opts?: LogToUserOptions) {

--- a/src/api/error/errors.ts
+++ b/src/api/error/errors.ts
@@ -3,6 +3,7 @@ import { compose, join, map, prop, reject } from 'ramda'
 import { isFunction } from 'ramda-adjunct'
 
 const joinErrorMessages = compose<any[], any[], string[], string>(join('\n'), map(prop('message')), reject(isFunction))
+type CommandType = 'Link' | 'Relink' | 'Unlink'
 
 export class SSEConnectionError extends ExtendableError {
   public statusCode: number
@@ -13,12 +14,14 @@ export class SSEConnectionError extends ExtendableError {
 }
 
 export class NewStickyHostError extends ExtendableError {
+  public command: CommandType
   public code: string = 'initial_link_required'
   public message: string
 
-  constructor(message: string = 'StickyHost has changed') {
+  constructor(message: string = 'StickyHost has changed', command: CommandType) {
     super(message)
     this.message = message
+    this.command = command
   }
 }
 

--- a/src/api/error/errors.ts
+++ b/src/api/error/errors.ts
@@ -15,10 +15,10 @@ export class SSEConnectionError extends ExtendableError {
 
 export class NewStickyHostError extends ExtendableError {
   public command: CommandType
-  public code: string = 'initial_link_required'
+  public code = 'initial_link_required'
   public message: string
 
-  constructor(message: string = 'StickyHost has changed', command: CommandType) {
+  constructor(command: CommandType, message = 'StickyHost has changed') {
     super(message)
     this.message = message
     this.command = command

--- a/src/api/error/errors.ts
+++ b/src/api/error/errors.ts
@@ -12,6 +12,16 @@ export class SSEConnectionError extends ExtendableError {
   }
 }
 
+export class NewStickyHostError extends ExtendableError {
+  public code: string = 'initial_link_required'
+  public message: string
+
+  constructor(message: string = 'StickyHost has changed') {
+    super(message)
+    this.message = message
+  }
+}
+
 export class BuildFailError extends ExtendableError {
   public code: string
   public message: string

--- a/src/modules/apps/link.ts
+++ b/src/modules/apps/link.ts
@@ -34,6 +34,7 @@ import startDebuggerTunnel from './debugger'
 import workspaceUse from '../../api/modules/workspace/use'
 import { BatchStream } from '../../api/typings/types'
 import { Messages } from '../../lib/constants/Messages'
+import { NewStickyHostError } from '../../api/error/errors';
 
 let nodeNotifier
 if (process.platform !== 'win32') {
@@ -52,6 +53,7 @@ interface LinkOptions {
 
 const DELETE_SIGN = chalk.red('D')
 const UPDATE_SIGN = chalk.blue('U')
+const INITIAL_LINK_CODE = 'initial_link_required'
 const stabilityThreshold = process.platform === 'darwin' ? 100 : 200
 const linkID = randomBytes(8).toString('hex')
 
@@ -161,12 +163,12 @@ const watchAndSendChanges = async (
 ): Promise<any> => {
   const changeQueue: ChangeToSend[] = []
 
-  const onInitialLinkRequired = e => {
-    const data = e.response && e.response.data
-    if (data?.code === 'initial_link_required') {
+  const onInitialLinkRequired = err => {
+    const data = err.response && err.response.data
+    if (data?.code === INITIAL_LINK_CODE || err?.code === INITIAL_LINK_CODE) {
       return warnAndLinkFromStart(root, projectUploader, unsafe, { yarnFilesManager })
     }
-    throw e
+    throw err
   }
 
   const defaultPatterns = ['*/**', 'manifest.json', 'policies.json', 'cypress.json']
@@ -194,9 +196,11 @@ const watchAndSendChanges = async (
         tsErrorsAsWarnings: unsafe,
       })
     } catch (err) {
+      const commandType = err instanceof NewStickyHostError ? err.command:'link'
+
       nodeNotifier?.notify({
         title: appId,
-        message: 'Link died',
+        message: `${commandType} died`,
       })
 
       if (err instanceof ChangeSizeLimitError) {

--- a/src/modules/apps/link.ts
+++ b/src/modules/apps/link.ts
@@ -34,7 +34,7 @@ import startDebuggerTunnel from './debugger'
 import workspaceUse from '../../api/modules/workspace/use'
 import { BatchStream } from '../../api/typings/types'
 import { Messages } from '../../lib/constants/Messages'
-import { NewStickyHostError } from '../../api/error/errors';
+import { NewStickyHostError } from '../../api/error/errors'
 
 let nodeNotifier
 if (process.platform !== 'win32') {
@@ -196,7 +196,7 @@ const watchAndSendChanges = async (
         tsErrorsAsWarnings: unsafe,
       })
     } catch (err) {
-      const commandType = err instanceof NewStickyHostError ? err.command:'link'
+      const commandType = err instanceof NewStickyHostError ? err.command : 'link'
 
       nodeNotifier?.notify({
         title: appId,


### PR DESCRIPTION
#### What is the purpose of this pull request?
Force app to `link` from scratch when `StickyHost` chage

#### What problem is this solving?
https://vtex.slack.com/archives/CCYP7AS59/p1596807966280500?thread_ts=1596572091.199400&cid=CCYP7AS59

#### How should this be manually tested?
Link `builder-hub`
Link `store-theme` 
Change something inside `store-theme` and save in order to `relink`
Kill `builder-hub` instance on `Rancher`
Change something inside `store-theme` and save in order to `relink`
Should appear `Relink died` and `link` all app from scratch

#### Screenshots or example usage

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [X] Update `CHANGELOG.md`