### PR TITLE
Use templates as remote configs instead of hardcoded strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+ - Use templates as remote configs instead of hardcoded strings.
+
 ## [3.7.1-beta] - 2021-05-07
 
 ### Fixed

--- a/src/modules/init/index.ts
+++ b/src/modules/init/index.ts
@@ -1,6 +1,7 @@
 import chalk from 'chalk'
 import enquirer from 'enquirer'
 import { keys, prop, reject, test } from 'ramda'
+import { FeatureFlag } from '../../api/modules'
 
 import log from '../../api/logger'
 import { promptConfirm } from '../../api/modules/prompts'
@@ -9,80 +10,17 @@ import * as git from './git'
 import { SessionManager } from '../../api/session/SessionManager'
 import { Messages } from '../../lib/constants/Messages'
 
-const VTEX_APPS = 'vtex-apps'
+// const VTEX_APPS = 'vtex-apps'
 
-const VTEXInternalTemplates = [
-  // Only show these templates for VTEX e-mail users.
-  'graphql-example',
-  'payment-provider-example',
-  'admin-example',
-  'delivery-theme',
-  'service-example',
-  'render-guide',
-  'masterdata-graphql-guide',
-  'support app',
-  'react-guide',
-]
+// Only show these templates for VTEX e-mail users.
+const VTEXInternalTemplates = FeatureFlag.getSingleton().getFeatureFlagInfo<string[]>('VTEXInternalTemplates')
 
 interface Template {
   repository: string
   organization: string
 }
 
-const templates: Record<string, Template> = {
-  'graphql-example': {
-    repository: 'graphql-example',
-    organization: VTEX_APPS,
-  },
-  'payment-provider-example': {
-    repository: 'payment-provider-example',
-    organization: VTEX_APPS,
-  },
-  'admin-example': {
-    repository: 'admin-example',
-    organization: VTEX_APPS,
-  },
-  store: {
-    repository: 'minimum-boilerplate-theme',
-    organization: VTEX_APPS,
-  },
-  'delivery-theme': {
-    repository: 'delivery-theme',
-    organization: VTEX_APPS,
-  },
-  'service-example': {
-    repository: 'service-example',
-    organization: VTEX_APPS,
-  },
-  'render-guide': {
-    repository: 'render-guide',
-    organization: VTEX_APPS,
-  },
-  'masterdata-graphql-guide': {
-    repository: 'masterdata-graphql-guide',
-    organization: VTEX_APPS,
-  },
-  'edition app': {
-    repository: 'edition-hello',
-    organization: VTEX_APPS,
-  },
-  'support app': {
-    repository: 'hello-support',
-    organization: VTEX_APPS,
-  },
-  'react-guide': {
-    repository: 'react-app-template',
-    organization: VTEX_APPS,
-  },
-  'checkout-ui-settings': {
-    repository: 'checkout-ui-settings',
-    organization: VTEX_APPS,
-  },
-  'service-worker-example': {
-    repository: 'service-worker-example',
-    organization: VTEX_APPS,
-  },
-}
+const templates = FeatureFlag.getSingleton().getFeatureFlagInfo<Record<string, Template>>('templates')
 
 const getTemplates = () =>
   // Return all templates if user's e-mail is `...@vtex...`.

--- a/src/modules/init/index.ts
+++ b/src/modules/init/index.ts
@@ -10,8 +10,6 @@ import * as git from './git'
 import { SessionManager } from '../../api/session/SessionManager'
 import { Messages } from '../../lib/constants/Messages'
 
-// const VTEX_APPS = 'vtex-apps'
-
 // Only show these templates for VTEX e-mail users.
 const VTEXInternalTemplates = FeatureFlag.getSingleton().getFeatureFlagInfo<string[]>('VTEXInternalTemplates')
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
This pull request solves issue [#1073](https://github.com/vtex/toolbelt/issues/1073) by modifying the template code to use remote configuration instead of encoded strings.

#### What problem is this solving?
By removing hardcodes, we can centralize system configs.

#### How should this be manually tested?
The expected result is the command to maintain its functioning. Running the command `vtex-test init`, we can see a list of options. 

#### Screenshots or example usage
This is normal operation
<img width="689" alt="Captura de Tela 2021-05-10 às 11 46 24" src="https://user-images.githubusercontent.com/25959568/117687077-6ba9f800-b185-11eb-8533-0a32230c7655.png">


#### Types of changes
- [X] Refactor (non-breaking change that only makes the code better)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [X] Update `CHANGELOG.md`