### PR TITLE
DT-404 update react link message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- Terms and conditions message when linking a react app.
+- Terms and conditions message when linking or publishing a react app.
 
 ### Added
 - `composable-commerce-sq4` as codeowners.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,16 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
-## [2.124.0] - 2021-03-17
-### Added
-- Terms and conditions message when linking or publishing a react app.
-
 ### Added
 - `composable-commerce-sq4` as codeowners.
 
 ### Removed
 - `composable-commerce` as codeowners.
+
+## [2.124.0] - 2021-03-17
+### Added
+- Terms and conditions message when linking or publishing a react app.
+
 ## [2.123.0] - 2021-03-08
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Terms and conditions message when linking a react app.
 
 ### Added
 - `composable-commerce-sq4` as codeowners.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.124.0] - 2021-03-17
 ### Added
 - Terms and conditions message when linking or publishing a react app.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "2.123.0",
+  "version": "2.124.0",
   "description": "The platform for e-commerce apps",
   "bin": "bin/run",
   "main": "lib/api/index.js",

--- a/src/api/conf.ts
+++ b/src/api/conf.ts
@@ -29,6 +29,14 @@ export const getNextFeedbackDate = (): string => conf.get('_nextFeedbackDate')
 
 export const saveNextFeedbackDate = (date: string) => conf.set('_nextFeedbackDate', date)
 
+const REACT_LINK_MESSAGE_DISPLAY = '_lastLinkReactDate'
+export const getLastLinkReactDate = (): string => conf.get(REACT_LINK_MESSAGE_DISPLAY)
+export const saveLastLinkReactDate = (date: string) => conf.set(REACT_LINK_MESSAGE_DISPLAY, date)
+
+const REACT_LINKS_COUNTER = '_numberOfReactLinks'
+export const getNumberOfReactLinks = (): number => conf.get(REACT_LINKS_COUNTER)
+export const saveNumberOfReactLinks = (count: number) => conf.set(REACT_LINKS_COUNTER, count)
+
 const envFromProcessEnv = {
   prod: Environment.Production,
 }

--- a/src/api/modules/utils.ts
+++ b/src/api/modules/utils.ts
@@ -1,3 +1,4 @@
+import jwt from 'jsonwebtoken'
 import axios from 'axios'
 import chalk from 'chalk'
 import { execSync } from 'child-process-es6-promise'
@@ -391,8 +392,16 @@ export const matchedDepsDiffTable = (title1: string, title2: string, deps1: stri
 }
 
 const REACT_BUILDER = 'react'
