### PR TITLE
Don't throw error when switching to same account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.1.2-beta] - 2021-02-04
 ### Changed
 - Don't throw error when switching to same account
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Don't throw error when switching to same account
 
 ## [3.1.1-beta] - 2021-02-04
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "3.1.1-beta",
+  "version": "3.1.2-beta",
   "description": "The platform for e-commerce apps",
   "bin": "bin/run",
   "main": "lib/api/index.js",

--- a/src/api/modules/auth/switch.ts
+++ b/src/api/modules/auth/switch.ts
@@ -1,9 +1,7 @@
 import chalk from 'chalk'
-import { split } from 'ramda'
 import { createFlowIssueError } from '../../error/utils'
 import { SessionManager } from '../../session/SessionManager'
 import log from '../../logger'
-import { promptConfirm } from '../prompts'
 import { handleErrorCreatingWorkspace, workspaceCreator } from '../workspace/create'
 import welcome from '../../../modules/auth/welcome'
 
@@ -11,9 +9,6 @@ interface SwitchOptions {
   showWelcomeMessage?: boolean
   workspace?: string
   gracefulAccountCheck?: boolean
-  initialPrompt?: {
-    message: string
-  }
 }
 
 interface AccountReturnArgs {
@@ -22,17 +17,21 @@ interface AccountReturnArgs {
   promptConfirmation?: boolean
 }
 
-const checkAndSwitch = async (targetAccount: string, targetWorkspace: string) => {
+enum SwitchStatus {
+  SwitchedAccount,
+  SwitchedOnlyWorkspace,
+  SwitchedNothing,
+}
+
+const checkAndSwitch = async (targetAccount: string, targetWorkspace: string): Promise<SwitchStatus> => {
   const session = SessionManager.getSingleton()
-  const { account: currAccount } = session
+  const { account: initialAccount, workspace: initialWorkspace } = session
   const isValidAccount = /^\s*[\w-]+\s*$/.test(targetAccount)
 
   if (!isValidAccount) {
     throw createFlowIssueError('Invalid account format')
-  } else if (!currAccount) {
+  } else if (!initialAccount) {
     throw createFlowIssueError("You're not logged in right now")
-  } else if (currAccount === targetAccount) {
-    throw createFlowIssueError(`You're already using the account ${chalk.blue(targetAccount)}`)
   }
 
   await session.login(targetAccount, {
@@ -47,41 +46,50 @@ const checkAndSwitch = async (targetAccount: string, targetWorkspace: string) =>
   const { account, workspace, userLogged } = session
 
   log.info(`Logged into ${chalk.blue(account)} as ${chalk.green(userLogged)} at workspace ${chalk.green(workspace)}`)
+
+  if (initialAccount !== targetAccount) {
+    return SwitchStatus.SwitchedAccount
+  }
+  if (initialWorkspace !== targetWorkspace) {
+    return SwitchStatus.SwitchedOnlyWorkspace
+  }
+  return SwitchStatus.SwitchedNothing
 }
 
-export const switchAccount = async (account: string, options: SwitchOptions): Promise<boolean> => {
-  const { account: currAccount, lastUsedAccount } = SessionManager.getSingleton()
+export const switchAccount = async (targetAccount: string, options: SwitchOptions): Promise<boolean> => {
+  const { account: currAccount, lastUsedAccount, workspace: currWorkspace } = SessionManager.getSingleton()
 
-  if (options.gracefulAccountCheck && currAccount === account) {
+  if (options.gracefulAccountCheck && currAccount === targetAccount) {
     return false
   }
 
-  if (options.initialPrompt) {
-    const confirm = await promptConfirm(options.initialPrompt.message)
-    if (!confirm) {
-      return false
-    }
-  }
-
-  if (account === '-') {
-    account = lastUsedAccount
-    if (account == null) {
+  if (targetAccount === '-') {
+    targetAccount = lastUsedAccount
+    if (targetAccount == null) {
       throw createFlowIssueError('No last used account was found')
     }
   }
 
   const previousAccount = currAccount
-  // Enable users to type `vtex switch {account}/{workspace}` and switch
-  // directly to a workspace without typing the `-w` option.
-  const [parsedAccount, parsedWorkspace] = split('/', account)
+  const [parsedAccount, parsedWorkspace] = targetAccount.split('/')
   if (parsedWorkspace) {
     options = { ...options, workspace: parsedWorkspace }
   }
 
-  await checkAndSwitch(parsedAccount, options.workspace || 'master')
-  log.info(`Switched from ${chalk.blue(previousAccount)} to ${chalk.blue(parsedAccount)}`)
+  const switchStatus = await checkAndSwitch(parsedAccount, options.workspace || 'master')
+  if (switchStatus === SwitchStatus.SwitchedAccount) {
+    log.info(`Switched from ${chalk.blue(previousAccount)} to ${chalk.blue(parsedAccount)}`)
+  } else if (switchStatus === SwitchStatus.SwitchedOnlyWorkspace) {
+    log.info(
+      `Switched from workspace ${chalk.blue(currWorkspace)} to ${chalk.blue(parsedWorkspace)} in account ${chalk.blue(
+        parsedAccount
+      )}`
+    )
+  } else if (switchStatus === SwitchStatus.SwitchedNothing) {
+    log.info(`You're already logged in ${chalk.blue(targetAccount)}`)
+  }
 
-  if (options.showWelcomeMessage) {
+  if (options.showWelcomeMessage && switchStatus === SwitchStatus.SwitchedAccount) {
     await welcome()
   }
 

--- a/src/api/modules/auth/switch.ts
+++ b/src/api/modules/auth/switch.ts
@@ -1,9 +1,10 @@
 import chalk from 'chalk'
 import { createFlowIssueError } from '../../error/utils'
 import { SessionManager } from '../../session/SessionManager'
-import log from '../../logger'
+import logger from '../../logger'
 import { handleErrorCreatingWorkspace, workspaceCreator } from '../workspace/create'
 import welcome from '../../../modules/auth/welcome'
+import { COLORS } from '../../constants'
 
 interface SwitchOptions {
   showWelcomeMessage?: boolean
@@ -45,7 +46,7 @@ const checkAndSwitch = async (targetAccount: string, targetWorkspace: string): P
 
   const { account, workspace, userLogged } = session
 
-  log.info(`Logged into ${chalk.blue(account)} as ${chalk.green(userLogged)} at workspace ${chalk.green(workspace)}`)
+  logger.info(`Logged into ${chalk.hex(COLORS.BLUE)(account)} as ${chalk.green(userLogged)} at workspace ${chalk.green(workspace)}`)
 
   if (initialAccount !== targetAccount) {
     return SwitchStatus.SwitchedAccount
@@ -78,15 +79,15 @@ export const switchAccount = async (targetAccount: string, options: SwitchOption
 
   const switchStatus = await checkAndSwitch(parsedAccount, options.workspace || 'master')
   if (switchStatus === SwitchStatus.SwitchedAccount) {
-    log.info(`Switched from ${chalk.blue(previousAccount)} to ${chalk.blue(parsedAccount)}`)
+    logger.info(`Switched from ${chalk.hex(COLORS.BLUE)(previousAccount)} to ${chalk.hex(COLORS.BLUE)(parsedAccount)}`)
   } else if (switchStatus === SwitchStatus.SwitchedOnlyWorkspace) {
-    log.info(
-      `Switched from workspace ${chalk.blue(currWorkspace)} to ${chalk.blue(parsedWorkspace)} in account ${chalk.blue(
-        parsedAccount
-      )}`
+    logger.info(
+      `Switched from workspace ${chalk.hex(COLORS.BLUE)(currWorkspace)} to ${chalk.hex(COLORS.BLUE)(
+        parsedWorkspace
+      )} in account ${chalk.hex(COLORS.BLUE)(parsedAccount)}`
     )
   } else if (switchStatus === SwitchStatus.SwitchedNothing) {
-    log.info(`You're already logged in ${chalk.blue(targetAccount)}`)
+    logger.info(`You're already logged in ${chalk.hex(COLORS.BLUE)(targetAccount)}`)
   }
 
   if (options.showWelcomeMessage && switchStatus === SwitchStatus.SwitchedAccount) {
@@ -108,9 +109,9 @@ export function returnToPreviousAccount({
     ...(promptConfirmation
       ? {
           initialPrompt: {
-            message: `Now you are logged in ${chalk.blue(
+            message: `Now you are logged in ${chalk.hex(COLORS.BLUE)(
               SessionManager.getSingleton().account
-            )}. Do you want to return to ${chalk.blue(previousAccount)} account?`,
+            )}. Do you want to return to ${chalk.hex(COLORS.BLUE)(previousAccount)} account?`,
           },
         }
       : null),

--- a/src/api/modules/auth/switch.ts
+++ b/src/api/modules/auth/switch.ts
@@ -46,7 +46,11 @@ const checkAndSwitch = async (targetAccount: string, targetWorkspace: string): P
 
   const { account, workspace, userLogged } = session
 
-  logger.info(`Logged into ${chalk.hex(COLORS.BLUE)(account)} as ${chalk.green(userLogged)} at workspace ${chalk.green(workspace)}`)
+  logger.info(
+    `Logged into ${chalk.hex(COLORS.BLUE)(account)} as ${chalk.green(userLogged)} at workspace ${chalk.green(
+      workspace
+    )}`
+  )
 
   if (initialAccount !== targetAccount) {
     return SwitchStatus.SwitchedAccount


### PR DESCRIPTION
#### What is the purpose of this pull request?
[Jira card](https://vtex-dev.atlassian.net/browse/DT-360?atlOrigin=eyJpIjoiMWI3MmNiNzNlZmIzNDJmOGI3NDIwNTQ3NzYxMWUwZTYiLCJwIjoiaiJ9)

Don't throw error when switching to same account.

If I use the command:

vtex switch `storecomponents/breno`

And I'm at `storecomponents/foobar`, toolbelt will throw an error saying that I'm already at storecomponents and won't switch me to the workspace breno.

The ideal would be to just to move me to the new workspace.

#### How should this be manually tested?
After the command `yarn watch`, you may try:
```bash
vtex-test switch vtex/master

vtex-test switch vtex/master
# This should not throw an error

vtex-test switch vtex/davi
# This should not throw an error either

vtex-test switch storecomponents/master
# This behavior won't change
```

#### Screenshots or example usage
<img width="979" alt="Screen Shot 2021-02-01 at 5 44 06 PM" src="https://user-images.githubusercontent.com/17756399/106516461-d3c9ad80-64b5-11eb-8258-53857706b536.png">


#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [x] Update `CHANGELOG.md`