### PR TITLE
Fix/import from vtex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Terms and conditions message when linking or publishing a react app.
 - `composable-commerce-sq4` as codeowners
 
-### Fixed
-
-- [vtex lib] Fix `import x from 'vtex'` error by forcing symlink
 ### Changed
 
 - Changed logging protocol from `http` to `https`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- [vtex lib] Fix `import x from 'vtex'` error by forcing symlink
+
 ## [3.3.2-beta] - 2021-03-23
 
 ## [3.3.1-beta] - 2021-03-22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.3.3-beta] - 2021-03-23
+
 ### Fixed
 
 - [vtex lib] Fix `import x from 'vtex'` error by forcing symlink

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,16 +18,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Terms and conditions message when linking or publishing a react app.
-
-### Added
-
 - `composable-commerce-sq4` as codeowners
 
+### Fixed
+
+- [vtex lib] Fix `import x from 'vtex'` error by forcing symlink
 ### Changed
 
 - Changed logging protocol from `http` to `https`.
-
-### Changed
 
 - Add self package to react packages as devDependency
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "3.3.2-beta",
+  "version": "3.3.3-beta",
   "description": "The platform for e-commerce apps",
   "bin": "bin/run",
   "main": "lib/api/index.js",

--- a/src/oclif/hooks/init.ts
+++ b/src/oclif/hooks/init.ts
@@ -24,7 +24,7 @@ import { ErrorReport } from '../../api/error/ErrorReport'
 import { FeatureFlag } from '../../api/modules/featureFlag'
 import { getHelpSubject, CommandI, renderCommands } from './utils'
 import * as fse from 'fs-extra'
-import path from 'path';
+import path from 'path'
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { initTimeStartTime } = require('../../../bin/run')
@@ -60,7 +60,7 @@ const checkLogin = async (command: string) => {
   }
 }
 
-const checkAndFixSymlink = async (options) => {
+const checkAndFixSymlink = async options => {
   try {
     require('vtex')
   } catch (err) {
@@ -68,7 +68,8 @@ const checkAndFixSymlink = async (options) => {
     try {
       await fse.symlink(options.config.root, path.join(options.config.root, 'node_modules', 'vtex'))
     } catch (err2) {
-      log.error('Failed to create symbolic link:', err2.message)
+      log.error('Failed to create symbolic link. Please run this command on Administrator mode')
+      process.exit(1)
     }
     log.info('Problem fixed. Please, run the command again')
     process.exit(1)

--- a/src/oclif/hooks/init.ts
+++ b/src/oclif/hooks/init.ts
@@ -65,7 +65,7 @@ const createSymlink = async options => {
     await fse.symlink(options.config.root, path.join(options.config.root, 'node_modules', 'vtex'))
   } catch (symLinkErr) {
     if (symLinkErr.code === "EEXIST") {
-      log.error(`Symbolic link already exist, maybe there is another error that I can't solve`)
+      log.error(`Symbolic link already exist, there is another error that couldn't be solved`)
     } else {
       log.error('Failed to create symbolic link. Please run this command on Administrator mode')
     }

--- a/src/oclif/hooks/init.ts
+++ b/src/oclif/hooks/init.ts
@@ -64,7 +64,7 @@ const createSymlink = async options => {
   try {
     await fse.symlink(options.config.root, path.join(options.config.root, 'node_modules', 'vtex'))
   } catch (symLinkErr) {
-    if (symLinkErr.code === "EEXIST") {
+    if (symLinkErr.code === 'EEXIST') {
       log.error(`Symbolic link already exist, there is another error that couldn't be solved`)
     } else {
       log.error('Failed to create symbolic link. Please run this command on Administrator mode')
@@ -77,7 +77,7 @@ const checkAndFixSymlink = async options => {
   try {
     require('vtex')
   } catch (requireErr) {
-    if (requireErr.code === "MODULE_NOT_FOUND") {
+    if (requireErr.code === 'MODULE_NOT_FOUND') {
       log.error('Import VTEX error, trying to autofix...')
       await createSymlink(options)
       log.info('Problem solved. Please, run the command again')


### PR DESCRIPTION
#### What is the purpose of this pull request?
New users run `toolbelt` commands that `require('vtex')` lib, and the symlink was not set.

#### What problem is this solving?
Enforce symlink to be created before running tests

#### How should this be manually tested?

Go to `symlinkPlugin.sh` script and comment last line that is reponsable for creating the `sl`

run `yarn watch`

run `vtex-test whoami` twice

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/20549906/112187223-ac9f7a80-8be0-11eb-884a-cba857c5bd80.png)




#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [x] Update `CHANGELOG.md`