### PR TITLE
Feature/app usd plan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-<<<<<<< HEAD
 
+- [install] Fix app's plan message for plans without metrics.
 - `composable-commerce` as codeowners.
 
 ## [2.122.0] - 2021-02-23
@@ -52,9 +52,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 -[install] Fix app's plan message for plans without metrics.
-=======
--[install] Handle paid app installations for multiple currencies
->>>>>>> 722396fd (Refactoring international app install)
 
 ## [2.121.2] - 2021-01-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+<<<<<<< HEAD
 
 - `composable-commerce` as codeowners.
 
@@ -51,6 +52,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 -[install] Fix app's plan message for plans without metrics.
+=======
+-[install] Handle paid app installations for multiple currencies
+>>>>>>> 722396fd (Refactoring international app install)
 
 ## [2.121.2] - 2021-01-13
 

--- a/src/api/clients/IOClients/apps/Billing.ts
+++ b/src/api/clients/IOClients/apps/Billing.ts
@@ -14,10 +14,13 @@ export class Billing extends AppClient {
   public installApp = async (
     appName: string,
     termsOfUseAccepted: boolean,
-    force: boolean
+    force: boolean,
+    selectedPlanId?: string
   ): Promise<InstallResponse> => {
     const graphQLQuery = `mutation InstallApps{
-      install(appName:"${appName}", termsOfUseAccepted:${termsOfUseAccepted}, force:${force}) {
+      install(appName:"${appName}", termsOfUseAccepted:${termsOfUseAccepted}, force:${force}${
+      selectedPlanId ? `, selectedPlanId: "${selectedPlanId}"` : ''
+    }) {
         code
         billingOptions
       }

--- a/src/lib/constants/BillingMessages.ts
+++ b/src/lib/constants/BillingMessages.ts
@@ -10,6 +10,8 @@ export const BillingMessages = {
   PRICING_COLUMN: chalk.hex(COLORS.WHITE).bold('Pricing (monthly)'),
   INSTALL_STARTED: 'Starting to install app with accepted Terms',
   INSTALL_SUCCESS: 'Installed after accepted terms',
+  CURRENCY_OPTIONS:
+    'This app can be purchased in different currencies. What currency do you want to use to complete the purchase?',
   app: (app: string) => chalk.hex(COLORS.PINK)(app),
   billingOptionsForApp: (app: string) =>
     chalk.bold(`${chalk.hex(COLORS.WHITE)('Billing Options for app ')}${BillingMessages.app(app)}`),
@@ -24,4 +26,6 @@ export const BillingMessages = {
       app
     )} app . To install it, you need to accept the app's terms.`,
   billingTable: (table: string) => `\n${table}`,
+  appCurrencyPage: (currency: string, link: string) =>
+    `Please follow to the App Store page to buy this app in '${currency}' currency: ${link}`,
 }

--- a/src/lib/constants/BillingMessages.ts
+++ b/src/lib/constants/BillingMessages.ts
@@ -10,8 +10,7 @@ export const BillingMessages = {
   PRICING_COLUMN: chalk.hex(COLORS.WHITE).bold('Pricing (monthly)'),
   INSTALL_STARTED: 'Starting to install app with accepted Terms',
   INSTALL_SUCCESS: 'Installed after accepted terms',
-  CURRENCY_OPTIONS:
-    'This app can be purchased in different currencies. What currency do you want to use to complete the purchase?',
+  CURRENCY_OPTIONS: 'Which currency do you prefer to use to buy this app?',
   app: (app: string) => chalk.hex(COLORS.PINK)(app),
   billingOptionsForApp: (app: string) =>
     chalk.bold(`${chalk.hex(COLORS.WHITE)('Billing Options for app ')}${BillingMessages.app(app)}`),
@@ -27,5 +26,6 @@ export const BillingMessages = {
     )} app . To install it, you need to accept the app's terms.`,
   billingTable: (table: string) => `\n${table}`,
   appCurrencyPage: (currency: string, link: string) =>
-    `Please follow to the App Store page to buy this app in '${currency}' currency: ${link}`,
+    `To buy this app in '${currency}' currency, go to the VTEX App Store at the following link: ${link}`,
+  shouldOpenPage: () => `Would you like to open the VTEX App Store page?`,
 }

