### PR TITLE
Fix/setup types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+### Changed
+ - Don't throw error when switching to same account
+ 
 ## [2.121.3] - 2021-02-11
 ### Fixed
 -[install] Fix app's plan message for plans without metrics.

--- a/package.json
+++ b/package.json
@@ -154,7 +154,7 @@
     "@types/yarnpkg__lockfile": "^1.1.3",
     "aws-sdk": "^2.750.0",
     "eslint": "^6.8.0",
-    "eslint-config-vtex": "^12.3.1",
+    "eslint-config-vtex": "12.3.1",
     "eslint-config-vtex-react": "^6.3.1",
     "jest": "24.9.0",
     "nodemon": "^2.0.2",

--- a/src/__tests__/modules/setup/setupTypings.test.ts
+++ b/src/__tests__/modules/setup/setupTypings.test.ts
@@ -12,10 +12,63 @@ const { setPackageJsonByBuilder, packageJsonEditorMock, setTarGzEmptyResponse } 
 
 const { runYarn } = jest.requireMock('../../../modules/utils')
 const { setupTypings } = require('../../../modules/setup/setupTypings')
+const { getBuilderDependencies } = require('../../../modules/setup/setupTypings')
 
 beforeEach(() => {
   jest.clearAllMocks()
   runYarn.mockReturnValue(undefined)
+})
+
+describe('Dependencies management', () => {
+  test('getBuilderDependencies', () => {
+    expect(
+      getBuilderDependencies(
+        {
+          dependencies: {},
+          peerDependencies: {},
+        },
+        {
+          builder: {
+            version: {
+              injectedDependencies: {},
+            },
+          },
+        },
+        'version',
+        'builder'
+      )
+    ).toEqual({})
+
+     expect(
+      getBuilderDependencies(
+        {
+          dependencies: { app: '3.x' },
+          peerDependencies: { app2: '1.x' },
+        },
+        {
+          builder: {
+            version: {
+              injectedDependencies: { app3: '5.x' },
+            },
+          },
+        },
+        'version',
+        'builder'
+      )
+    ).toEqual({ app: '3.x', app2: '1.x', app3: '5.x' })
+
+     expect(
+      getBuilderDependencies(
+        {
+          dependencies: { app: '3.x' },
+          peerDependencies: { app2: '1.x' },
+        },
+        {},
+        'version',
+        'builder'
+      )
+    ).toEqual({ app: '3.x', app2: '1.x' })
+  })
 })
 
 describe('React type dependencies are correctly inserted', () => {

--- a/src/__tests__/modules/setup/setupTypings.test.ts
+++ b/src/__tests__/modules/setup/setupTypings.test.ts
@@ -39,7 +39,7 @@ describe('Dependencies management', () => {
       )
     ).toEqual({})
 
-     expect(
+    expect(
       getBuilderDependencies(
         {
           dependencies: { app: '3.x' },
@@ -57,7 +57,7 @@ describe('Dependencies management', () => {
       )
     ).toEqual({ app: '3.x', app2: '1.x', app3: '5.x' })
 
-     expect(
+    expect(
       getBuilderDependencies(
         {
           dependencies: { app: '3.x' },

--- a/src/api/clients/IOClients/apps/Builder.ts
+++ b/src/api/clients/IOClients/apps/Builder.ts
@@ -5,6 +5,7 @@ import { ErrorKinds } from '../../../error/ErrorKinds'
 import { ErrorReport } from '../../../error/ErrorReport'
 import { IOClientFactory } from '../IOClientFactory'
 import { NewStickyHostError } from '../../../error/errors'
+import { TypingsInfo, TypingsInfoResponse } from 'BuilderHub'
 
 interface StickyOptions {
   sticky?: boolean
@@ -138,8 +139,8 @@ export class Builder extends AppClient {
     return this.http.get(routes.tsConfig)
   }
 
-  public typingsInfo = async () => {
-    const res = await this.http.get(routes.typings)
+  public typingsInfo = async (): Promise<TypingsInfo> => {
+    const res = await this.http.get<TypingsInfoResponse>(routes.typings)
     return res.typingsInfo
   }
 

--- a/src/api/manifest/ManifestEditor.ts
+++ b/src/api/manifest/ManifestEditor.ts
@@ -63,6 +63,10 @@ export class ManifestEditor {
     return this.manifest.dependencies
   }
 
+  public get peerDependencies() {
+    return this.manifest.peerDependencies
+  }
+
   public get builders() {
     return this.manifest.builders
   }

--- a/src/typings/builderHub.d.ts
+++ b/src/typings/builderHub.d.ts
@@ -1,0 +1,15 @@
+declare module 'BuilderHub' {
+  interface TypingsInfo {
+    [builder in string]: {
+      [builderVersion in string]: {
+        injectedDependencies: {
+          [dependency in string]: string
+        }
+      }
+    }
+  }
+
+  interface TypingsInfoResponse {
+    typingsInfo: TypingsInfo
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3619,7 +3619,22 @@ eslint-config-vtex-react@^6.3.1:
     eslint-plugin-react "^7.18.0"
     eslint-plugin-react-hooks "^2.3.0"
 
-eslint-config-vtex@^12.3.1, eslint-config-vtex@^12.3.2:
+eslint-config-vtex@12.3.1:
+  version "12.3.1"
+  resolved "https://registry.yarnpkg.com/eslint-config-vtex/-/eslint-config-vtex-12.3.1.tgz#53904b08693de8b93020ce87d7d36348d12ef2a4"
+  integrity sha512-kfSeuf7E92PPWPOyh1MEiN/E7DmOmy4uHTkaL6gvS7naCnv7w6Xl3NXRL7eM+FJT8+p7wU98IMoHXhwLKo6bGA==
+  dependencies:
+    "@typescript-eslint/eslint-plugin" "^2.17.0"
+    "@typescript-eslint/parser" "^2.17.0"
+    confusing-browser-globals "^1.0.9"
+    eslint-config-prettier "^6.9.0"
+    eslint-plugin-cypress "^2.9.0"
+    eslint-plugin-import "^2.20.0"
+    eslint-plugin-jest "^23.7.0"
+    eslint-plugin-prettier "^3.1.2"
+    eslint-plugin-vtex "^1.0.3"
+
+eslint-config-vtex@^12.3.2:
   version "12.3.2"
   resolved "https://registry.yarnpkg.com/eslint-config-vtex/-/eslint-config-vtex-12.3.2.tgz#ecc041d779c7ae1275582c693e3c0c0009bed304"
   integrity sha512-CfjOkat59dMJnimsgzqwISsZUr+MKdzS1rtOh1X+vnioV3pvlSDDnLUYfwZ6ZND/Pd+f6X42yhWmIl6XxkmeOQ==
@@ -3726,6 +3741,11 @@ eslint-plugin-react@^7.18.0:
     semver "^6.3.0"
     string.prototype.matchall "^4.0.2"
     xregexp "^4.3.0"
+
+eslint-plugin-vtex@^1.0.3:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-vtex/-/eslint-plugin-vtex-1.2.1.tgz#4cb26d5844a50250c0d65f1d1444db85fdf1c406"
+  integrity sha512-YJ07HC0vXtl2VXn0gRIutNww1uuMWmyV/8ERsLfB6AqLRwWF8+6vran84RuPXtV5u4aqhtOejw2XAn2Omtk7IA==
 
 eslint-plugin-vtex@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
#### What is the purpose of this pull request?
Enable developers to import components from apps that are peerDependencies
https://vtex-dev.atlassian.net/browse/DT-331?atlOrigin=eyJpIjoiMzdjODllMWE2ZTg3NGRlNGEyNTY1ZmY2MDIxMDEyZTQiLCJwIjoiaiJ9

#### What problem is this solving?
Developers couldn't import types from apps that were peer dependencies

#### How should this be manually tested?
In a workspace with the version of the builder hub with [this changes](https://github.com/vtex/builder-hub/pull/10860) and using this version of the toolbelt, let's try to setup and link an app.

The app I've tested is the `store-theme` in the branch `product-shelf`, that imports the types of a peerDependency: https://github.com/vtex-apps/store-theme/tree/product-shelf

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [x] Update `CHANGELOG.md`