### PR TITLE
Fix / isFreeApp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- [install] Classify app as free if it declares no plan
+
 ## [2.127.1] - 2021-04-20
  - Fix `set edition` command to handle prompt cancellations
  - Add check on `set edition` command to install tenant-provisioner app in sponsor account

--- a/src/api/modules/utils.ts
+++ b/src/api/modules/utils.ts
@@ -135,8 +135,8 @@ export const appIdFromRegistry = (app: string, majorLocator: string) => {
 }
 
 const FREE_BILLING_OPTIONS_TYPE = 'free'
-export const isFreeApp = ({ type, free }: { type?: string; free?: boolean }) =>
-  type === FREE_BILLING_OPTIONS_TYPE || free
+export const isFreeApp = ({ type, free, plans }: { type?: string; free?: boolean; plans?: Plan[] }) =>
+  type === FREE_BILLING_OPTIONS_TYPE || free || !plans || plans.length === 0
 
 type BillingInfo = {
   subscription?: number


### PR DESCRIPTION
#### What is the purpose of this pull request?
The purpose of this pull request is to classify an app as free during the installation process if the app declares no billing plan.

#### What problem is this solving?
After some changes related to billing ([#1019](https://github.com/vtex/toolbelt/pull/1019)), users started to have problems when trying to install an app of type `sponsored` that didn't declare any billing plan. [Here](https://vtex.slack.com/archives/C2WSEU9QQ/p1618942741133300) we have an explanation of the behavior they have observed.

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [x] Update `CHANGELOG.md`