### PR TITLE
Update @vtex/cli-plugin-plugins to 1.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.7.0-beta] - 2021-05-03
+
 ### Changed
  - Update @vtex/cli-plugin-plugins
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+ - Update @vtex/cli-plugin-plugins
+
 ## [3.6.1-beta] - 2021-04-22
  - Fix `set edition` command to handle prompt cancellations
  - Add check on `set edition` command to install tenant-provisioner app in sponsor account

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "3.6.1-beta",
+  "version": "3.7.0-beta",
   "description": "The platform for e-commerce apps",
   "bin": "bin/run",
   "main": "lib/api/index.js",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@vtex/cli-plugin-deploy": "^0.3.1",
     "@vtex/cli-plugin-deps": "^0.1.1",
     "@vtex/cli-plugin-edition": "^0.1.1",
-    "@vtex/cli-plugin-plugins": "1.13.0",
+    "@vtex/cli-plugin-plugins": "^1.13.0",
     "@vtex/cli-plugin-whoami": "^0.2.2",
     "@vtex/cli-plugin-workspace": "^1.0.1",
     "@vtex/node-error-report": "^0.0.2",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@vtex/cli-plugin-deploy": "^0.3.1",
     "@vtex/cli-plugin-deps": "^0.1.1",
     "@vtex/cli-plugin-edition": "^0.1.1",
-    "@vtex/cli-plugin-plugins": "^1.11.1",
+    "@vtex/cli-plugin-plugins": "1.13.0",
     "@vtex/cli-plugin-whoami": "^0.2.2",
     "@vtex/cli-plugin-workspace": "^1.0.1",
     "@vtex/node-error-report": "^0.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1263,10 +1263,10 @@
     ramda "^0.27.1"
     tslib "^1"
 
-"@vtex/cli-plugin-plugins@^1.11.1":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@vtex/cli-plugin-plugins/-/cli-plugin-plugins-1.11.1.tgz#b07939743b2a15e74e5caa57857cff3133abf959"
-  integrity sha512-1Qim+Vb2eQagXr4O803O0sbmu/hODbgz8oA7KviKLuPguEJWk2QJs3M2uhlWKTpr8kEo9jKlGpmoVgUdgjwHCg==
+"@vtex/cli-plugin-plugins@1.13.0":
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/@vtex/cli-plugin-plugins/-/cli-plugin-plugins-1.13.0.tgz#d8d8f21c6e2d50d8383a552f06c7f18e7c50fac7"
+  integrity sha512-m9bzD6SOVwk6IAEOZx6kU4fx1RA1FWXF2vBNvJCxcVxQOGS77woAzqItM/3z/luur6coho0nlYnu2kC9SvSgyg==
   dependencies:
     "@oclif/color" "^0.x"
     "@oclif/command" "^1.5.12"


### PR DESCRIPTION
#### What is the purpose of this pull request?
To update @vtex/cli-plugin-plugins to 1.13.0.

#### What problem is this solving?
Changes in [#8](https://github.com/vtex/cli-plugin-plugins/pull/8) don't work in toolbelt without this.

#### How should this be manually tested?
The feature of @vtex/cli-plugin-plugins@1.13.0 can be tested with the following command: `vtex plugins source`.

#### Screenshots or example usage

<img width="611" alt="Captura de Tela 2021-05-03 às 15 01 58" src="https://user-images.githubusercontent.com/25959568/116920518-b88b4d00-ac20-11eb-8e93-025b19995311.png">

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [x] Update `CHANGELOG.md`