### PR TITLE
Fix / installation / Handle sponsored apps as if they were free

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- [install] Handle sponsored apps as if they were free
+
 ## [2.127.1] - 2021-04-20
  - Fix `set edition` command to handle prompt cancellations
  - Add check on `set edition` command to install tenant-provisioner app in sponsor account

--- a/src/api/modules/utils.ts
+++ b/src/api/modules/utils.ts
@@ -138,6 +138,10 @@ const FREE_BILLING_OPTIONS_TYPE = 'free'
 export const isFreeApp = ({ type, free }: { type?: string; free?: boolean }) =>
   type === FREE_BILLING_OPTIONS_TYPE || free
 
+const SPONSORED_BILLING_OPTIONS_TYPE = 'sponsored'
+export const isSponsoredApp = ({ type }: { type?: string }) => 
+  type === SPONSORED_BILLING_OPTIONS_TYPE
+
 type BillingInfo = {
   subscription?: number
   currency?: string

--- a/src/api/modules/utils.ts
+++ b/src/api/modules/utils.ts
@@ -139,8 +139,7 @@ export const isFreeApp = ({ type, free }: { type?: string; free?: boolean }) =>
   type === FREE_BILLING_OPTIONS_TYPE || free
 
 const SPONSORED_BILLING_OPTIONS_TYPE = 'sponsored'
-export const isSponsoredApp = ({ type }: { type?: string }) => 
-  type === SPONSORED_BILLING_OPTIONS_TYPE
+export const isSponsoredApp = ({ type }: { type?: string }) => type === SPONSORED_BILLING_OPTIONS_TYPE
 
 type BillingInfo = {
   subscription?: number

--- a/src/modules/apps/install.ts
+++ b/src/modules/apps/install.ts
@@ -7,7 +7,7 @@ import { createRegistryClient } from '../../api/clients/IOClients/infra/Registry
 import log from '../../api/logger'
 import { ManifestEditor, ManifestValidator } from '../../api/manifest'
 import { promptConfirm } from '../../api/modules/prompts'
-import { isFreeApp, optionsFormatter, validateAppAction } from '../../api/modules/utils'
+import { isFreeApp, isSponsoredApp, optionsFormatter, validateAppAction } from '../../api/modules/utils'
 import { BillingMessages } from '../../lib/constants/BillingMessages'
 import { switchOpen } from '../featureFlag/featureFlagDecider'
 
@@ -101,7 +101,7 @@ const checkBillingOptions = async (app: string, billingOptions: BillingOptions, 
   const { termsURL } = billingOptions
   const license = await licenseURL(app, termsURL)
   let planId: string | undefined
-  if (isFreeApp(billingOptions)) {
+  if (isFreeApp(billingOptions) || isSponsoredApp(billingOptions)) {
     log.info(BillingMessages.acceptToInstallFree(app))
   } else {
     log.info(BillingMessages.acceptToInstallPaid(app))


### PR DESCRIPTION
#### What is the purpose of this pull request?
The purpose of this pull request is to handle apps of type `sponsored` as free apps, during the installation process.

#### What problem is this solving?
After some changes related to billing ([#1019](https://github.com/vtex/toolbelt/pull/1019)), users started to have problems when trying to install an app of type `sponsored` that didn't declare any billing plan. [Here](https://vtex.slack.com/archives/C2WSEU9QQ/p1618942741133300) we have an explanation of the behavior they have observed.

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [x] Update `CHANGELOG.md`