### PR TITLE
Remove app purchases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Removed
+- App purchases and all code related to it
 
 ## [2.127.4] - 202105-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Removed
-- App purchases and all code related to it
+### Changed
+- Redirect user to App Store instead of conducting purchases through toolbelt
 
 ## [2.127.4] - 202105-20
 

--- a/package.json
+++ b/package.json
@@ -83,7 +83,6 @@
     "child-process-es6-promise": "~1.2.1",
     "chokidar": "~3.3.0",
     "cli-table": "~0.3.1",
-    "cli-table2": "~0.2.0",
     "clipboardy": "~2.1.0",
     "co-body": "^6.0.0",
     "configstore": "^5.0.1",

--- a/src/api/modules/utils.ts
+++ b/src/api/modules/utils.ts
@@ -2,7 +2,6 @@ import jwt from 'jsonwebtoken'
 import axios from 'axios'
 import chalk from 'chalk'
 import { execSync } from 'child-process-es6-promise'
-import Table from 'cli-table2'
 import { ArrayChange, diffArrays } from 'diff'
 import enquirer from 'enquirer'
 import { existsSync } from 'fs-extra'
@@ -10,7 +9,6 @@ import moment from 'moment'
 import { resolve as resolvePath } from 'path'
 import R, { compose, concat, contains, curry, head, last, prop, propSatisfies, reduce, split, tail, __ } from 'ramda'
 import semverDiff from 'semver-diff'
-import { BillingMessages } from '../../lib/constants/BillingMessages'
 import { createAppsClient } from '../clients/IOClients/infra/Apps'
 import { createRegistryClient } from '../clients/IOClients/infra/Registry'
 import { createWorkspacesClient } from '../clients/IOClients/infra/Workspaces'
@@ -140,99 +138,6 @@ export const isFreeApp = ({ type, free }: { type?: string; free?: boolean }) =>
 
 const SPONSORED_BILLING_OPTIONS_TYPE = 'sponsored'
 export const isSponsoredApp = ({ type }: { type?: string }) => type === SPONSORED_BILLING_OPTIONS_TYPE
