### PR TITLE
[3.x] Fix / isFreeApp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- [install] Classify app as free if it declares no plan
+
 ## [3.6.0-beta] - 2021-04-13
 
 ### Added

--- a/src/api/modules/utils.ts
+++ b/src/api/modules/utils.ts
@@ -134,8 +134,8 @@ export const appIdFromRegistry = (app: string, majorLocator: string) => {
 }
 
 const FREE_BILLING_OPTIONS_TYPE = 'free'
-export const isFreeApp = ({ type, free }: { type?: string; free?: boolean }) =>
-  type === FREE_BILLING_OPTIONS_TYPE || free
+export const isFreeApp = ({ type, free, plans }: { type?: string; free?: boolean; plans?: Plan[] }) =>
+  type === FREE_BILLING_OPTIONS_TYPE || free || !plans || plans.length === 0
 
 type BillingInfo = {
   subscription?: number


### PR DESCRIPTION
#### What is the purpose of this pull request?
The purpose of this pull request is to classify an app as free during the installation process if the app declares no billing plan.

#### What problem is this solving?
This will keep consistency with the change introduced in #1081. 
Dealing with the case of a `sponsored` app that does not declare any billing plan also prevents similar problems to those that happened in the `2.x` version from happening here.

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [x] Update `CHANGELOG.md`