### PR TITLE
Add builderhub client retries for links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Add retries to builder hub app link client
 
 ## [2.115.4] - 2020-11-03
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.115.5] - 2020-11-03
 ### Changed
 - Add retries to builder hub app link client
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.115.4",
+  "version": "2.115.5",
   "description": "The platform for e-commerce apps",
   "bin": "bin/run",
   "main": "lib/api/index.js",

--- a/src/modules/apps/link.ts
+++ b/src/modules/apps/link.ts
@@ -273,7 +273,7 @@ export async function appLink(options: LinkOptions) {
 
   const appId = manifest.appLocator
 
-  const builder = Builder.createClient({}, { timeout: 60000 })
+  const builder = Builder.createClient({}, { timeout: 60000, retries: 3 })
   const projectUploader = ProjectUploader.getProjectUploader(appId, builder)
 
   if (options.setup) {


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
We are experiencing some connectivity issues on the platform [query](https://splunk72.vtex.com/en-US/app/vtex_io_apps/search?q=search%20index%3Dio_vtex_logs%20%7C%20spath%20%22data.parsedInfo.response.data.message%22%20%7C%20search%20%22data.parsedInfo.response.data.message%22%3D%22Connection%20refused%22%7C%20spath%20app%20%7C%20search%20app%3D%22vtex.toolbelt-telemetry*%22&display.page.search.mode=smart&dispatch.sample_ratio=1&workload_pool=&earliest=-3w&latest=now&display.general.type=events&display.page.search.tab=events&display.visualizations.charting.chart=line&sid=1604421610.500111_F40559E7-0C1C-4566-8DBF-B2707C656667)

Add retries to builderhub client to diminish those issues.

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [ ] Update `CHANGELOG.md`