### PR TITLE
Change Install script download url

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -41,18 +41,21 @@
         exit 1
     fi
         
+    TAR_ARGS="xz"
+    versionUrl=https://vtex-toolbelt-test.s3.us-east-2.amazonaws.com/\$OS-\$ARCH
+
+    echo "Downloading latest version from \$versionUrl"
+    URL=\$(curl -sk \$versionUrl | jq --raw-output '.gz')
+
     mkdir -p /usr/local/lib
     cd /usr/local/lib
+
     rm -rf vtex
+    rm -rf ~/.vtex
     rm -rf ~/.local/share/vtex/client
 
-    URL=https://vtex-toolbelt-test.s3.us-east-2.amazonaws.com/vtex-\$OS-\$ARCH.tar.gz
-    TAR_ARGS="xz"
-    
-
-    
     echo "Installing VTEX from \$URL"
-    
+
     if [ \$(command -v curl) ]; then
         curl "\$URL" | tar "\$TAR_ARGS"
     else
@@ -76,5 +79,5 @@ SCRIPT
   # test the CLI
   LOCATION=$(command -v vtex)
   echo "vtex installed to $LOCATION"
-  vtex version
+  vtex -v
 }

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -32,6 +32,8 @@
     rm -rf ~/.local/share/vtex
     echo "removing /usr/local/lib/vtex ..."
     rm -rf /usr/local/lib/vtex
+    echo "removing ~/.vtex ..."
+    rm -rf ~/.vtex
     
 SCRIPT
     echo "VTEX CLI Uninstalled"


### PR DESCRIPTION
#### What is the purpose of this pull request?
Change `aws` install script to download `toolbelt` from base tar to custom tar

#### What problem is this solving?
When `toolbelt` have some version deprecated, the new user that download `toolbelt` from this script will download the latest version that is the deprecated file.

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [ ] Update `CHANGELOG.md`