### PR TITLE
adding instructions to install it on windows from an executable file

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,15 @@ To install it, run:
   ```
 </details>
 
+<details>
+  <summary>Installing from executable installer on windows</summary>
+  If you are installing the toolbelt in a Windows machine, you can also do it from an executable installer, like installing any other program in Windows.
+
+  Download it from:
+
+  [Toolbelt Installer](https://vtex.io/vtexcli/install/win-x64)
+</details>
+
 # Using the CLI 
 
 After installation, run `vtex` to see our commands and what each one of them does.


### PR DESCRIPTION
#### What is the purpose of this pull request?
This request adds a suggestion of windows installer to the README.md file

#### What problem is this solving?
Windows users might need extra steps if installing it from `yarn` or `npm`, like adding the folder to the Path, so that the command works.
But there already exists a installer that does all the job, it is just not suggested as an installation method. This information is quite useful for those installing it on Windows machines. I'm picking the installer URL as recommended in this [issue](https://github.com/vtex/toolbelt/issues/1111).

#### How should this be manually tested?
No tests, only adding documentation.

#### Screenshots or example usage

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [ ] Update `CHANGELOG.md`