### PR TITLE
Update recommendedEdition in edition.ts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+ - Update recommendedEdition in edition.ts to `edition-store@5.x`
+
 ## [3.0.0] - 2021-10-20
 
  - Release major 3.x as stable.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
- - Update recommendedEdition in edition.ts to `edition-store@5.x`
+ - Update `recommendedEdition` in `edition.ts to `edition-store@5.x`
 
 ## [3.0.0] - 2021-10-20
 

--- a/src/api/modules/workspace/common/edition.ts
+++ b/src/api/modules/workspace/common/edition.ts
@@ -6,7 +6,7 @@ import log from '../../../logger'
 import { promptConfirm } from '../../prompts'
 import { setEdition } from '../../sponsor'
 
-const recommendedEdition = 'vtex.edition-store@2.x'
+const recommendedEdition = 'vtex.edition-store@5.x'
 
 const getCurrEdition = async () => {
   const sponsor = Sponsor.createClient({ workspace: 'master' })
@@ -33,7 +33,7 @@ const promptSwitchEdition = (currEditionId: string) => {
       recommendedEdition
     )}.`
   )
-  log.warn(`For more information about editions, check ${chalk.blue('https://vtex.io/docs/concepts/edition-app/')}`)
+  log.warn(`For more information about editions, check ${chalk.blue('https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-edition-app')}`)
   return promptConfirm(`Would you like to change the edition to ${chalk.blue(recommendedEdition)} now?`, false)
 }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
There is a warning message that is outdated. It recommends `edition-store@2.x`, when it should recommend `edition-store@5.x` according to this doc:

https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-edition-app

It also shares an outdated vtex.io/docs link to the documentation.

#### What problem is this solving?
Reducing the confusion in novice developers working with Store Framework

#### How should this be manually tested?
Open an account that had `edition-business@0.x` and try doing `vtex workspace reset`. It should show an updated message, recommending `edition-store@5.x` and the proper documentation link in our Developer Portal.

#### Screenshots or example usage

<img width="944" alt="Screen Shot 2022-09-15 at 15 29 04" src="https://user-images.githubusercontent.com/2094877/190482163-86eafd2f-7f94-48e0-ae3b-9d6ab9f3e16c.png">

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [ ] Update `CHANGELOG.md`