+const VTEX_ACCOUNT = 'vtex'
 
 export const continueAfterReactTermsAndConditions = async (manifest: ManifestEditor): Promise<boolean> => {
+  const session = SessionManager.getSingleton()
+  const { token } = session
+  const decodedToken = jwt.decode(token)
+  if (decodedToken?.[`account`] === VTEX_ACCOUNT) {
+    return true
+  }
+
   if (!Object.keys(manifest.builders).includes(REACT_BUILDER)) {
     return true
   }

--- a/src/api/modules/utils.ts
+++ b/src/api/modules/utils.ts
@@ -392,13 +392,16 @@ export const matchedDepsDiffTable = (title1: string, title2: string, deps1: stri
 }
 
 const REACT_BUILDER = 'react'
-const VTEX_ACCOUNT = 'vtex'
+const EMAIL_KEY = 'sub'
+const I_VTEX_ACCOUNT = '@vtex.com'
+const BR_VTEX_ACCOUNT = '@vtex.com.br'
 
 export const continueAfterReactTermsAndConditions = async (manifest: ManifestEditor): Promise<boolean> => {
   const session = SessionManager.getSingleton()
   const { token } = session
   const decodedToken = jwt.decode(token)
-  if (decodedToken?.[`account`] === VTEX_ACCOUNT) {
+  const userEmail = decodedToken?.[EMAIL_KEY] as string
+  if (userEmail && (userEmail.endsWith(I_VTEX_ACCOUNT) || userEmail.endsWith(BR_VTEX_ACCOUNT))) {
     return true
   }
 

--- a/src/api/modules/utils.ts
+++ b/src/api/modules/utils.ts
@@ -392,7 +392,7 @@ export const matchedDepsDiffTable = (title1: string, title2: string, deps1: stri
 
 const REACT_BUILDER = 'react'
 
-export const continueAfterLinkTermsAndConditions = async (manifest: ManifestEditor): Promise<boolean> => {
+export const continueAfterReactTermsAndConditions = async (manifest: ManifestEditor): Promise<boolean> => {
   if (!Object.keys(manifest.builders).includes(REACT_BUILDER)) {
     return true
   }

--- a/src/modules/apps/link.ts
+++ b/src/modules/apps/link.ts
@@ -8,7 +8,7 @@ import {
 import {
   checkBuilderHubMessage,
   showBuilderHubMessage,
-  continueAfterLinkTermsAndConditions,
+  continueAfterReactTermsAndConditions,
   validateAppAction,
 } from '../../api/modules/utils'
 import { createFlowIssueError } from '../../api/error/utils'
@@ -271,7 +271,7 @@ export async function appLink(options: LinkOptions) {
   const manifest = await ManifestEditor.getManifestEditor()
   await manifest.writeSchema()
 
-  const mustContinue = await continueAfterLinkTermsAndConditions(manifest)
+  const mustContinue = await continueAfterReactTermsAndConditions(manifest)
   if (!mustContinue) {
     return
   }

--- a/src/modules/apps/link.ts
+++ b/src/modules/apps/link.ts
@@ -5,7 +5,12 @@ import {
   ProjectSizeLimitError,
   ProjectUploader,
 } from '../../api/modules/apps/ProjectUploader'
-import { checkBuilderHubMessage, showBuilderHubMessage, validateAppAction } from '../../api/modules/utils'
+import {
+  checkBuilderHubMessage,
+  showBuilderHubMessage,
+  continueAfterLinkTermsAndConditions,
+  validateAppAction,
+} from '../../api/modules/utils'
 import { createFlowIssueError } from '../../api/error/utils'
 import { concat, intersection, isEmpty, map, pipe, prop } from 'ramda'
 import { createInterface } from 'readline'
@@ -265,6 +270,11 @@ export async function appLink(options: LinkOptions) {
   const root = getAppRoot()
   const manifest = await ManifestEditor.getManifestEditor()
   await manifest.writeSchema()
+
+  const mustContinue = await continueAfterLinkTermsAndConditions(manifest)
+  if (!mustContinue) {
+    return
+  }
 
   const builderHubMessage = await checkBuilderHubMessage('link')
   if (!isEmpty(builderHubMessage)) {

--- a/src/modules/apps/publish.ts
+++ b/src/modules/apps/publish.ts
@@ -10,7 +10,11 @@ import { listLocalFiles } from '../../api/modules/apps/file'
 import { ProjectUploader } from '../../api/modules/apps/ProjectUploader'
 import { listenBuild } from '../../api/modules/build'
 import { promptConfirm } from '../../api/modules/prompts'
-import { checkBuilderHubMessage, showBuilderHubMessage } from '../../api/modules/utils'
+import {
+  checkBuilderHubMessage,
+  continueAfterReactTermsAndConditions,
+  showBuilderHubMessage,
+} from '../../api/modules/utils'
 import { SessionManager } from '../../api/session/SessionManager'
 import * as conf from '../../api/conf'
 import { returnToPreviousAccount, switchAccount } from '../../api/modules/auth/switch'
@@ -121,6 +125,12 @@ export default async (path: string, options) => {
 
   const { account } = SessionManager.getSingleton()
   const manifest = await ManifestEditor.getManifestEditor()
+
+  const mustContinue = await continueAfterReactTermsAndConditions(manifest)
+  if (!mustContinue) {
+    process.exit(1)
+  }
+
   const versionMsg = chalk.bold.yellow(manifest.version)
   const appNameMsg = chalk.bold.yellow(`${manifest.vendor}.${manifest.name}`)
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
[Jira card](https://vtex-dev.atlassian.net/browse/DT-404?atlOrigin=eyJpIjoiNTUwOTY0NWM0ODM4NDI4NGEwYmQ5YmE5Y2YxYWEzZDciLCJwIjoiaiJ9)

We're adding a message with some terms of development while using the react builder

#### What problem is this solving?
Lack of information about the responsibilities involved in developing a react app

#### How should this be manually tested?
You shall try to link a react app using this version of the toolbelt.

I've done that using the `react-app-template` app, from `vtex init`.

The message that's displayed
<img width="1680" alt="Screen Shot 2021-03-16 at 3 40 25 PM" src="https://user-images.githubusercontent.com/17756399/111364221-ba4c8180-866f-11eb-9bfa-dfab25693fd0.png">

The default selection is no:
<img width="1680" alt="Screen Shot 2021-03-16 at 3 40 35 PM" src="https://user-images.githubusercontent.com/17756399/111364248-c3d5e980-866f-11eb-919f-7e1cce49399e.png">

If you accept, the link will continue as is:
<img width="1680" alt="Screen Shot 2021-03-16 at 3 40 54 PM" src="https://user-images.githubusercontent.com/17756399/111364305-d05a4200-866f-11eb-8fab-acc8a7cbf4d8.png">

#### Behavior
- The message will be displayed only with the linking action
- The app must use the `react` builder at any version
- The message will not be displayed more than two times
- It will wait for 24 hours or until the next day to start to display the message again

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [x] Update `CHANGELOG.md`