### PR TITLE
Feat/sfjsecrets plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.9.0-beta] - 2021-08-24
+
+### Added
+- cli-plugin-sfjsecrets for StoreFramework Jamstack
+
 ## [3.8.0-beta] - 2021-06-09
 
 ### Removed

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "@vtex/cli-plugin-deps": "^0.1.1",
     "@vtex/cli-plugin-edition": "^0.1.1",
     "@vtex/cli-plugin-plugins": "^1.13.2",
+    "@vtex/cli-plugin-sfjsecrets": "^0.0.4",
     "@vtex/cli-plugin-whoami": "^0.2.2",
     "@vtex/cli-plugin-workspace": "^1.0.1",
     "@vtex/node-error-report": "^0.0.2",
@@ -174,6 +175,7 @@
       "@vtex/cli-plugin-deploy",
       "@vtex/cli-plugin-whoami",
       "@vtex/cli-plugin-plugins",
+      "@vtex/cli-plugin-sfjsecrets",
       "@vtex/cli-plugin-autoupdate"
     ],
     "update": {


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add sfjsecrets plugin to Toolbelt

#### What problem is this solving?
The [sfjsecrets plugin](https://github.com/vtex/cli-plugin-sfjsecrets/) is a plugin developed for Store Framework Jamstack. It allows developers to encrypt and decrypt the secrets used by the store to access private APIs and dependencies (which are used to build the store). Instead of having the secrets from all SFJ stores in the build pipeline, each store will manage its own secrets through a file in its own repository.

#### How should this be manually tested?
It can be manually tested the same way as the other Toobelt plugins

#### Screenshots or example usage
The commands are:
- vtex(-test) secrets hide
- vtex(-test) secrets reveal
- vtex(-test) secrets setup

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [ ] Update `CHANGELOG.md`