--- a/src/lib/constants/BillingMessages.ts
+++ b/src/lib/constants/BillingMessages.ts
@@ -10,7 +10,7 @@ export const BillingMessages = {
   PRICING_COLUMN: chalk.hex(COLORS.WHITE).bold('Pricing (monthly)'),
   INSTALL_STARTED: 'Starting to install app with accepted Terms',
   INSTALL_SUCCESS: 'Installed after accepted terms',
-  CURRENCY_OPTIONS: 'Which currency do you prefer to use to buy this app?',
+  CURRENCY_OPTIONS: 'Which currency do you prefer to buy this app?',
   app: (app: string) => chalk.hex(COLORS.PINK)(app),
   billingOptionsForApp: (app: string) =>
     chalk.bold(`${chalk.hex(COLORS.WHITE)('Billing Options for app ')}${BillingMessages.app(app)}`),
@@ -26,6 +26,6 @@ export const BillingMessages = {
     )} app . To install it, you need to accept the app's terms.`,
   billingTable: (table: string) => `\n${table}`,
   appCurrencyPage: (currency: string, link: string) =>
-    `To buy this app in '${currency}' currency, go to the VTEX App Store at the following link: ${link}`,
+    `To buy this app in '${currency}' currency, please go to the VTEX App Store at the following link: ${link}`,
   shouldOpenPage: () => `Would you like to open the VTEX App Store page?`,
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->

Currently all paid apps are only sold to Brazil and using the currency BRL (Brazilian Real). Our goal is to now release the App Store globally, selling apps to any country in USD (United State Dollars). This require some changes in the toolbelt which this PR attempts to solve.

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->

Handle `vtex install` for international apps.

#### How should this be manually tested?

There are multiple scenarios, first we have to make sure that old features still works and new ones work as expected.

_Brazilian VTEX account_

1) App is free: `vtex-test install vtex.social-selling` (This should work exactly as before)

![image](https://user-images.githubusercontent.com/12221113/107725261-9ab6e780-6cc4-11eb-8d52-59a55fa56646.png)

2) Paid app, in BRL only: `vtex-test install vtex.sms-provider` (This should work exactly as before)

![image](https://user-images.githubusercontent.com/12221113/107725317-ba4e1000-6cc4-11eb-9b1b-0fed97b63326.png)

3) Paid app, available both in BRL and USD. User is prompted to choose which Plan.

`vtex-test install pilateslovers.billingoptionstest@20.x`

![image](https://user-images.githubusercontent.com/12221113/107725378-e79abe00-6cc4-11eb-853d-b878788b85a6.png)

a) If the user chooses `BRL`, the install process should be exactly like the old one:

![image](https://user-images.githubusercontent.com/12221113/107725469-203a9780-6cc5-11eb-91b2-00c4fba3641f.png)

b) If the user chooses `USD` (or any thing other than `BRL`):

  i) If he account has an active contract (i.e that app was previously bought), the app should be automatically installed

  ii) Othwerwisea message is shown explaning that this app can only be installed and purchased in the App Store website

`vtex-test install pilateslovers.billingoptionstest@20.x`

![image](https://user-images.githubusercontent.com/12221113/107725578-5aa43480-6cc5-11eb-8287-3aef2ac9febe.png)

Also, user is asked if she wants to go app's page in VTEX App Store. If Yes, a new tab is open in the user default browser.

4) App is only sold in USD 

`vtex-test install pilateslovers.billingoptionstest@81.x`

This should work exactly like 3) with option b) (i and ii)

Repeat all these tests with a international account like `vtexromania`.

#### Screenshots or example usage

Check above

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [x] Update `CHANGELOG.md`