### PR TITLE
feat(react-graphql-types): add self package to react dev dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add self package to react packages as devDependency
+
 ### Added
 
 - `stale` issues github workflow.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
 - Add self package to react packages as devDependency
 
 ### Added

--- a/src/modules/setup/setupTypings.ts
+++ b/src/modules/setup/setupTypings.ts
@@ -136,12 +136,15 @@ export const setupTypings = async (
       dependencies: manifest.dependencies,
       peerDependencies: manifest.peerDependencies,
     }
+
+    const shouldIncludeSelfAsDevDependency = builder => ['node', 'react'].includes(builder)
+
     const buildersWithAllDeps = filteredBuilders.map((builder: string) => {
       return {
         builder,
         deps: {
           ...getBuilderDependencies(allDependencies, typingsData, manifest.builders[builder], builder),
-          ...(builder === 'node' ? { [appName]: appMajor } : {}),
+          ...(shouldIncludeSelfAsDevDependency(builder) ? { [appName]: appMajor } : {}),
         },
       }
     })


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->

Add self (app you are setuping) package to react app dev dependencies

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->

This allows the use of graphql operation types, by importing the app types. Related to https://github.com/vtex/builder-hub/pull/1095

#### How should this be manually tested?
 - npm link package
 - vtex setup on your app
 - check react package devDependecies, it should include self package

#### Screenshots or example usage

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [x] Update `CHANGELOG.md`