### PR TITLE
Feat/ignore deprecate and outdate to autoupdate command

### DIFF
--- a/.github/workflows/publish-stable-aws.yml
+++ b/.github/workflows/publish-stable-aws.yml
@@ -11,6 +11,7 @@ jobs:
   aws-publish:
     runs-on: ubuntu-latest
     steps:
+      - name: Deploy on AWS
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:

--- a/.github/workflows/publish-stable-aws.yml
+++ b/.github/workflows/publish-stable-aws.yml
@@ -11,9 +11,19 @@ jobs:
   aws-publish:
     runs-on: ubuntu-latest
     steps:
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: false
+          prerelease: false
       - name: Deploy on AWS
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+        uses: actions/checkout@v2
+        uses: actions/setup-node@v1
         with:
           node-version: 12
           registry-url: https://registry.npmjs.org/
@@ -36,16 +46,6 @@ jobs:
             IS_CI: "true"
             AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID}}
             AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          draft: false
-          prerelease: false
       - name: Get deploy version
         id: branch_name
         run: |

--- a/.github/workflows/publish-stable-aws.yml
+++ b/.github/workflows/publish-stable-aws.yml
@@ -11,19 +11,8 @@ jobs:
   aws-publish:
     runs-on: ubuntu-latest
     steps:
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          draft: false
-          prerelease: false
-      - name: Deploy on AWS
-        uses: actions/checkout@v2
-        uses: actions/setup-node@v1
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
         with:
           node-version: 12
           registry-url: https://registry.npmjs.org/

--- a/.github/workflows/publish-stable-aws.yml
+++ b/.github/workflows/publish-stable-aws.yml
@@ -36,6 +36,16 @@ jobs:
             IS_CI: "true"
             AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID}}
             AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: false
+          prerelease: false
       - name: Get deploy version
         id: branch_name
         run: |

--- a/.github/workflows/publish-stable-aws.yml
+++ b/.github/workflows/publish-stable-aws.yml
@@ -35,20 +35,26 @@ jobs:
             IS_CI: "true"
             AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID}}
             AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
+  publish-sucess:
+    runs-on: ubuntu-latest
+    needs: [aws-publish]
+    steps:
       - name: Get deploy version
