### PR TITLE
Fix install's plan message for plans without metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.121.3] - 2021-02-11
 ### Fixed
 -[install] Fix app's plan message for plans without metrics.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+-[install] Fix app's plan message for plans without metrics.
 
 ## [2.121.2] - 2021-01-13
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.121.2",
+  "version": "2.121.3",
   "description": "The platform for e-commerce apps",
   "bin": "bin/run",
   "main": "lib/api/index.js",

--- a/src/api/modules/utils.ts
+++ b/src/api/modules/utils.ts
@@ -192,7 +192,7 @@ const billingInfoFromPolicy = ({ currency, billing: { items } }: Policy): Billin
 const billingInfoFromPlan = ({ currency, price: { subscription, metrics } }: Plan): BillingInfo => ({
   currency,
   subscription,
-  metrics: metrics.map(({ id, ranges }) => ({ name: id, ranges })),
+  metrics: metrics?.map(({ id, ranges }) => ({ name: id, ranges })),
 })
 
 const buildBillingInfo = (plans?: Plan[], policies?: Policy[]): BillingInfo => {


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->

Users could not install apps with `billingOptions` that did not have any `metrics`

![image](https://user-images.githubusercontent.com/12221113/106960655-28219700-671b-11eb-91a1-99e3493cb74d.png)


#### How should this be manually tested?

1) `vtex-test install acupula.ditocrm`

App's Billing Options should be shown correctly

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/12221113/106960773-5606db80-671b-11eb-84ec-265a8b1f5a79.png)

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [x] Update `CHANGELOG.md`