### PR TITLE
Fix edition set command error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+ - Fix `set edition` command to handle prompt cancellations
+ - Add check on `set edition` command to install tenant-provisioner app in sponsor account
 
 ## [2.127.0] - 2021-04-19
 

--- a/src/api/modules/sponsor/setEdition.ts
+++ b/src/api/modules/sponsor/setEdition.ts
@@ -54,7 +54,7 @@ export default async function setEdition(edition: string, workspace?: string, au
     switched = await promptSwitchToAccount('vtex', true)
   } else {
     if (targetWorkspace === 'master') {
-      switched = await promptWorkspaceMaster(targetWorkspace)
+      switched = await promptWorkspaceMaster(targetAccount)
     }
     switched = await promptSwitchToAccount(sponsorAccount, false)
   }

--- a/src/api/modules/sponsor/setEdition.ts
+++ b/src/api/modules/sponsor/setEdition.ts
@@ -83,6 +83,7 @@ const trySetEdition = async (sponsorAccount: string, targetAccount: string, targ
   const workspaceNotice = targetWorkspace === 'master' ? '' : `in workspace ${chalk.blue(targetWorkspace)} `
   log.info(`Now setting edition ${chalk.blue(edition)} ${workspaceNotice}of account ${chalk.blue(targetAccount)}...`)
 
+  // Retry a couple of times since it might take some time for the installation to propagate until the route is available.
   for (let retry = 1; !success && retry <= maxSetEditionRetries; retry++) {
     await sleepSec(1.5 * retry)
 

--- a/src/api/modules/sponsor/setEdition.ts
+++ b/src/api/modules/sponsor/setEdition.ts
@@ -5,7 +5,7 @@ import { createFlowIssueError } from '../../error/utils'
 import { Sponsor } from '../../clients/IOClients/apps/Sponsor'
 import { SessionManager } from '../../session/SessionManager'
 import log from '../../logger'
-import { promptWorkspaceMaster } from '../utils'
+import { promptWorkspaceMaster, sleepSec } from '../utils'
 import { returnToPreviousAccount, switchAccount } from '../auth/switch'
 import { promptConfirm } from '../prompts'
 
@@ -65,8 +65,6 @@ const trySetEditionOnce = async (client: Sponsor, targetAccount: string, targetW
 }
 
 const maxSetEditionRetries = 3
-
-const sleepSec = (sec: number) => new Promise(resolve => setTimeout(resolve, sec * 1000))
 
 const trySetEdition = async (
   sponsorAccount: string,

--- a/src/api/modules/sponsor/setEdition.ts
+++ b/src/api/modules/sponsor/setEdition.ts
@@ -26,11 +26,12 @@ const confirmAndSwitchEnvironment = async (sponsorAccount: string, targetAccount
     if (targetWorkspace !== 'master') {
       throw createFlowIssueError('Can only set initial edition in master workspace')
     }
-    return await promptSwitchToAccount('vtex', true)
+    return promptSwitchToAccount('vtex', true)
   }
 
   const workspaceIsOk = targetWorkspace !== 'master' || (await promptWorkspaceMaster(targetAccount))
-  return workspaceIsOk && (await promptSwitchToAccount(sponsorAccount, false))
+  if (!workspaceIsOk) return false
+  return promptSwitchToAccount(sponsorAccount, false)
 }
 
 const tenantProvisionerApp = 'vtex.tenant-provisioner'
@@ -87,6 +88,7 @@ const trySetEdition = async (
   log.info(`Now setting edition ${chalk.blue(edition)} ${workspaceNotice}of account ${chalk.blue(targetAccount)}...`)
 
   // Retry a couple of times since it might take some time for the installation to propagate until the route is available.
+  /* eslint-disable no-await-in-loop */
   for (let retry = 1; !success && retry <= maxSetEditionRetries; retry++) {
     await sleepSec(1.5 * retry)
 
@@ -95,6 +97,7 @@ const trySetEdition = async (
         ? await trySetEditionOnce(client, targetAccount, targetWorkspace, edition)
         : await client.setEdition(targetAccount, targetWorkspace, edition).then(() => true)
   }
+  /* eslint-enable no-await-in-loop */
   return success
 }
 

--- a/src/api/modules/sponsor/setEdition.ts
+++ b/src/api/modules/sponsor/setEdition.ts
@@ -45,12 +45,19 @@ const promptInstallTenantProvisioner = async (account: string) => {
   return true
 }
 
+const isProvisionerNotInstalledError = (err: any) => {
+  const res = err.response
+  return res?.status === 404 &&
+      res.data?.source === 'Vtex.Kube.Router' &&
+      res.data?.code === 'NotFound'
+}
+
 const trySetEditionOnce = async (client: Sponsor, targetAccount: string, targetWorkspace: string, edition: string) => {
   try {
     await client.setEdition(targetAccount, targetWorkspace, edition)
     return true
   } catch (err) {
-    if (err.response?.status !== 404) {
+    if (!isProvisionerNotInstalledError(err)) {
       throw err
     }
     return false

--- a/src/api/modules/utils.ts
+++ b/src/api/modules/utils.ts
@@ -33,6 +33,8 @@ const workspaceProductionAllowedOperatios = ['install', 'uninstall']
 const builderHubMessagesLinkTimeout = 2000 // 2 seconds
 const builderHubMessagesPublishTimeout = 10000 // 10 seconds
 
+export const sleepSec = (sec: number) => new Promise(resolve => setTimeout(resolve, sec * 1000))
+
 export const workspaceMasterMessage = `This action is ${chalk.red('not allowed')} in workspace ${chalk.green(
   'master'
 )}, please use another workspace.

--- a/src/modules/apps/install.ts
+++ b/src/modules/apps/install.ts
@@ -15,8 +15,9 @@ const PROMPT_PLAN_CHOICES_NAME = 'billingOptionsPlanChoices'
 const BRAZILIAN_REAL_CURRENCY_CODE = 'BRL'
 const ERROR_MESSAGE_APP_CONTRACT_NOT_FOUND = 'No contract found for app'
 
-const { installApp } = Billing.createClient()
-const { installApp: legacyInstallApp } = createAppsClient()
+const installApp = (appName: string, termsOfUseAccepted: boolean, force: boolean, selectedPlanId?: string) =>
+    Billing.createClient().installApp(appName, termsOfUseAccepted, force, selectedPlanId)
+const legacyInstallApp = (descriptor: string) => createAppsClient().installApp(descriptor)
 
 const isError = (errorCode: number) => compose(equals(errorCode), path(['response', 'status']))
 const isForbiddenError = isError(403)

--- a/src/modules/apps/install.ts
+++ b/src/modules/apps/install.ts
@@ -16,7 +16,7 @@ const BRAZILIAN_REAL_CURRENCY_CODE = 'BRL'
 const ERROR_MESSAGE_APP_CONTRACT_NOT_FOUND = 'No contract found for app'
 
 const installApp = (appName: string, termsOfUseAccepted: boolean, force: boolean, selectedPlanId?: string) =>
-    Billing.createClient().installApp(appName, termsOfUseAccepted, force, selectedPlanId)
+  Billing.createClient().installApp(appName, termsOfUseAccepted, force, selectedPlanId)
 const legacyInstallApp = (descriptor: string) => createAppsClient().installApp(descriptor)
 
 const isError = (errorCode: number) => compose(equals(errorCode), path(['response', 'status']))


### PR DESCRIPTION
#### What is the purpose of this pull request?

This fixes 2 main issues with the `vtex edition set command`:
 - We were not handling responses to flow prompts, so we completely ignored when the user said
they didn't want to do some action like confirm the change in the `master` workspace or switching
to the sponsor account.
 - This is the more complex one which is almost a feature: to actually handle when the setEdition
API request actually returns a 404 error because of the `vtex.tenant-provisioner` app not being 
installed. Now we handle the corresponding not found errors from router and prompt the user to
already install the necessary app and retry the request after installing.

The 2 tricky parts were:
 - The route map of the platform has only eventual consistency, so we don't have guarantee anymore
that after installing an app, a call to some of its APIs will immediately work. So we implemented a retry
logic with an increasing delay to give some change to invalidate the route map cache and actually call
the app. 
 - The `appsInstall` command was actually using a static client so it didn't try to install apps in the
current context, but actually in the context where toolbelt started executing. Fixed that by creating 
some indirect functions that actually create a new client and then proxy the arguments to a function 
call in that client.

#### What problem is this solving?
Broken flow of `vtex edition set` command, not respecting user rejections. Now no means no.

Also repeated errors with the `vtex.tenant-provisioner` app not being installed which cause 
unnecessary round-trips with the development team (🙋‍♂️ ) to fix the issue. Now toolbelt will already
detect the problem and fix it automatically.

#### How should this be manually tested?
 - `vtex edition set` and say no to some of the prompts, should stop the flow.
 - Uninstall the `vtex.tenant-provisioner` app from the sponsor and make sure toolbelt prompts to
install it and manages to set the edition afterwards.
 - Try to set an edition that doesn't exist and make sure toolbelt doesn't think it's the app that is not
installed.

#### Screenshots or example usage
![Screen Shot 2021-04-09 at 17 53 11](https://user-images.githubusercontent.com/1613383/114239430-755cf780-995c-11eb-9df0-965cfea68fb7.png)

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [x] Update `CHANGELOG.md`