-        id: branch_name
-        run: |
-          echo ::set-output name=SOURCE_TAG::$(curl https://api.github.com/repos/vtex/toolbelt/releases/latest -s | jq .tag_name -r)
+        run: echo ::set-output name=SOURCE_TAG::$(curl https://api.github.com/repos/vtex/toolbelt/releases/latest -s | jq .tag_name -r)
       - name: Trigger slack notification bot [Success]
-        if: success()
         run: 'curl --connect-timeout 30 --retry 3 --retry-delay 120 --data "status=success&user=${{ github.actor }}&platform=AWS-S3&version=${{ steps.branch_name.outputs.SOURCE_TAG }}" --header "token: ${{ secrets.TOOLBELT_NOTIFICATION_KEY }}" https://master--vtex.myvtex.com/_v/public/toolbelt-notification/status'
-      - name: Trigger slack notification bot [Fail]
-        if: failure()
-        run: 'curl --connect-timeout 30 --retry 3 --retry-delay 120 --data "status=failed&user=${{ github.actor }}&platform=AWS-S3&version=${{ steps.branch_name.outputs.SOURCE_TAG }}" --header "token: ${{ secrets.TOOLBELT_NOTIFICATION_KEY }}" https://master--vtex.myvtex.com/_v/public/toolbelt-notification/status'
       - name: Trigger next workflow
-        if: success()
         uses: peter-evans/repository-dispatch@v1
         with:
           token: ${{ secrets.REPO_GHA_PAT }}
           repository: vtex/homebrew-vtex
           event-type: bump-brew
+  publish-failed:
+    runs-on: ubuntu-latest
+    needs: [aws-publish]
+    if: failure()
+    steps:
+      - name: Get deploy version
+        run: echo ::set-output name=SOURCE_TAG::$(curl https://api.github.com/repos/vtex/toolbelt/releases/latest -s | jq .tag_name -r)
+      - name: Trigger slack notification bot [Fail]
+        run: 'curl --connect-timeout 30 --retry 3 --retry-delay 120 --data "status=failed&user=${{ github.actor }}&platform=AWS-S3&version=${{ steps.branch_name.outputs.SOURCE_TAG }}" --header "token: ${{ secrets.TOOLBELT_NOTIFICATION_KEY }}" https://master--vtex.myvtex.com/_v/public/toolbelt-notification/status'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+### Added
+-[autoupdate] skip `checkForDeprecation` and `checkForOutdate` for `autoupdate` command.
 ## [2.121.0] - 2021-01-04
 ### Added
 - [Toolbelt Notification] Integrate `toolbelt` with `toolbelt-notification`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.121.1] - 2021-01-05
 ### Added
 -[autoupdate] skip `checkForDeprecation` and `checkForOutdate` for `autoupdate` command.
 ## [2.121.0] - 2021-01-04

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.121.0",
+  "version": "2.121.1",
   "description": "The platform for e-commerce apps",
   "bin": "bin/run",
   "main": "lib/api/index.js",

--- a/src/CLIPreTasks/CLIPreTasks.ts
+++ b/src/CLIPreTasks/CLIPreTasks.ts
@@ -9,6 +9,10 @@ import { OutdatedChecker } from './OutdatedChecker/OutdatedChecker'
 import { EnvVariablesConstants } from '../lib/constants/EnvVariables'
 import { FeatureFlagUpdateChecker } from '../modules/featureFlag/featureFlagUpdateChecker'
 
+const COMMANDS = {
+  AUTOUPDATE: 'autoupdate',
+}
+
 export class CLIPreTasks {
   public static readonly PRETASKS_LOCAL_DIR = PathConstants.PRETASKS_FOLDER
 
@@ -50,15 +54,17 @@ export class CLIPreTasks {
     })
   }
 
-  public runTasks() {
+  public runTasks(command: string) {
     if (process.env[EnvVariablesConstants.IGNORE_CLIPRETASKS]) {
       return
     }
 
     this.ensureCompatibleNode()
     this.removeOutdatedPaths()
-    DeprecationChecker.checkForDeprecation(CLIPreTasks.PRETASKS_LOCAL_DIR, this.pkg)
-    OutdatedChecker.checkForOutdate(CLIPreTasks.PRETASKS_LOCAL_DIR, this.pkg)
+    if (command !== COMMANDS.AUTOUPDATE) {
+      DeprecationChecker.checkForDeprecation(CLIPreTasks.PRETASKS_LOCAL_DIR, this.pkg)
+      OutdatedChecker.checkForOutdate(CLIPreTasks.PRETASKS_LOCAL_DIR, this.pkg)
+    }
     FeatureFlagUpdateChecker.checkForUpdateFeatureFlag()
   }
 }

--- a/src/oclif/hooks/init.ts
+++ b/src/oclif/hooks/init.ts
@@ -56,7 +56,7 @@ const checkLogin = async (command: string) => {
 
 const main = async (options?: HookKeyOrOptions<'init'>, calculateInitTime?: boolean) => {
   const cliPreTasksStart = process.hrtime()
-  CLIPreTasks.getCLIPreTasks(pkg).runTasks()
+  CLIPreTasks.getCLIPreTasks(pkg).runTasks(options.id)
   TelemetryCollector.getCollector().registerMetric({
     command: 'not-applicable',
     [MetricNames.CLI_PRE_TASKS_LATENCY]: hrTimeToMs(process.hrtime(cliPreTasksStart)),


### PR DESCRIPTION
#### What is the purpose of this pull request?
Enable `vtex autoupdate` when `toolbelt` is `deprecated` or `outdated`
#### What problem is this solving?
`Toolbelt` return with `exit 1` when `CLI` is `deprecated` or `outdated`
<!--- What is the motivation and context for this change? -->


#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [X] Update `CHANGELOG.md`