### PR TITLE
Fixed typo in update message

### DIFF
--- a/src/update.ts
+++ b/src/update.ts
@@ -22,7 +22,7 @@ export function updateNotify() {
       // @ts-ignore
       isYarnGlobal: true,
       message: [
-        `There is a new Toolbelt version avaible: ${chalk.dim(oldVersion)} → ${chalk.green(latestVersion)}`,
+        `A new version is available for the VTEX Toolbelt: ${chalk.dim(oldVersion)} → ${chalk.green(latestVersion)}`,
         `To update, you must use the same method you used to install. As the following example(s):`,
         ...updateMessageSwitch(),
         `Changelog: ${ColorifyConstants.URL_INTERACTIVE(changelog)}`,


### PR DESCRIPTION
#### What is the purpose of this pull request?

Improve the update message for the VTEX IO CLI

#### What problem is this solving?

The message had a typo: `avaible` instead of `available`. I fixed it and reorganized the sentence in a way that seemed more natural for native English speakers.

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [ ] Update `CHANGELOG.md`