### PR TITLE
New option to specify folderName when using init command and checking for the default branch when downloading template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- It is now possible to specify a project folder name when using the `init` command.
+
+### Fixed
+
+- Searchs for the default_branch name for a GitHub Repo before trying to download it. We used to assume the default was always `master` but [GitHub is adoping `main`](https://github.com/github/renaming).
+
+## [3.1.4-beta] - 2021-02-12
+
 - `stale` issues github workflow.
 
 ## [3.1.4-beta] - 2021-02-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.2.0-beta] - 2021-03-09
+
 ### Added
 
 - It is now possible to specify a project folder name when using the `init` command.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "3.1.4-beta",
+  "version": "3.2.0-beta",
   "description": "The platform for e-commerce apps",
   "bin": "bin/run",
   "main": "lib/api/index.js",

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -4,17 +4,19 @@ import appsInit from '../modules/init'
 export default class Init extends CustomCommand {
   static description = 'Create basic files and folders for your VTEX app'
 
-  static examples = ['vtex init']
+  static examples = ['vtex init', 'vtex init project-name']
 
   static flags = {
     ...CustomCommand.globalFlags,
   }
 
-  static args = []
+  static args = [{ name: 'projectName', required: false }]
 
   async run() {
-    this.parse(Init)
+    const {
+      args: { projectName },
+    } = this.parse(Init)
 
-    await appsInit()
+    await appsInit(projectName)
   }
 }

--- a/src/lib/constants/Messages.ts
+++ b/src/lib/constants/Messages.ts
@@ -55,6 +55,17 @@ export const Messages = {
     `• If you installed using ${ColorifyConstants.COMMAND_OR_VTEX_REF(`chocolatey`)}, update running:
     ${ColorifyConstants.COMMAND_OR_VTEX_REF(`choco uninstall vtex`)}.
     ${ColorifyConstants.COMMAND_OR_VTEX_REF(`choco install vtex`)}.`,
+  INIT_HELLO_EXPLANATION: () => `Hello! I will help you generate basic files and folders for your app.`,
+  INIT_START_DEVELOPING: (folder: string) =>
+    `Run ${ColorifyConstants.COMMAND_OR_VTEX_REF(`cd ${folder}`)} and ${ColorifyConstants.COMMAND_OR_VTEX_REF(
+      'vtex link'
+    )} to start developing!`,
+  PROMPT_CONFIRM_NEW_FOLDER: (folder: string) =>
+    `You are about to create the new folder ${folder}. Do you want to continue?`,
+  DEBUG_DOWNLOAD_TEMPLATE_URL: (url: string) => `We will try to download the template app from this URL: ${url}`,
+  DEBUG_PROMPT_APP_INFO: () => `Prompting for app info`,
+  ERROR_COULD_NOT_DETERMINE_DEFAULT_BRANCH: (org: string, repo: string) =>
+    `We could not determine the default branch for repo ${org}/${repo}. Please try again.`,
 }
 
 export function updateMessageSwitch() {

--- a/src/modules/init/git.ts
+++ b/src/modules/init/git.ts
@@ -4,6 +4,7 @@ import request from 'request'
 import unzip from 'unzip-stream'
 import axios from 'axios'
 import log from '../../api/logger'
+import { Messages } from '../../lib/constants/Messages'
 
 const urlForRepo = async (repo: string, org: string) => {
   /**
@@ -16,7 +17,7 @@ const urlForRepo = async (repo: string, org: string) => {
     return { url: `https://github.com/${org}/${repo}/archive/${branchName}.zip`, branchName }
   } catch (err) {
     log.debug(err)
-    throw new Error(`We could not determine the default branch for repo ${org}/${repo}. Please try again.`)
+    throw new Error(Messages.ERROR_COULD_NOT_DETERMINE_DEFAULT_BRANCH(org, repo))
   }
 }
 
@@ -25,7 +26,7 @@ const fetchAndUnzip = async (url: string, path: string) => pipeStreams([request(
 export const clone = async (repo: string, org: string, projectFolderName?: string) => {
   const cwd = process.cwd()
   const { url, branchName } = await urlForRepo(repo, org)
-  log.debug(`We will try to download the template app from this URL: ${url}`)
+  log.debug(Messages.DEBUG_DOWNLOAD_TEMPLATE_URL(url))
   const destPath = `${cwd}/${projectFolderName ?? repo}`
   const cloned = `${destPath}/${repo}-${branchName}`
 

--- a/src/modules/init/git.ts
+++ b/src/modules/init/git.ts
@@ -2,16 +2,32 @@ import { copy, emptyDir, ensureDir, remove } from 'fs-extra'
 import pipeStreams from 'pipe-streams-to-promise'
 import request from 'request'
 import unzip from 'unzip-stream'
+import axios from 'axios'
+import log from '../../api/logger'
 
-const urlForRepo = (repo: string, org: string) => `https://github.com/${org}/${repo}/archive/master.zip`
+const urlForRepo = async (repo: string, org: string) => {
+  /**
+   * If we have internal templates in the future (in a private org repo) we have to figure out
+   * how to make this request authenticated. But, since toolbelt is open-source and so are the
+   * apps templates, we can afford not to take care of this right now.
+   */
+  try {
+    const { default_branch: branchName } = (await axios.get(`https://api.github.com/repos/${org}/${repo}`)).data
+    return { url: `https://github.com/${org}/${repo}/archive/${branchName}.zip`, branchName }
+  } catch (err) {
+    log.debug(err)
+    throw new Error(`We could not determine the default branch for repo ${org}/${repo}. Please try again.`)
+  }
+}
 
 const fetchAndUnzip = async (url: string, path: string) => pipeStreams([request(url), unzip.Extract({ path })])
 
-export const clone = async (repo: string, org: string) => {
+export const clone = async (repo: string, org: string, projectFolderName?: string) => {
   const cwd = process.cwd()
-  const url = urlForRepo(repo, org)
-  const destPath = `${cwd}/${repo}`
-  const cloned = `${destPath}/${repo}-master`
+  const { url, branchName } = await urlForRepo(repo, org)
+  log.debug(`We will try to download the template app from this URL: ${url}`)
+  const destPath = `${cwd}/${projectFolderName ?? repo}`
+  const cloned = `${destPath}/${repo}-${branchName}`
 
   await ensureDir(destPath)
   await emptyDir(destPath)

--- a/src/modules/init/index.ts
+++ b/src/modules/init/index.ts
@@ -7,6 +7,7 @@ import { promptConfirm } from '../../api/modules/prompts'
 
 import * as git from './git'
 import { SessionManager } from '../../api/session/SessionManager'
+import { Messages } from '../../lib/constants/Messages'
 
 const VTEX_APPS = 'vtex-apps'
 
@@ -106,7 +107,7 @@ const promptTemplates = async (): Promise<string> => {
 
 const promptContinue = async (repoName: string, projectFolderName?: string) => {
   const proceed = await promptConfirm(
-    `You are about to create the new folder ${process.cwd()}/${projectFolderName ?? repoName}. Do you want to continue?`
+    Messages.PROMPT_CONFIRM_NEW_FOLDER(`${process.cwd()}/${projectFolderName ?? repoName}`)
   )
   if (!proceed) {
     log.info('Bye o/')
@@ -115,18 +116,14 @@ const promptContinue = async (repoName: string, projectFolderName?: string) => {
 }
 
 export default async (projectFolderName?: string) => {
-  log.debug('Prompting for app info')
-  log.info('Hello! I will help you generate basic files and folders for your app.')
+  log.debug(Messages.DEBUG_PROMPT_APP_INFO)
+  log.info(Messages.INIT_HELLO_EXPLANATION())
   try {
     const { repository: repo, organization: org } = templates[await promptTemplates()]
     await promptContinue(repo, projectFolderName)
     log.info(`Cloning ${chalk.bold.cyan(repo)} from ${chalk.bold.cyan(org)}.`)
     await git.clone(repo, org, projectFolderName)
-    log.info(
-      `Run ${chalk.bold.green(`cd ${projectFolderName ?? repo}`)} and ${chalk.bold.green(
-        'vtex link'
-      )} to start developing!`
-    )
+    log.info(Messages.INIT_START_DEVELOPING(projectFolderName ?? repo))
   } catch (err) {
     log.error(err.message)
     log.debug(err)

--- a/src/modules/init/index.ts
+++ b/src/modules/init/index.ts
@@ -104,9 +104,9 @@ const promptTemplates = async (): Promise<string> => {
   return chosen
 }
 
-const promptContinue = async (repoName: string) => {
+const promptContinue = async (repoName: string, projectFolderName?: string) => {
   const proceed = await promptConfirm(
-    `You are about to create the new folder ${process.cwd()}/${repoName}. Do you want to continue?`
+    `You are about to create the new folder ${process.cwd()}/${projectFolderName ?? repoName}. Do you want to continue?`
   )
   if (!proceed) {
     log.info('Bye o/')
@@ -114,15 +114,19 @@ const promptContinue = async (repoName: string) => {
   }
 }
 
-export default async () => {
+export default async (projectFolderName?: string) => {
   log.debug('Prompting for app info')
   log.info('Hello! I will help you generate basic files and folders for your app.')
   try {
     const { repository: repo, organization: org } = templates[await promptTemplates()]
-    await promptContinue(repo)
+    await promptContinue(repo, projectFolderName)
     log.info(`Cloning ${chalk.bold.cyan(repo)} from ${chalk.bold.cyan(org)}.`)
-    await git.clone(repo, org)
-    log.info(`Run ${chalk.bold.green(`cd ${repo}`)} and ${chalk.bold.green('vtex link')} to start developing!`)
+    await git.clone(repo, org, projectFolderName)
+    log.info(
+      `Run ${chalk.bold.green(`cd ${projectFolderName ?? repo}`)} and ${chalk.bold.green(
+        'vtex link'
+      )} to start developing!`
+    )
   } catch (err) {
     log.error(err.message)
     log.debug(err)


### PR DESCRIPTION
New option to specify folderName when using init command and check for the default branch when downloading template

#### What is the purpose of this pull request?
Fix a bug with the `init` command and improve a bit the experience of using it by enabling the option to specify a folderName for the new project.

#### What problem is this solving?
This PR is solving a problem where I wasn't able to `init` a new project using the `graphql-example` template because we assumed the default branch for all projects was the `master` branch but I got a 404 cause we're using `main` as the default branch.

#### How should this be manually tested?
This could be tested by cloning the branch, running `yarn watch` on the project and trying the following commands on a new terminal:
```bash
$ vtex-test init --help
$ vtex-test init project1
$ vtex-test init
```

#### Screenshots or example usage
https://user-images.githubusercontent.com/5959178/108906512-bcd33280-75ff-11eb-8857-0a149cabd3ec.mov

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [X] Update `CHANGELOG.md`