### PR TITLE
Treat InstallStatus as a constant instead of a type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- [install] Treat `InstallStatus` as a variable not as a type
 ### Changed
 - [autoupdate] Update to version 0.0.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.5.2-beta] - 2021-04-09
+
 ### Fixed
 - [install] Treat `InstallStatus` as a variable not as a type
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "3.5.1-beta",
+  "version": "3.5.2-beta",
   "description": "The platform for e-commerce apps",
   "bin": "bin/run",
   "main": "lib/api/index.js",

--- a/src/lib/constants/InstallStatus.ts
+++ b/src/lib/constants/InstallStatus.ts
@@ -1,0 +1,14 @@
+export enum InstallStatus {
+  ACCEPTED_TERMS = 'installed_by_accepted_terms',
+  ALREADY_PURCHASED = 'already_purchased',
+  CHECK_TERMS = 'check_terms',
+  FREE = 'installed_free',
+  OWN_APP = 'own_app',
+  OWN_REGISTRY = 'installed_from_own_registry',
+  PREVIOUS_PURCHASE = 'installed_by_previous_purchase',
+  PUBLIC_REGISTRY = 'public_app',
+  USER_HAS_NO_BUY_APP_LICENSE = 'no_buy_app_license',
+  USER_HAS_NO_INSTALL_APP_LICENSE = 'no_install_app_license',
+  AREA_UNAVAILABLE = 'area_unavailable',
+  CONTRACT_NOT_FOUND = 'contract_not_found',
+}

--- a/src/modules/apps/install.ts
+++ b/src/modules/apps/install.ts
@@ -7,6 +7,7 @@ import { ManifestEditor, ManifestValidator } from '../../api/manifest'
 import { promptConfirm } from '../../api/modules/prompts'
 import { isFreeApp, optionsFormatter, validateAppAction } from '../../api/modules/utils'
 import { BillingMessages } from '../../lib/constants/BillingMessages'
+import { InstallStatus } from '../../lib/constants/InstallStatus'
 
 const { installApp } = Billing.createClient()
 const { installApp: legacyInstallApp } = createAppsClient()

--- a/src/typings/global.d.ts
+++ b/src/typings/global.d.ts
@@ -1,5 +1,6 @@
 import { AppManifest } from '@vtex/api'
 import { Readable } from 'stream'
+import { InstallStatus } from '../lib/constants/InstallStatus'
 
 declare global {
   interface Change {
@@ -75,21 +76,6 @@ declare global {
   interface InstallResponse {
     code: InstallStatus
     billingOptions?: string
-  }
-
-  enum InstallStatus {
-    ACCEPTED_TERMS = 'installed_by_accepted_terms',
-    ALREADY_PURCHASED = 'already_purchased',
-    CHECK_TERMS = 'check_terms',
-    FREE = 'installed_free',
-    OWN_APP = 'own_app',
-    OWN_REGISTRY = 'installed_from_own_registry',
-    PREVIOUS_PURCHASE = 'installed_by_previous_purchase',
-    PUBLIC_REGISTRY = 'public_app',
-    USER_HAS_NO_BUY_APP_LICENSE = 'no_buy_app_license',
-    USER_HAS_NO_INSTALL_APP_LICENSE = 'no_install_app_license',
-    AREA_UNAVAILABLE = 'area_unavailable',
-    CONTRACT_NOT_FOUND = 'contract_not_found',
   }
 
   interface PriceMetric {


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
Fix install command

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
install command was breaking because InstallStatus wasn't being found.

#### How should this be manually tested?
Try to install a few apps.
#### Screenshots or example usage

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [x] Update `CHANGELOG.md`