-
-type BillingInfo = {
-  subscription?: number
-  currency?: string
-  termsURL?: string
-  metrics?: Array<{
-    name: string
-    ranges: Range[]
-  }>
-}
-
-const chalkBillingTable = (table: any, { subscription, metrics, currency }: BillingInfo) => {
-  if (subscription) {
-    table.push([
-      {
-        content: BillingMessages.SUBSCRIPTION_MONTHLY,
-      },
-      {
-        content: BillingMessages.price(subscription, currency),
-      },
-    ])
-  }
-  metrics?.forEach(({ name, ranges }) => {
-    table.push([
-      {
-        content: name,
-      },
-      {
-        content: ranges.reduce<string>((text, { exclusiveFrom, multiplier }) => {
-          if (text.length > 0) {
-            text += '\n'
-          }
-          text += BillingMessages.pricePerUnit(multiplier, currency)
-          if (exclusiveFrom > 0) {
-            text += BillingMessages.forUnitsOrMore(exclusiveFrom + 1)
-          }
-          return text
-        }, ''),
-        hAlign: 'left',
-      },
-    ])
-  })
-}
-
-const billingInfoFromPolicy = ({ currency, billing: { items } }: Policy): BillingInfo => {
-  const subscription = items.reduce<number>((sum, { fixed }) => (fixed ? sum + fixed : sum), 0)
-
-  const metrics = items.reduce((metricsInfo, { calculatedByMetricUnit }) => {
-    if (calculatedByMetricUnit) {
-      const { metricName, ranges } = calculatedByMetricUnit
-      metricsInfo.push({ name: metricName, ranges })
-    }
-    return metricsInfo
-  }, [])
-  return { currency, subscription, metrics }
-}
-
-const billingInfoFromPlan = ({ currency, price: { subscription, metrics } }: Plan): BillingInfo => ({
-  currency,
-  subscription,
-  metrics: metrics?.map(({ id, ranges }) => ({ name: id, ranges })),
-})
-
-const buildBillingInfo = (plans?: Plan[], policies?: Policy[]): BillingInfo => {
-  if (plans && plans.length > 0) {
-    return billingInfoFromPlan(plans[0]) // Currenly only a single plan is supported in App Store
-  }
-  if (policies && policies.length > 0) {
-    return billingInfoFromPolicy(policies[0])
-  }
-}
-
-export function optionsFormatter(billingOptions: BillingOptions, app: string, licenseURL?: string) {
-  const { plans, policies } = billingOptions
-  /** TODO: Eliminate the need for this stray, single `cli-table2` dependency */
-  const table = new Table({
-    head: [{ content: BillingMessages.billingOptionsForApp(app), colSpan: 2 }],
-  })
-  table.push([{ content: BillingMessages.CHARGED_COLUMN }, { content: BillingMessages.PRICING_COLUMN }])
-  const billingInfo = buildBillingInfo(plans, policies)
-  if (isFreeApp(billingOptions) || !billingInfo) {
-    table.push([{ content: BillingMessages.NA }, { content: BillingMessages.FREE_APP }])
-  } else {
-    chalkBillingTable(table, billingInfo)
-  }
-  if (licenseURL && licenseURL.length > 0) {
-    table.push([
-      { content: BillingMessages.APP_STORE_TERMS_OF_SERVICE },
-      { content: BillingMessages.licenseLink(licenseURL) },
-    ])
-  }
-  return table.toString()
-}
 
 export async function checkBuilderHubMessage(cliRoute: string): Promise<any> {
   const http = axios.create({

--- a/src/api/modules/utils.ts
+++ b/src/api/modules/utils.ts
@@ -132,13 +132,6 @@ export const appIdFromRegistry = (app: string, majorLocator: string) => {
     .catch(handleError(app))
 }
 
-const FREE_BILLING_OPTIONS_TYPE = 'free'
-export const isFreeApp = ({ type, free }: { type?: string; free?: boolean }) =>
-  type === FREE_BILLING_OPTIONS_TYPE || free
-
-const SPONSORED_BILLING_OPTIONS_TYPE = 'sponsored'
-export const isSponsoredApp = ({ type }: { type?: string }) => type === SPONSORED_BILLING_OPTIONS_TYPE
-
 export async function checkBuilderHubMessage(cliRoute: string): Promise<any> {
   const http = axios.create({
     baseURL: `https://vtex.myvtex.com`,

--- a/src/api/modules/utils.ts
+++ b/src/api/modules/utils.ts
@@ -1,13 +1,9 @@
 import jwt from 'jsonwebtoken'
 import axios from 'axios'
 import chalk from 'chalk'
-import { execSync } from 'child-process-es6-promise'
-import { ArrayChange, diffArrays } from 'diff'
 import enquirer from 'enquirer'
-import { existsSync } from 'fs-extra'
 import moment from 'moment'
-import { resolve as resolvePath } from 'path'
-import R, { compose, concat, contains, curry, head, last, prop, propSatisfies, reduce, split, tail, __ } from 'ramda'
+import { compose, concat, contains, curry, head, last, prop, propSatisfies, reduce, split, tail, __ } from 'ramda'
 import semverDiff from 'semver-diff'
 import { createAppsClient } from '../clients/IOClients/infra/Apps'
 import { createRegistryClient } from '../clients/IOClients/infra/Registry'
@@ -16,9 +12,7 @@ import { getLastLinkReactDate, getNumberOfReactLinks, saveLastLinkReactDate, sav
 import { createFlowIssueError } from '../error/utils'
 import log from '../logger'
 import { ManifestEditor } from '../manifest'
-import { getAppRoot } from '../manifest/ManifestUtil'
 import { SessionManager } from '../session/SessionManager'
-import { createTable } from '../table'
 import { promptConfirm } from './prompts'
 
 const workspaceExampleName = process.env.USER || 'example'
@@ -176,123 +170,6 @@ export const resolveAppId = (appName: string, appVersion: string): Promise<strin
 }
 
 export const isLinked = propSatisfies<string, Manifest>(contains('+build'), 'version')
-
-export const yarnPath = `"${require.resolve('yarn/bin/yarn')}"`
-
-export const formatNano = (nanoseconds: number): string =>
-  `${(nanoseconds / 1e9).toFixed(0)}s ${((nanoseconds / 1e6) % 1e3).toFixed(0)}ms`
-
-export const runYarn = (relativePath: string, force: boolean) => {
-  log.info(`Running yarn in ${chalk.green(relativePath)}`)
-  const root = getAppRoot()
-  const command = force
-    ? `${yarnPath} --force --non-interactive --ignore-engines`
-    : `${yarnPath} --non-interactive --ignore-engines`
-  execSync(command, { stdio: 'inherit', cwd: resolvePath(root, relativePath) })
-  log.info('Finished running yarn')
-}
-
-export const runYarnIfPathExists = (relativePath: string) => {
-  const root = getAppRoot()
-  const pathName = resolvePath(root, relativePath)
-  if (existsSync(pathName)) {
-    try {
-      runYarn(relativePath, false)
-    } catch (e) {
-      log.error(`Failed to run yarn in ${chalk.green(relativePath)}`)
-      throw e
-    }
-  }
-}
-
-const formatAppId = (appId: string) => {
-  const [appVendor, appName] = R.split('.', appId)
-  if (!appName) {
-    // Then the app is an 'infra' app.
-    const [infraAppVendor, infraAppName] = R.split(':', appId)
-    if (!infraAppName) {
-      return appId
-    }
-    return `${chalk.blue(infraAppVendor)}:${infraAppName}`
-  }
-  return `${chalk.blue(appVendor)}.${appName}`
-}
-
-const cleanVersion = (appId: string) => {
-  return R.compose<string, string[], string, string>(
-    (version: string) => {
-      const [pureVersion, build] = R.split('+build', version)
-      return build ? `${pureVersion}(linked)` : pureVersion
-    },
-    R.last,
-    R.split('@')
-  )(appId)
-}
-
-export const matchedDepsDiffTable = (title1: string, title2: string, deps1: string[], deps2: string[]) => {
-  const depsDiff = diffArrays(deps1, deps2)
-  // Get deduplicated names (no version) of the changed deps.
-  const depNames = [
-    ...new Set(
-      R.compose<string[] | Array<ArrayChange<string>>, any[], string[], string[], string[]>(
-        R.map(k => R.head(R.split('@', k))),
-        R.flatten,
-        R.pluck('value'),
-        R.filter((k: any) => !!k.removed || !!k.added)
-      )(depsDiff)
-    ),
-  ].sort((strA, strB) => strA.localeCompare(strB))
-  const produceStartValues = () => R.map(_ => [])(depNames) as any
-  // Each of the following objects will start as a { `depName`: [] }, ... }-like.
-  const addedDeps = R.zipObj(depNames, produceStartValues())
-  const removedDeps = R.zipObj(depNames, produceStartValues())
-
-  // Custom function to set the objects values.
-  const setObjectValues = (obj, formatter, filterFunction) => {
-    R.compose<void | Array<ArrayChange<string>>, any[], any[], any[], any[]>(
-      // eslint-disable-next-line array-callback-return
-      R.map(k => {
-        const index = R.head(R.split('@', k))
-        obj[index].push(formatter(k))
-      }),
-      R.flatten,
-      R.pluck('value'),
-      R.filter(filterFunction)
-    )(depsDiff)
-    R.mapObjIndexed((_, index) => {
-      obj[index] = obj[index].join(',')
-    })(obj)
-  }
-
-  // Setting the objects values.
-  setObjectValues(
-    removedDeps,
-    k => chalk.red(`${cleanVersion(k)}`),
-    (k: any) => !!k.removed
-  )
-  setObjectValues(
-    addedDeps,
-    k => chalk.green(`${cleanVersion(k)}`),
-    (k: any) => !!k.added
-  )
-
-  const table = createTable() // Set table headers.
-  table.push(['', chalk.bold.yellow(title1), chalk.bold.yellow(title2)])
-
-  const formattedDepNames = R.map(formatAppId, depNames)
-  // Push array of changed dependencies pairs to the table.
-  Array.prototype.push.apply(
-    table,
-    R.map((k: any[]) => R.flatten(k))(
-      R.zip(
-        // zipping 3 arrays.
-        R.zip(formattedDepNames, R.values(removedDeps)),
-        R.values(addedDeps)
-      )
-    )
-  )
-  return table
-}
 
 const REACT_BUILDER = 'react'
 const EMAIL_KEY = 'sub'

--- a/src/api/modules/utils.ts
+++ b/src/api/modules/utils.ts
@@ -126,6 +126,11 @@ export const appIdFromRegistry = (app: string, majorLocator: string) => {
     .catch(handleError(app))
 }
 
+export const getVendorFromApp = (app: string) => {
+  const [vendor] = app.split('.')
+  return vendor
+}
+
 export async function checkBuilderHubMessage(cliRoute: string): Promise<any> {
   const http = axios.create({
     baseURL: `https://vtex.myvtex.com`,

--- a/src/lib/constants/BillingMessages.ts
+++ b/src/lib/constants/BillingMessages.ts
@@ -25,7 +25,7 @@ export const BillingMessages = {
       app
     )} app . To install it, you need to accept the app's terms.`,
   billingTable: (table: string) => `\n${table}`,
-  appCurrencyPage: (currency: string, link: string) =>
-    `To buy this app in '${currency}' currency, please go to the VTEX App Store at the following link: ${link}`,
   shouldOpenPage: () => `Would you like to open the VTEX App Store page?`,
+  getAppForInstall: (link: string) =>
+    `To install this app, you first need to get it from VTEX App Store at the following link: ${link}`,
 }

--- a/src/lib/constants/BillingMessages.ts
+++ b/src/lib/constants/BillingMessages.ts
@@ -2,29 +2,7 @@ import chalk from 'chalk'
 import { COLORS } from '../../api/constants/Colors'
 
 export const BillingMessages = {
-  APP_STORE_TERMS_OF_SERVICE: chalk.hex(COLORS.WHITE).bold('App Terms of Service'),
-  FREE_APP: chalk.hex(COLORS.WHITE)('Free app'),
-  NA: chalk.hex(COLORS.WHITE).italic('N/A'),
-  SUBSCRIPTION_MONTHLY: 'Subscription',
-  CHARGED_COLUMN: chalk.hex(COLORS.WHITE).bold('What is being charged'),
-  PRICING_COLUMN: chalk.hex(COLORS.WHITE).bold('Pricing (monthly)'),
-  INSTALL_STARTED: 'Starting to install app with accepted Terms',
-  INSTALL_SUCCESS: 'Installed after accepted terms',
-  CURRENCY_OPTIONS: 'Which currency do you prefer to buy this app?',
   app: (app: string) => chalk.hex(COLORS.PINK)(app),
-  billingOptionsForApp: (app: string) =>
-    chalk.bold(`${chalk.hex(COLORS.WHITE)('Billing Options for app ')}${BillingMessages.app(app)}`),
-  licenseLink: (url: string) => chalk.underline(url),
-  price: (amount: number, currency: string) => `${amount} (${currency})`,
-  pricePerUnit: (amount: number, currency = 'BRL') => `${BillingMessages.price(amount, currency)} per unit`,
-  forUnitsOrMore: (units: number) => ` - for ${units} or more units`,
-  acceptToInstallFree: (app: string) =>
-    `${BillingMessages.app(app)} is a free app! Accept the app's terms to install it.`,
-  acceptToInstallPaid: (app: string) =>
-    `Here are some details about the pricing of ${BillingMessages.app(
-      app
-    )} app . To install it, you need to accept the app's terms.`,
-  billingTable: (table: string) => `\n${table}`,
   shouldOpenPage: () => `Would you like to open the VTEX App Store page?`,
   getAppForInstall: (link: string) =>
     `To install this app, you first need to get it from VTEX App Store at the following link: ${link}`,

--- a/src/lib/constants/BillingMessages.ts
+++ b/src/lib/constants/BillingMessages.ts
@@ -6,6 +6,6 @@ export const BillingMessages = {
   shouldOpenPage: () => `Would you like to open the VTEX App Store page?`,
   getAppForInstall: (link: string) =>
     `To install this app, you first need to get it from VTEX App Store at the following link: ${link}`,
-  accountNotSponsoredByVendorError: (app: string) =>
-    `Cannot install app '${app}' because it has billingOptions with type 'sponsored' but this account is not sponsored by the app's vendor.`,
+  accountNotSponsoredByVendorError: (app: string, account: string, vendor: string) =>
+    `Cannot install '${app}' in account '${account}' because '${app}' is of type sponsored and '${account}' is not sponsored by '${vendor}'`,
 }

--- a/src/lib/constants/BillingMessages.ts
+++ b/src/lib/constants/BillingMessages.ts
@@ -6,4 +6,6 @@ export const BillingMessages = {
   shouldOpenPage: () => `Would you like to open the VTEX App Store page?`,
   getAppForInstall: (link: string) =>
     `To install this app, you first need to get it from VTEX App Store at the following link: ${link}`,
+  accountNotSponsoredByVendorError: (app: string) =>
+    `Cannot install app '${app}' because it has billingOptions with type 'sponsored' but this account is not sponsored by the app's vendor.`,
 }

--- a/src/modules/apps/install.ts
+++ b/src/modules/apps/install.ts
@@ -80,14 +80,6 @@ const prepareInstall = async (appsList: string[], force: boolean): Promise<void>
         log.error(e.response.data.message)
       } else {
         switch (e.message) {
-          case 'no_buy_app_license':
-            log.error(
-              `You do not have permission to purchase apps. Please check your VTEX IO 'Buy Apps' resource access in Account Managament`
-            )
-            break
-          case 'area_unavailable':
-            log.error('Unfortunately, app purchases are not yet available in your region')
-            break
           case 'app_store_contract_not_found':
             // eslint-disable-next-line no-await-in-loop
             await handleAppStoreContractNotFoundError(app)

--- a/src/modules/apps/install.ts
+++ b/src/modules/apps/install.ts
@@ -134,6 +134,7 @@ const prepareInstall = async (appsList: string[], force: boolean): Promise<void>
       } else {
         // eslint-disable-next-line no-await-in-loop
         const { code, billingOptions } = await installApp(app, false, force)
+        console.log(JSON.stringify({ code }, null, 2))
         switch (code) {
           case 'installed_from_own_registry':
             log.debug('Installed from own registry')
@@ -157,6 +158,16 @@ const prepareInstall = async (appsList: string[], force: boolean): Promise<void>
       }
       log.info(`Installed app ${chalk.green(app)} successfully`)
     } catch (e) {
+      console.log(
+        JSON.stringify(
+          {
+            'e.message': e?.message,
+            'e.response.data': e?.response?.data,
+          },
+          null,
+          2
+        )
+      )
       if (isNotFoundError(e)) {
         log.warn(
           `Billing app not found in current workspace. Please install it with ${chalk.green(
@@ -178,6 +189,11 @@ const prepareInstall = async (appsList: string[], force: boolean): Promise<void>
             break
           case 'area_unavailable':
             log.error('Unfortunately, app purchases are not yet available in your region')
+            break
+          case 'app_store_contract_not_found':
+            log.error(
+              `No active contract found for the app '${app}'. Get this app from VTEX App Store website to have an active contract.`
+            )
             break
           default:
             logGraphQLErrorMessage(e)

--- a/src/modules/apps/install.ts
+++ b/src/modules/apps/install.ts
@@ -1,19 +1,13 @@
 import chalk from 'chalk'
-import enquirer from 'enquirer'
 import { compose, equals, head, path } from 'ramda'
 import { Billing } from '../../api/clients/IOClients/apps/Billing'
 import { createAppsClient } from '../../api/clients/IOClients/infra/Apps'
-import { createRegistryClient } from '../../api/clients/IOClients/infra/Registry'
 import log from '../../api/logger'
 import { ManifestEditor, ManifestValidator } from '../../api/manifest'
 import { promptConfirm } from '../../api/modules/prompts'
-import { isFreeApp, isSponsoredApp, optionsFormatter, validateAppAction } from '../../api/modules/utils'
+import { validateAppAction } from '../../api/modules/utils'
 import { BillingMessages } from '../../lib/constants/BillingMessages'
 import { switchOpen } from '../featureFlag/featureFlagDecider'
-
-const PROMPT_PLAN_CHOICES_NAME = 'billingOptionsPlanChoices'
-const BRAZILIAN_REAL_CURRENCY_CODE = 'BRL'
-const ERROR_MESSAGE_APP_CONTRACT_NOT_FOUND = 'No contract found for app'
 
 const installApp = (appName: string, termsOfUseAccepted: boolean, force: boolean, selectedPlanId?: string) =>
   Billing.createClient().installApp(appName, termsOfUseAccepted, force, selectedPlanId)
@@ -29,98 +23,20 @@ const logGraphQLErrorMessage = e => {
   log.error(e.message)
 }
 
-const promptPolicies = async () => {
-  return promptConfirm('Do you accept all the Terms?')
-}
-
-const hasLicenseFile = async (name: string, version: string) => {
-  const client = createRegistryClient()
-  try {
-    await client.getAppFile(name, version, '/public/metadata/licenses/en-US.md')
-    return true
-  } catch (err) {
-    if (err.response?.status === 404) {
-      return false
-    }
-    throw err
-  }
-}
-
-const licenseURL = async (app: string, termsURL?: string): Promise<string | undefined> => {
-  const [name, argVersion] = app.split('@')
-  const version = argVersion ?? 'x'
-  return (await hasLicenseFile(name, version)) ? `https://apps.vtex.com/_v/terms/${name}@${version}` : termsURL
-}
-
-const buildBillingOptionsPlanChoices = ({ plans }: BillingOptions) =>
-  plans?.reduce<Record<string, Plan>>((choices, plan) => {
-    choices[plan.currency] = plan
-    return choices
-  }, {}) ?? {}
-
 const appStoreProductPage = (app: string) => {
   const [appName] = app.split('@')
   const [vendor, name] = appName.split('.')
-  return `https://apps.vtex.com/apps?salesChannel=2&textLink=${vendor}-${name}`
+  return `https://apps.vtex.com/${vendor}-${name}/p`
 }
 
-const promptCurrencyChoices = async (billingOptions: BillingOptions) => {
-  const planChoices = buildBillingOptionsPlanChoices(billingOptions)
-  const currencyChoices = Object.keys(planChoices)
-  let [selectedCurrency] = currencyChoices
-  if (currencyChoices.length > 1) {
-    const answer = await enquirer.prompt({
-      name: PROMPT_PLAN_CHOICES_NAME,
-      message: BillingMessages.CURRENCY_OPTIONS,
-      type: 'select',
-      choices: currencyChoices,
-    })
-    selectedCurrency = answer[PROMPT_PLAN_CHOICES_NAME]
+async function handleAppStoreContractNotFoundError(app: string) {
+  const appWebsite = appStoreProductPage(app)
+  log.info(BillingMessages.getAppForInstall(appWebsite))
+
+  const shouldOpenProductPage = await promptConfirm(BillingMessages.shouldOpenPage(), true)
+  if (shouldOpenProductPage) {
+    switchOpen(appWebsite, { wait: false })
   }
-  return planChoices[selectedCurrency]
-}
-
-const handleInternationalAppInstall = async (app: string, { id, currency }: Plan, force: boolean) => {
-  try {
-    await installApp(app, true, force, id)
-  } catch (e) {
-    if (!e.message?.startsWith(ERROR_MESSAGE_APP_CONTRACT_NOT_FOUND)) {
-      throw e
-    }
-    const appWebsite = appStoreProductPage(app)
-    log.info(BillingMessages.appCurrencyPage(currency, appWebsite))
-
-    const shouldOpenProductPage = await promptConfirm(BillingMessages.shouldOpenPage(), true)
-    if (shouldOpenProductPage) {
-      switchOpen(appWebsite, { wait: false })
-    }
-  }
-}
-
-const checkBillingOptions = async (app: string, billingOptions: BillingOptions, force: boolean) => {
-  const { termsURL } = billingOptions
-  const license = await licenseURL(app, termsURL)
-  let planId: string | undefined
-  if (isFreeApp(billingOptions) || isSponsoredApp(billingOptions)) {
-    log.info(BillingMessages.acceptToInstallFree(app))
-  } else {
-    log.info(BillingMessages.acceptToInstallPaid(app))
-    const selectedPlan = await promptCurrencyChoices(billingOptions)
-    planId = selectedPlan.id
-    if (selectedPlan.currency !== BRAZILIAN_REAL_CURRENCY_CODE) {
-      return handleInternationalAppInstall(app, selectedPlan, force)
-    }
-  }
-
-  log.info(BillingMessages.billingTable(optionsFormatter(billingOptions, app, license)))
-  const confirm = await promptPolicies()
-  if (!confirm) {
-    return
-  }
-
-  log.info(BillingMessages.INSTALL_STARTED)
-  await installApp(app, true, force, planId)
-  log.debug(BillingMessages.INSTALL_SUCCESS)
 }
 
 const prepareInstall = async (appsList: string[], force: boolean): Promise<void> => {
@@ -133,8 +49,7 @@ const prepareInstall = async (appsList: string[], force: boolean): Promise<void>
         await legacyInstallApp(app)
       } else {
         // eslint-disable-next-line no-await-in-loop
-        const { code, billingOptions } = await installApp(app, false, force)
-        console.log(JSON.stringify({ code }, null, 2))
+        const { code } = await installApp(app, true, force)
         switch (code) {
           case 'installed_from_own_registry':
             log.debug('Installed from own registry')
@@ -147,27 +62,10 @@ const prepareInstall = async (appsList: string[], force: boolean): Promise<void>
             break
           case 'installed_free':
             log.debug('Free app')
-            break
-          case 'check_terms':
-            if (!billingOptions) {
-              throw new Error('Failed to get billing options')
-            }
-            // eslint-disable-next-line no-await-in-loop
-            await checkBillingOptions(app, JSON.parse(billingOptions), force)
         }
       }
       log.info(`Installed app ${chalk.green(app)} successfully`)
     } catch (e) {
-      console.log(
-        JSON.stringify(
-          {
-            'e.message': e?.message,
-            'e.response.data': e?.response?.data,
-          },
-          null,
-          2
-        )
-      )
       if (isNotFoundError(e)) {
         log.warn(
           `Billing app not found in current workspace. Please install it with ${chalk.green(
@@ -191,9 +89,8 @@ const prepareInstall = async (appsList: string[], force: boolean): Promise<void>
             log.error('Unfortunately, app purchases are not yet available in your region')
             break
           case 'app_store_contract_not_found':
-            log.error(
-              `No active contract found for the app '${app}'. Get this app from VTEX App Store website to have an active contract.`
-            )
+            // eslint-disable-next-line no-await-in-loop
+            await handleAppStoreContractNotFoundError(app)
             break
           default:
             logGraphQLErrorMessage(e)

--- a/src/modules/apps/install.ts
+++ b/src/modules/apps/install.ts
@@ -39,6 +39,10 @@ async function handleAppStoreContractNotFoundError(app: string) {
   }
 }
 
+function handleAccountNotSponsoredByVendorError(app: string) {
+  log.error(BillingMessages.accountNotSponsoredByVendorError(app))
+}
+
 const prepareInstall = async (appsList: string[], force: boolean): Promise<void> => {
   for (const app of appsList) {
     ManifestValidator.validateApp(app)
@@ -83,6 +87,9 @@ const prepareInstall = async (appsList: string[], force: boolean): Promise<void>
           case 'app_store_contract_not_found':
             // eslint-disable-next-line no-await-in-loop
             await handleAppStoreContractNotFoundError(app)
+            break
+          case 'account_not_sponsored_by_vendor':
+            handleAccountNotSponsoredByVendorError(app)
             break
           default:
             logGraphQLErrorMessage(e)

--- a/src/modules/apps/install.ts
+++ b/src/modules/apps/install.ts
@@ -1,3 +1,4 @@
+import { getVendorFromApp, validateAppAction } from '../../api/modules/utils'
 import chalk from 'chalk'
 import { compose, equals, head, path } from 'ramda'
 import { Billing } from '../../api/clients/IOClients/apps/Billing'
@@ -5,9 +6,10 @@ import { createAppsClient } from '../../api/clients/IOClients/infra/Apps'
 import log from '../../api/logger'
 import { ManifestEditor, ManifestValidator } from '../../api/manifest'
 import { promptConfirm } from '../../api/modules/prompts'
-import { validateAppAction } from '../../api/modules/utils'
+
 import { BillingMessages } from '../../lib/constants/BillingMessages'
 import { switchOpen } from '../featureFlag/featureFlagDecider'
+import { SessionManager } from '../../api/session/SessionManager'
 
 const installApp = (appName: string, termsOfUseAccepted: boolean, force: boolean, selectedPlanId?: string) =>
   Billing.createClient().installApp(appName, termsOfUseAccepted, force, selectedPlanId)
@@ -40,7 +42,9 @@ async function handleAppStoreContractNotFoundError(app: string) {
 }
 
 function handleAccountNotSponsoredByVendorError(app: string) {
-  log.error(BillingMessages.accountNotSponsoredByVendorError(app))
+  const { account } = SessionManager.getSingleton()
+  const vendor = getVendorFromApp(app)
+  log.error(BillingMessages.accountNotSponsoredByVendorError(app, account, vendor))
 }
 
 const prepareInstall = async (appsList: string[], force: boolean): Promise<void> => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1959,11 +1959,6 @@ ansi-red@^0.1.1:
   dependencies:
     ansi-wrap "0.1.0"
 
-ansi-regex@^2.0.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
-  integrity sha1-w7M6te42DYbg5ijwRorn7yfWVN8=
-
 ansi-regex@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
@@ -3061,16 +3056,6 @@ cli-spinners@^2.2.0:
   resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-2.2.0.tgz#e8b988d9206c692302d8ee834e7a85c0144d8f77"
   integrity sha512-tgU3fKwzYjiLEQgPMD9Jt+JjHVL9kW93FiIMX/l7rivvOD4/LL0Mf7gda3+4U2KJBloybwgj5KEoQgGRioMiKQ==
 
-cli-table2@~0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/cli-table2/-/cli-table2-0.2.0.tgz#2d1ef7f218a0e786e214540562d4bd177fe32d97"
-  integrity sha1-LR738hig54biFFQFYtS9F3/jLZc=
-  dependencies:
-    lodash "^3.10.1"
-    string-width "^1.0.1"
-  optionalDependencies:
-    colors "^1.1.2"
-
 cli-table@^0.3.1, cli-table@~0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/cli-table/-/cli-table-0.3.1.tgz#f53b05266a8b1a0b934b3d0821e6e2dc5914ae23"
@@ -3222,11 +3207,6 @@ co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
   integrity sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=
-
-code-point-at@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
-  integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
 
 collection-visit@^1.0.0:
   version "1.0.0"
@@ -5649,13 +5629,6 @@ is-extglob@^2.1.0, is-extglob@^2.1.1:
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
   integrity sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=
 
-is-fullwidth-code-point@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz#ef9e31386f031a7f0d643af82fde50c457ef00cb"
-  integrity sha1-754xOG8DGn8NZDr4L95QxFfvAMs=
-  dependencies:
-    number-is-nan "^1.0.0"
-
 is-fullwidth-code-point@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
@@ -6837,11 +6810,6 @@ lodash.union@^4.6.0:
   resolved "https://registry.yarnpkg.com/lodash.union/-/lodash.union-4.6.0.tgz#48bb5088409f16f1821666641c44dd1aaae3cd88"
   integrity sha1-SLtQiECfFvGCFmZkHETdGqrjzYg=
 
-lodash@^3.10.1:
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
-  integrity sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=
-
 lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.3:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
@@ -7390,11 +7358,6 @@ npm-run-path@^2.0.0:
   integrity sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=
   dependencies:
     path-key "^2.0.0"
-
-number-is-nan@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
-  integrity sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=
 
 numbro@2.1.0:
   version "2.1.0"
@@ -9090,15 +9053,6 @@ string-length@^2.0.0:
     astral-regex "^1.0.0"
     strip-ansi "^4.0.0"
 
-string-width@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-1.0.2.tgz#118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3"
-  integrity sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=
-  dependencies:
-    code-point-at "^1.0.0"
-    is-fullwidth-code-point "^1.0.0"
-    strip-ansi "^3.0.0"
-
 string-width@^2.0.0, string-width@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
@@ -9200,13 +9154,6 @@ string_decoder@~1.1.1:
   integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
   dependencies:
     safe-buffer "~5.1.0"
-
-strip-ansi@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
-  integrity sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=
-  dependencies:
-    ansi-regex "^2.0.0"
 
 strip-ansi@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->

With the goal ensuring a single source for buying [VTEX App Store](https://apps.vtex.com/) apps, this PR removes the option to buy apps that are available in App Store, including free apps.

Why?

App Store is a VTEX store which mean users can buy apps using the VTEX's checkout experience. As a marketplace, App Store can give more transparency to both buyers and sellers when the process of buying apps is done using VTEX e-commerce features. Feel free to get in touch with App Store team (or Squad 1) to get more details about this!

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->

https://github.com/vtex/billing-app/pull/111 removes app purchases (or App Store contract creation), which means that apps that are in App Store can only be purchased (including free apps) from VTEX App Store [website](https://apps.vtex.com/).

As a consequence, toolbelt no longer needs to handle buying apps, accepting terms of uses, showing the pricing model for the app and all of the things related to buying an app, all of these things can be handled in the App Store website.

#### How should this be manually tested?

I tried to test all possible scenarios but if you think something is missing in the tests below, specially cases that had/can cause more problems, please let me know!

- `install` app without billingOptions (should remain as it is):
    - Non proprietary (should respond with `forbidden_private_app`):
    ```
    vtex login sandboxintegracao -w marlon
    vtex-test install extensions.account-dialog@0.11.0
    ```
    - Proprietary (should remain as it is: app installed successfully):
    ```
    vtex login extensions -w marlon
    vtex-test install extensions.account-dialog@0.11.0
    ```

- `install` app with `billingOptions.type === sponsored` with account that is sponsored (should be installed successfully): 
```
vtex login samsungbrtest -w marlon
vtex-test install samsungbr.samsung-store@0.x
```

- `install` app with `billingOptions.type === sponsored` with account that is NOT sponsored (should show error informing that the app has type sponsored but the account is not sponsored by): 
```
vtex login sandboxintegracao -w marlon
vtex-test install samsungbr.samsung-store@0.x
```
![image](https://user-images.githubusercontent.com/12221113/119205228-17005a00-ba6e-11eb-94a2-2bc077573cab.png)


- Published paid app on App Store, no active contract (should respond with link to VTEX App Store and ask if user wants to open the browser in that link):

```
vtex login sandboxintegracao -w marlon
vtex-test install acupula.kitlook@2.x
```

![image](https://user-images.githubusercontent.com/12221113/119041673-4723fc00-b98d-11eb-9f61-2056261594eb.png)

- Published free app on App Store, no active contract (should respond with link to VTEX App Store and ask if user wants to open the browser in that link): 

```
vtex login sandboxintegracao -w marlon
vtex-test install vtex.tawk-to@0x
```

- Published free app on App Store, with active contract (app installed successfully without showing or accepting terms):
```
vtex login sandboxintegracao -w marlon
vtex-test install acupula.action-pay@0.x
```

- Published paid app on App Store, with active contract (app installed successfully without showing or accepting terms):
```
vtex login sandboxintegracao -w marlon
vtex-test install vtex.sms-provider@0.x
```
    
- Free app with billingOptions, not published on App Store (app installed successfully without showing or accepting terms):
```
vtex login sandboxintegracao -w marlon
vtex-test install expertoretailcl.er-ai-tracking-pixel@0.x
```

- App with billingOptions with type `billable` (paid), not published on App Store, no active contract (should respond with link to VTEX App Store and ask if user wants to open the browser in that link):
```
vtex login sandboxintegracao -w marlon
vtex-test install acupula.kitlook@1.x
```

- Billable (paid) app, not published on App Store, with active contract (app installed successfully without showing or accepting terms):
```
vtex login fashion2 -w marlon
vtex-test install acupula.kitlook@1.x
```

#### Screenshots or example usage

#### Types of changes
- [x] Refactor (non-breaking change that only makes the code better)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [x] Update `CHANGELOG.md`