### PR TITLE
Feature/adds release display-name flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `--display-name` flag to release command
+
 ## [3.8.0-beta] - 2021-06-09
 
 ### Removed

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -774,6 +774,7 @@ OPTIONS
   -h, --help     show CLI help
   -v, --verbose  Show debug level logs
   --trace        Ensure all requests to VTEX IO are traced
+  --display-name Add the project name to the tag and release commit
 
 EXAMPLES
   vtex release

--- a/src/commands/release.ts
+++ b/src/commands/release.ts
@@ -1,6 +1,7 @@
+import { flags as oclifFlags } from '@oclif/command'
+
 import { CustomCommand } from '../api/oclif/CustomCommand'
 import appsRelease, { releaseTypeAliases, supportedReleaseTypes, supportedTagNames } from '../modules/release'
-
 import { ColorifyConstants } from '../api/constants/Colors'
 
 export default class Release extends CustomCommand {
@@ -17,6 +18,10 @@ export default class Release extends CustomCommand {
 
   static flags = {
     ...CustomCommand.globalFlags,
+    'display-name': oclifFlags.boolean({
+      description: 'Add the project name to the tag and release commit',
+      default: false,
+    }),
   }
 
   static args = [
@@ -33,8 +38,9 @@ export default class Release extends CustomCommand {
   async run() {
     const {
       args: { releaseType, tagName },
+      flags: { 'display-name': displayName },
     } = this.parse(Release)
 
-    await appsRelease(releaseType, tagName)
+    await appsRelease(releaseType, tagName, displayName)
   }
 }

--- a/src/modules/release/index.ts
+++ b/src/modules/release/index.ts
@@ -78,7 +78,7 @@ export default async (
     .split('/')
 
   // Pachamama v2 requires that version tags start with a 'v' character.
-  const tagText = `${displayName ? `${manifest.name}@` : ''}v${newVersion}`
+  const tagText = `${displayName ? `${manifest.name}@` : 'v'}${newVersion}`
   const changelogVersion = `\n\n## [${newVersion}] - ${year}-${month}-${day}`
 
   if (!(await utils.confirmRelease())) {

--- a/src/modules/release/index.ts
+++ b/src/modules/release/index.ts
@@ -78,7 +78,7 @@ export default async (
     .split('/')
 
   // Pachamama v2 requires that version tags start with a 'v' character.
-  const tagText = `${displayName ? manifest.name : ''}/v${newVersion}`
+  const tagText = `${displayName ? `${manifest.name}@` : ''}v${newVersion}`
   const changelogVersion = `\n\n## [${newVersion}] - ${year}-${month}-${day}`
 
   if (!(await utils.confirmRelease())) {

--- a/src/modules/release/index.ts
+++ b/src/modules/release/index.ts
@@ -4,6 +4,7 @@ import semver from 'semver'
 
 import log from '../../api/logger'
 import { ReleaseUtils } from './utils'
+import { ManifestEditor } from '../../api/manifest'
 
 export const releaseTypeAliases = {
   pre: 'prerelease',
@@ -59,13 +60,15 @@ Valid release tags are: ${supportedTagNames.join(', ')}`)
 
 export default async (
   releaseType = 'patch', // This arg. can also be a valid (semver) version.
-  tagName = 'beta'
+  tagName = 'beta',
+  displayName = false
 ) => {
   const utils = new ReleaseUtils()
   utils.checkGit()
   utils.checkIfInGitRepo()
   const normalizedReleaseType = prop<string>(releaseType, releaseTypeAliases) || releaseType
   const [oldVersion, newVersion] = getNewAndOldVersions(utils, normalizedReleaseType, tagName)
+  const manifest = await ManifestEditor.getManifestEditor()
 
   log.info(`Old version: ${chalk.bold(oldVersion)}`)
   log.info(`New version: ${chalk.bold.yellow(newVersion)}`)
@@ -75,7 +78,7 @@ export default async (
     .split('/')
 
   // Pachamama v2 requires that version tags start with a 'v' character.
-  const tagText = `v${newVersion}`
+  const tagText = `${displayName ? manifest.name : ''}/v${newVersion}`
   const changelogVersion = `\n\n## [${newVersion}] - ${year}-${month}-${day}`
 
   if (!(await utils.confirmRelease())) {


### PR DESCRIPTION
#### What is the purpose of this pull request?
This PR adds the `--display-name` flag to the `vtex release` command so the tag name is created with the app name from the manifest.

#### What problem is this solving?
While developing in a monorepo tags can become a bit hard to understand what tag is related to what app, so adding a folder pattern to the tag name can solve this problem. Instead of `v0.10.1` we have `admin-ui@0.10.1`. 

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [x] Update `CHANGELOG.md`