### PR TITLE
Add branch name in order to run action in custom branch

### DIFF
--- a/.github/workflows/create-release-and-trigger-publish.yml
+++ b/.github/workflows/create-release-and-trigger-publish.yml
@@ -25,15 +25,21 @@ jobs:
     runs-on: ubuntu-latest
     needs: [create-release]
     steps:
+    - name: Extract branch name
+      shell: bash
+      run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF##*/})"
+      id: extract_branch
     - name: Trigger NPM publish
       uses: peter-evans/repository-dispatch@v1
       with:
         token: ${{ secrets.REPO_GHA_PAT }}
         repository: vtex/toolbelt
         event-type: publish-stable-npm
+        client-payload: '{"ref": "${{ steps.extract_branch.outputs.branch }}"}'
     - name: Trigger AWS publish
       uses: peter-evans/repository-dispatch@v1
       with:
         token: ${{ secrets.REPO_GHA_PAT }}
         repository: vtex/toolbelt
         event-type: publish-stable-aws
+        client-payload: '{"ref": "${{ steps.extract_branch.outputs.branch }}"}'

--- a/.github/workflows/publish-stable-aws.yml
+++ b/.github/workflows/publish-stable-aws.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.client_payload.ref }}
       - uses: actions/setup-node@v1
         with:
           node-version: 12

--- a/.github/workflows/publish-stable-npm.yml
+++ b/.github/workflows/publish-stable-npm.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.client_payload.ref }}
       - uses: actions/setup-node@v1
         with:
           node-version: 12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- [Github Action] Enable deploy from custom branch instead of master.
 
 ## [2.121.4] - 2021-02-18
 ### Changed


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix Github Action Deploy

#### What problem is this solving?
When `github_dispatch` is triggered, it runs on `master`, so won't deploy the latest version that are in the branch, since we can't run `releasy` on master because is protected, this solution will run on the deploy branch.

#### How should this be manually tested?
New workflow

- Merge feture on master
- Create new branch com master with the name of the new version, ie: `v.2.139.0`
- run `releasy patch | minor | major` in order to bum to the version desired ( the same as the branch name)



#### Screenshots or example usage

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [ ] Update `CHANGELOG.md`