### PR TITLE
Feat/feature flag performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- [Feature Flags] Cache locally all flags
 
 ## [2.118.2] - 2020-11-11
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- [npm] Fix inconsistent deploy
 
 ## [2.119.0] - 2020-11-13
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.119.1] - 2020-11-13
 ### Fixed
 - [npm] Fix inconsistent deploy
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
-- [Feature Flags] Cache locally all flags
+- [Feature Flags] 
+  - Cache locally all flags
+  - New class to use feature flags
 
 ## [2.118.2] - 2020-11-11
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.119.0] - 2020-11-13
 ### Changed
 - [Feature Flags] 
   - Cache locally all flags

--- a/docs/featureFlag.md
+++ b/docs/featureFlag.md
@@ -72,7 +72,13 @@ Today it's only possible to access all feature flags inside `toolbelt`, all othe
 - Get all feature flags:
 
 ```javascript
-const featureFlags: Record<string, any> = FeatureFlag.getSingleton().getFeatureFlagInfo()
+const featureFlags: Record<string, any> = FeatureFlag.getSingleton().getAllFeatureFlagInfo()
+```
+
+- Get specific feature flag (typed):
+
+```javascript
+const flagTest: boolean = FeatureFlag.getSingleton().getFeatureFlagInfo<boolean>("FEATURE_FLAG_TEST")
 ```
 
 - Example of usage:
@@ -85,9 +91,9 @@ const featureFlags: Record<string, any> = FeatureFlag.getSingleton().getFeatureF
   // featureFlagDecider.ts
   export async function switchWhoami() {
     try {
-      const featureFlags: Record<string, any> = FeatureFlag.getSingleton().getFeatureFlagInfo()
+      const flagWhoami: boolean = FeatureFlag.getSingleton().getFeatureFlagInfo<boolean>("FEATURE_FLAG_WHOAMI_PLUGIN")
 
-      if (featureFlags.FEATURE_FLAG_WHOAMI_PLUGIN.VTEX){
+      if (flagWhoami){
         return newAuthWhoami()
       } else {
         return oldAuthWhoami()
@@ -103,7 +109,7 @@ const featureFlags: Record<string, any> = FeatureFlag.getSingleton().getFeatureF
 
   ```javascript
   // main.ts
-  import { switchWhoami } from './featureFlagDecider'
+  import { switchWhoami } from '../featureFlag/featureFlagDecider'
 
   async run() {
     this.parse(WhoAmI)

--- a/docs/featureFlag.md
+++ b/docs/featureFlag.md
@@ -71,10 +71,9 @@ Today it's only possible to access all feature flags inside `toolbelt`, all othe
 
 - Get all feature flags:
 
-  ```javascript
-  const configClient = ToolbeltConfig.createClient()
-  const { featureFlags } = await configClient.getGlobalConfig()
-  ```
+```javascript
+const featureFlags: Record<string, any> = FeatureFlag.getSingleton().getFeatureFlagInfo()
+```
 
 - Example of usage:
 
@@ -86,8 +85,7 @@ Today it's only possible to access all feature flags inside `toolbelt`, all othe
   // featureFlagDecider.ts
   export async function switchWhoami() {
     try {
-      const configClient = ToolbeltConfig.createClient()
-      const { featureFlags } = await configClient.getGlobalConfig()
+      const featureFlags: Record<string, any> = FeatureFlag.getSingleton().getFeatureFlagInfo()
 
       if (featureFlags.FEATURE_FLAG_WHOAMI_PLUGIN.VTEX){
         return newAuthWhoami()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.118.2",
+  "version": "2.119.0",
   "description": "The platform for e-commerce apps",
   "bin": "bin/run",
   "main": "lib/api/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.119.0",
+  "version": "2.119.1",
   "description": "The platform for e-commerce apps",
   "bin": "bin/run",
   "main": "lib/api/index.js",

--- a/src/CLIPreTasks/CLIPreTasks.ts
+++ b/src/CLIPreTasks/CLIPreTasks.ts
@@ -8,7 +8,6 @@ import { DeprecationChecker } from './DeprecationChecker/DeprecationChecker'
 import { OutdatedChecker } from './OutdatedChecker/OutdatedChecker'
 import { EnvVariablesConstants } from '../lib/constants/EnvVariables'
 import { FeatureFlagUpdateChecker } from '../modules/featureFlag/featureFlagUpdateChecker'
-import { FeatureFlag } from '../modules/featureFlag/featureFlag'
 
 export class CLIPreTasks {
   public static readonly PRETASKS_LOCAL_DIR = PathConstants.PRETASKS_FOLDER
@@ -58,7 +57,6 @@ export class CLIPreTasks {
 
     this.ensureCompatibleNode()
     this.removeOutdatedPaths()
-    FeatureFlag.getSingleton(join(CLIPreTasks.PRETASKS_LOCAL_DIR, FeatureFlag.FEATURE_FLAG_STORE_FILENAME))
     DeprecationChecker.checkForDeprecation(CLIPreTasks.PRETASKS_LOCAL_DIR, this.pkg)
     OutdatedChecker.checkForOutdate(CLIPreTasks.PRETASKS_LOCAL_DIR, this.pkg)
     FeatureFlagUpdateChecker.checkForUpdateFeatureFlag()

--- a/src/CLIPreTasks/CLIPreTasks.ts
+++ b/src/CLIPreTasks/CLIPreTasks.ts
@@ -7,6 +7,8 @@ import { PathConstants } from '../lib/constants/Paths'
 import { DeprecationChecker } from './DeprecationChecker/DeprecationChecker'
 import { OutdatedChecker } from './OutdatedChecker/OutdatedChecker'
 import { EnvVariablesConstants } from '../lib/constants/EnvVariables'
+import { FeatureFlagUpdateChecker } from '../modules/featureFlag/featureFlagUpdateChecker'
+import { FeatureFlag } from '../modules/featureFlag/featureFlag' 
 
 export class CLIPreTasks {
   public static readonly PRETASKS_LOCAL_DIR = PathConstants.PRETASKS_FOLDER
@@ -56,7 +58,9 @@ export class CLIPreTasks {
 
     this.ensureCompatibleNode()
     this.removeOutdatedPaths()
+    FeatureFlag.getSingleton(join(CLIPreTasks.PRETASKS_LOCAL_DIR, FeatureFlag.FEATURE_FLAG_STORE_FILENAME))
     DeprecationChecker.checkForDeprecation(CLIPreTasks.PRETASKS_LOCAL_DIR, this.pkg)
     OutdatedChecker.checkForOutdate(CLIPreTasks.PRETASKS_LOCAL_DIR, this.pkg)
+    FeatureFlagUpdateChecker.checkForUpdateFeatureFlag()
   }
 }

--- a/src/CLIPreTasks/CLIPreTasks.ts
+++ b/src/CLIPreTasks/CLIPreTasks.ts
@@ -8,7 +8,7 @@ import { DeprecationChecker } from './DeprecationChecker/DeprecationChecker'
 import { OutdatedChecker } from './OutdatedChecker/OutdatedChecker'
 import { EnvVariablesConstants } from '../lib/constants/EnvVariables'
 import { FeatureFlagUpdateChecker } from '../modules/featureFlag/featureFlagUpdateChecker'
-import { FeatureFlag } from '../modules/featureFlag/featureFlag' 
+import { FeatureFlag } from '../modules/featureFlag/featureFlag'
 
 export class CLIPreTasks {
   public static readonly PRETASKS_LOCAL_DIR = PathConstants.PRETASKS_FOLDER

--- a/src/api/clients/IOClients/external/VTEXID.ts
+++ b/src/api/clients/IOClients/external/VTEXID.ts
@@ -2,7 +2,7 @@ import { InstanceOptions, IOClient, IOContext } from '@vtex/api'
 import querystring from 'querystring'
 import { storeUrl } from '../../../storeUrl'
 import { IOClientFactory } from '../IOClientFactory'
-import { switchOpen } from '../../../../modules/featureFlagDecider'
+import { switchOpen } from '../../../../modules/featureFlag/featureFlagDecider'
 
 export class VTEXID extends IOClient {
   private static readonly DEFAULT_TIMEOUT = 10000

--- a/src/api/error/ErrorKinds.ts
+++ b/src/api/error/ErrorKinds.ts
@@ -6,6 +6,7 @@ export const ErrorKinds = {
   EDITION_REQUEST_ERROR: 'EditionRequestError',
   INVALID_OR_EXPIRED_TOKEN_ERROR: 'InvalidOrExpiredTokenError',
   OUTDATED_CHECK_ERROR: 'OutdatedCheckError',
+  FEATURE_FLAG_CHECK_ERROR: 'FeatureFlagCheckError',
   SETUP_TOOLING_ERROR: 'SetupToolingError',
   SETUP_TSCONFIG_ERROR: 'SetupTSConfigError',
   SETUP_TYPINGS_ERROR: 'SetupTypingsError',

--- a/src/lib/auth/AuthProviders/OAuthAuthenticator/index.ts
+++ b/src/lib/auth/AuthProviders/OAuthAuthenticator/index.ts
@@ -11,7 +11,7 @@ import { randomCryptoString } from '../../../utils/randomCryptoString'
 import { spawnUnblockingChildProcess } from '../../../utils/spawnUnblockingChildProcess'
 import { AuthProviderBase } from '../AuthProviderBase'
 import { LoginServer } from './LoginServer'
-import { switchOpen } from '../../../../modules/featureFlagDecider'
+import { switchOpen } from '../../../../modules/featureFlag/featureFlagDecider'
 
 export class OAuthAuthenticator extends AuthProviderBase {
   public static readonly AUTH_TYPE = 'oauth'

--- a/src/modules/browse.ts
+++ b/src/modules/browse.ts
@@ -1,7 +1,7 @@
 import QRCode from 'qrcode-terminal'
 import { SessionManager } from '../api/session/SessionManager'
 import { storeUrl } from '../api/storeUrl'
-import { switchOpen } from './featureFlagDecider'
+import { switchOpen } from './featureFlag/featureFlagDecider'
 
 interface BrowseOptions {
   qr: boolean

--- a/src/modules/featureFlag/featureFlag.ts
+++ b/src/modules/featureFlag/featureFlag.ts
@@ -22,7 +22,7 @@ export class FeatureFlag implements IFeatureFlag {
   }
 
   private store: Configstore
-  
+
   constructor(public storeFilePath: string) {
     this.store = new Configstore('', null, { configPath: storeFilePath })
   }

--- a/src/modules/featureFlag/featureFlag.ts
+++ b/src/modules/featureFlag/featureFlag.ts
@@ -1,0 +1,45 @@
+import Configstore from 'configstore'
+
+export interface IFeatureFlag {
+  storeFilePath: string
+  getLastFeatureFlagUpdate: () => number
+  setLastFeatureFlagUpdate: (date: number) => void
+  getFeatureFlagInfo: () => Record<string, any>
+  setFeatureFlagInfo: (info: Record<string, any>) => void
+}
+
+export class FeatureFlag implements IFeatureFlag {
+  public static readonly FEATURE_FLAG_STORE_FILENAME = 'feature-flag.json'
+  private static singleton: FeatureFlag
+
+  public static getSingleton(storeFilePath?: string): FeatureFlag {
+    if (FeatureFlag.singleton) {
+      return FeatureFlag.singleton
+    }
+
+    FeatureFlag.singleton = new FeatureFlag(storeFilePath)
+    return FeatureFlag.singleton
+  }
+
+  private store: Configstore
+  
+  constructor(public storeFilePath: string) {
+    this.store = new Configstore('', null, { configPath: storeFilePath })
+  }
+
+  getLastFeatureFlagUpdate() {
+    return (this.store.get('lastFeatureFlagCheck') as number) ?? 0
+  }
+
+  getFeatureFlagInfo() {
+    return (this.store.get('featureFlagInfo') as Record<string, any> | null) ?? {}
+  }
+
+  setLastFeatureFlagUpdate(date: number) {
+    this.store.set('lastFeatureFlagCheck', date)
+  }
+
+  setFeatureFlagInfo(versionFeatureFlagInfo: Record<string, any>) {
+    this.store.set('featureFlagInfo', versionFeatureFlagInfo)
+  }
+}

--- a/src/modules/featureFlag/featureFlag.ts
+++ b/src/modules/featureFlag/featureFlag.ts
@@ -2,16 +2,7 @@ import Configstore from 'configstore'
 import { join } from 'path'
 import { CLIPreTasks } from '../../CLIPreTasks/CLIPreTasks'
 
-export interface IFeatureFlag {
-  storeFilePath: string
-  getLastFeatureFlagUpdate: () => number
-  setLastFeatureFlagUpdate: (date: number) => void
-  getAllFeatureFlagInfo: () => Record<string, any>
-  getFeatureFlagInfo: <T>(flagName: string) => T
-  setFeatureFlagInfo: (info: Record<string, any>) => void
-}
-
-export class FeatureFlag implements IFeatureFlag {
+export class FeatureFlag {
   public static readonly FEATURE_FLAG_STORE_FILENAME = 'feature-flag.json'
   private static singleton: FeatureFlag
 
@@ -20,9 +11,8 @@ export class FeatureFlag implements IFeatureFlag {
       return FeatureFlag.singleton
     }
 
-    FeatureFlag.singleton = new FeatureFlag(
-      join(CLIPreTasks.PRETASKS_LOCAL_DIR, FeatureFlag.FEATURE_FLAG_STORE_FILENAME)
-    )
+    const filePath: string = join(CLIPreTasks.PRETASKS_LOCAL_DIR, FeatureFlag.FEATURE_FLAG_STORE_FILENAME)
+    FeatureFlag.singleton = new FeatureFlag(filePath)
     return FeatureFlag.singleton
   }
 

--- a/src/modules/featureFlag/featureFlag.ts
+++ b/src/modules/featureFlag/featureFlag.ts
@@ -1,10 +1,13 @@
 import Configstore from 'configstore'
+import { join } from 'path'
+import { CLIPreTasks } from '../../CLIPreTasks/CLIPreTasks'
 
 export interface IFeatureFlag {
   storeFilePath: string
   getLastFeatureFlagUpdate: () => number
   setLastFeatureFlagUpdate: (date: number) => void
-  getFeatureFlagInfo: () => Record<string, any>
+  getAllFeatureFlagInfo: () => Record<string, any>
+  getFeatureFlagInfo: <T>(flagName: string) => T
   setFeatureFlagInfo: (info: Record<string, any>) => void
 }
 
@@ -12,12 +15,14 @@ export class FeatureFlag implements IFeatureFlag {
   public static readonly FEATURE_FLAG_STORE_FILENAME = 'feature-flag.json'
   private static singleton: FeatureFlag
 
-  public static getSingleton(storeFilePath?: string): FeatureFlag {
+  public static getSingleton(): FeatureFlag {
     if (FeatureFlag.singleton) {
       return FeatureFlag.singleton
     }
 
-    FeatureFlag.singleton = new FeatureFlag(storeFilePath)
+    FeatureFlag.singleton = new FeatureFlag(
+      join(CLIPreTasks.PRETASKS_LOCAL_DIR, FeatureFlag.FEATURE_FLAG_STORE_FILENAME)
+    )
     return FeatureFlag.singleton
   }
 
@@ -31,8 +36,12 @@ export class FeatureFlag implements IFeatureFlag {
     return (this.store.get('lastFeatureFlagCheck') as number) ?? 0
   }
 
-  getFeatureFlagInfo() {
+  getAllFeatureFlagInfo() {
     return (this.store.get('featureFlagInfo') as Record<string, any> | null) ?? {}
+  }
+
+  getFeatureFlagInfo<T>(flagName: string): T {
+    return this.store.get(`featureFlagInfo.${flagName}`) as T
   }
 
   setLastFeatureFlagUpdate(date: number) {

--- a/src/modules/featureFlag/featureFlagDecider.ts
+++ b/src/modules/featureFlag/featureFlagDecider.ts
@@ -1,7 +1,7 @@
-import { ToolbeltConfig } from '../api/clients/IOClients/apps/ToolbeltConfig'
+import { ToolbeltConfig } from '../../api/clients/IOClients/apps/ToolbeltConfig'
 import open from 'open'
-import { ErrorReport } from '../api/error/ErrorReport'
-import { ErrorKinds } from '../api/error/ErrorKinds'
+import { ErrorReport } from '../../api/error/ErrorReport'
+import { ErrorKinds } from '../../api/error/ErrorKinds'
 import opn from 'opn'
 
 export async function switchOpen(url: string, options) {

--- a/src/modules/featureFlag/featureFlagUpdateChecker.ts
+++ b/src/modules/featureFlag/featureFlagUpdateChecker.ts
@@ -12,10 +12,8 @@ export class FeatureFlagUpdateChecker {
   }
 
   private static shouldUpdateFeatureFlagFile() {
-    return (
-      Date.now() - FeatureFlag.getSingleton().getLastFeatureFlagUpdate() >=
-      FeatureFlagUpdateChecker.FEATURE_FLAG_CHECK_INTERVAL
-    )
+    const invervalFromLastUpdate: number = Date.now() - FeatureFlag.getSingleton().getLastFeatureFlagUpdate()
+    return invervalFromLastUpdate >= FeatureFlagUpdateChecker.FEATURE_FLAG_CHECK_INTERVAL
   }
 
   private static startUpdateFileProcess() {

--- a/src/modules/featureFlag/featureFlagUpdateChecker.ts
+++ b/src/modules/featureFlag/featureFlagUpdateChecker.ts
@@ -12,14 +12,16 @@ export class FeatureFlagUpdateChecker {
   }
 
   private static shouldUpdateFeatureFlagFile() {
-    return Date.now() - FeatureFlag.getSingleton().getLastFeatureFlagUpdate() >= FeatureFlagUpdateChecker.FEATURE_FLAG_CHECK_INTERVAL
+    return (
+      Date.now() - FeatureFlag.getSingleton().getLastFeatureFlagUpdate() >=
+      FeatureFlagUpdateChecker.FEATURE_FLAG_CHECK_INTERVAL
+    )
   }
 
   private static startUpdateFileProcess() {
     spawnUnblockingChildProcess(process.execPath, [
       join(__dirname, 'featureFlagUpdateExec.js'),
-      FeatureFlag.getSingleton().storeFilePath
+      FeatureFlag.getSingleton().storeFilePath,
     ])
   }
-
 }

--- a/src/modules/featureFlag/featureFlagUpdateChecker.ts
+++ b/src/modules/featureFlag/featureFlagUpdateChecker.ts
@@ -1,0 +1,25 @@
+import { join } from 'path'
+import { spawnUnblockingChildProcess } from '../../lib/utils/spawnUnblockingChildProcess'
+import { FeatureFlag } from './featureFlag'
+
+export class FeatureFlagUpdateChecker {
+  private static readonly FEATURE_FLAG_CHECK_INTERVAL = 1000 * 60 * 2 // 2 Minutes
+
+  public static checkForUpdateFeatureFlag() {
+    if (FeatureFlagUpdateChecker.shouldUpdateFeatureFlagFile()) {
+      FeatureFlagUpdateChecker.startUpdateFileProcess()
+    }
+  }
+
+  private static shouldUpdateFeatureFlagFile() {
+    return Date.now() - FeatureFlag.getSingleton().getLastFeatureFlagUpdate() >= FeatureFlagUpdateChecker.FEATURE_FLAG_CHECK_INTERVAL
+  }
+
+  private static startUpdateFileProcess() {
+    spawnUnblockingChildProcess(process.execPath, [
+      join(__dirname, 'featureFlagUpdateExec.js'),
+      FeatureFlag.getSingleton().storeFilePath
+    ])
+  }
+
+}

--- a/src/modules/featureFlag/featureFlagUpdateChecker.ts
+++ b/src/modules/featureFlag/featureFlagUpdateChecker.ts
@@ -19,9 +19,6 @@ export class FeatureFlagUpdateChecker {
   }
 
   private static startUpdateFileProcess() {
-    spawnUnblockingChildProcess(process.execPath, [
-      join(__dirname, 'featureFlagUpdateExec.js'),
-      FeatureFlag.getSingleton().storeFilePath,
-    ])
+    spawnUnblockingChildProcess(process.execPath, [join(__dirname, 'featureFlagUpdateExec.js')])
   }
 }

--- a/src/modules/featureFlag/featureFlagUpdateExec.ts
+++ b/src/modules/featureFlag/featureFlagUpdateExec.ts
@@ -30,8 +30,7 @@ export const updateFeatureFlagsFile = async (store: IFeatureFlag) => {
 
 if (require.main === module) {
   // eslint-disable-next-line prefer-destructuring
-  const storeFilePath = process.argv[2]
-  const store = FeatureFlag.getSingleton(storeFilePath)
+  const store = FeatureFlag.getSingleton()
   // eslint-disable-next-line prefer-destructuring
   updateFeatureFlagsFile(store)
   console.log(`Finished checking for feature flag after ${hrTimeToMs(process.hrtime(initTime))}`)

--- a/src/modules/featureFlag/featureFlagUpdateExec.ts
+++ b/src/modules/featureFlag/featureFlagUpdateExec.ts
@@ -1,0 +1,39 @@
+const initTime = process.hrtime()
+
+import { ToolbeltConfig } from '../../api/clients/IOClients/apps/ToolbeltConfig'
+import { ErrorKinds } from '../../api/error/ErrorKinds'
+import { ErrorReport } from '../../api/error/ErrorReport'
+import { TelemetryCollector } from '../../lib/telemetry/TelemetryCollector'
+import { hrTimeToMs } from '../../lib/utils/hrTimeToMs'
+import { IFeatureFlag, FeatureFlag } from './featureFlag';
+
+export const updateFeatureFlagsFile = async (store: IFeatureFlag) => {
+  try {
+    const client = ToolbeltConfig.createClient({}, { retries: 3 })
+    const { featureFlags } = await client.getGlobalConfig()
+
+    store.setFeatureFlagInfo(featureFlags)
+    store.setLastFeatureFlagUpdate(Date.now())
+
+  } catch (err) {
+    const telemetryCollector = TelemetryCollector.getCollector()
+    const errorReport = telemetryCollector.registerError(
+      ErrorReport.create({
+        kind: ErrorKinds.FEATURE_FLAG_CHECK_ERROR,
+        originalError: err,
+      })
+    )
+
+    console.error('Error checking for feature flag', JSON.stringify(errorReport.toObject(), null, 2))
+    telemetryCollector.flush()
+  }
+}
+
+if (require.main === module) {
+  // eslint-disable-next-line prefer-destructuring
+  const storeFilePath = process.argv[2]
+  const store = FeatureFlag.getSingleton(storeFilePath)
+  // eslint-disable-next-line prefer-destructuring
+  updateFeatureFlagsFile(store)
+  console.log(`Finished checking for feature flag after ${hrTimeToMs(process.hrtime(initTime))}`)
+}

--- a/src/modules/featureFlag/featureFlagUpdateExec.ts
+++ b/src/modules/featureFlag/featureFlagUpdateExec.ts
@@ -29,9 +29,7 @@ export const updateFeatureFlagsFile = async (store: IFeatureFlag) => {
 }
 
 if (require.main === module) {
-  // eslint-disable-next-line prefer-destructuring
   const store = FeatureFlag.getSingleton()
-  // eslint-disable-next-line prefer-destructuring
   updateFeatureFlagsFile(store)
   console.log(`Finished checking for feature flag after ${hrTimeToMs(process.hrtime(initTime))}`)
 }

--- a/src/modules/featureFlag/featureFlagUpdateExec.ts
+++ b/src/modules/featureFlag/featureFlagUpdateExec.ts
@@ -3,11 +3,11 @@ import { ErrorKinds } from '../../api/error/ErrorKinds'
 import { ErrorReport } from '../../api/error/ErrorReport'
 import { TelemetryCollector } from '../../lib/telemetry/TelemetryCollector'
 import { hrTimeToMs } from '../../lib/utils/hrTimeToMs'
-import { IFeatureFlag, FeatureFlag } from './featureFlag'
+import { FeatureFlag } from './featureFlag'
 
 const initTime = process.hrtime()
 
-export const updateFeatureFlagsFile = async (store: IFeatureFlag) => {
+export const updateFeatureFlagsFile = async (store: FeatureFlag) => {
   try {
     const client = ToolbeltConfig.createClient({}, { retries: 3 })
     const { featureFlags } = await client.getGlobalConfig()

--- a/src/modules/featureFlag/featureFlagUpdateExec.ts
+++ b/src/modules/featureFlag/featureFlagUpdateExec.ts
@@ -1,11 +1,11 @@
-const initTime = process.hrtime()
-
 import { ToolbeltConfig } from '../../api/clients/IOClients/apps/ToolbeltConfig'
 import { ErrorKinds } from '../../api/error/ErrorKinds'
 import { ErrorReport } from '../../api/error/ErrorReport'
 import { TelemetryCollector } from '../../lib/telemetry/TelemetryCollector'
 import { hrTimeToMs } from '../../lib/utils/hrTimeToMs'
-import { IFeatureFlag, FeatureFlag } from './featureFlag';
+import { IFeatureFlag, FeatureFlag } from './featureFlag'
+
+const initTime = process.hrtime()
 
 export const updateFeatureFlagsFile = async (store: IFeatureFlag) => {
   try {
@@ -14,7 +14,6 @@ export const updateFeatureFlagsFile = async (store: IFeatureFlag) => {
 
     store.setFeatureFlagInfo(featureFlags)
     store.setLastFeatureFlagUpdate(Date.now())
-
   } catch (err) {
     const telemetryCollector = TelemetryCollector.getCollector()
     const errorReport = telemetryCollector.registerError(

--- a/src/nps.ts
+++ b/src/nps.ts
@@ -1,6 +1,6 @@
 import enquirer from 'enquirer'
 import moment from 'moment'
-import { switchOpen } from './modules/featureFlagDecider'
+import { switchOpen } from './modules/featureFlag/featureFlagDecider'
 import { getNextFeedbackDate, saveNextFeedbackDate } from './api/conf'
 import { promptConfirm } from './api/modules/prompts'
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
Cache feature flags locally

#### What problem is this solving?
Every time that the user triggers a command, a request is made to the `toolbelt-config-server` now is stored in `.vtex/pretasks`

#### Types of changes
- [X] Refactor (non-breaking change that only makes the code better)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [X] Update `CHANGELOG.md`