### PR TITLE
NAD-1450 - feat: add cli-plugin-admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,63 +7,81 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- [@vtex/cli-plugin-admin](https://github.com/vtex/cli-plugin-admin)
+
 ### Changed
- - Update `recommendedEdition` in `edition.ts to `edition-store@5.x`
+
+- Update `recommendedEdition` in `edition.ts to`edition-store@5.x`
 
 ## [3.0.0] - 2021-10-20
 
- - Release major 3.x as stable.
+- Release major 3.x as stable.
 
 ## [3.8.1-beta] - 2021-10-07
 
 ### Changed
- - Undo a remotion of a condition in ManifestUtil for OCLIF_COMPILATION
+
+- Undo a remotion of a condition in ManifestUtil for OCLIF_COMPILATION
 
 ## [3.8.0-beta] - 2021-06-09
 
 ### Removed
+
 - App purchases and all code related to it
 
 ## [3.7.3-beta] - 2021-05-31
 
 ### Changed
- - Update @vtex/cli-plugin-plugins to ^1.13.2
+
+- Update @vtex/cli-plugin-plugins to ^1.13.2
 
 ## [3.7.2-beta] - 2021-05-10
 
 ### Changed
- - Use templates as remote configs instead of hardcoded strings.
+
+- Use templates as remote configs instead of hardcoded strings.
 
 ## [3.7.1-beta] - 2021-05-07
 
 ### Fixed
- - Fix typo in version update message
+
+- Fix typo in version update message
 
 ## [3.7.0-beta] - 2021-05-03
 
 ### Changed
- - Update @vtex/cli-plugin-plugins
+
+- Update @vtex/cli-plugin-plugins
 
 ## [3.6.1-beta] - 2021-04-22
- - Fix `set edition` command to handle prompt cancellations
- - Add check on `set edition` command to install tenant-provisioner app in sponsor account
+
+- Fix `set edition` command to handle prompt cancellations
+- Add check on `set edition` command to install tenant-provisioner app in sponsor account
 
 ## [3.6.0-beta] - 2021-04-13
 
 ### Added
+
 - [vtex init] Service worker example to list of templates
 
 ## [3.5.2-beta] - 2021-04-09
 
 ### Fixed
+
 - [install] Treat `InstallStatus` as a variable not as a type
+
 ### Changed
+
 - [autoupdate] Update to version 0.0.2
 
 ## [3.5.1-beta] - 2021-04-01
 
 ### Fixed
+
 - [hook] Change imports from node_modules to package name
+
 ## [3.5.0-beta] - 2021-04-01
 
 ### Changed
@@ -75,6 +93,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 -[Messages] Update Plugins / Default commands message UX
+
 ## [3.3.4-beta] - 2021-03-29
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@tiagonapoli/oclif-plugin-spaced-commands": "^0.0.6",
     "@vtex/api": "3.77.0",
     "@vtex/cli-plugin-abtest": "0.1.1",
+    "@vtex/cli-plugin-admin": "^0.0.2",
     "@vtex/cli-plugin-autoupdate": "^0.0.2",
     "@vtex/cli-plugin-deploy": "^0.3.1",
     "@vtex/cli-plugin-deps": "^0.1.1",
@@ -174,7 +175,8 @@
       "@vtex/cli-plugin-deploy",
       "@vtex/cli-plugin-whoami",
       "@vtex/cli-plugin-plugins",
-      "@vtex/cli-plugin-autoupdate"
+      "@vtex/cli-plugin-autoupdate",
+      "@vtex/cli-plugin-admin"
     ],
     "update": {
       "node": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1209,6 +1209,15 @@
     numbro "2.1.0"
     tslib "^1"
 
+"@vtex/cli-plugin-admin@^0.0.2":
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/@vtex/cli-plugin-admin/-/cli-plugin-admin-0.0.2.tgz#4f1142f2106684f0040baced9a6fe5db561614e6"
+  integrity sha512-xSaQhVbsHh4r9Li1JeFabkLu8Bn40lmwzy0VkrERQNOfCMgu7u9tloRakF5aBJXI86LGRy+weTJaEI6d+TlZ4Q==
+  dependencies:
+    "@oclif/command" "^1"
+    "@oclif/config" "^1"
+    tslib "^1"
+
 "@vtex/cli-plugin-autoupdate@^0.0.2":
   version "0.0.2"
   resolved "https://registry.npmjs.org/@vtex/cli-plugin-autoupdate/-/cli-plugin-autoupdate-0.0.2.tgz#f632d598d454632502eb02e32967bc9038d7fc74"


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add the [cli-plugin-admin](https://github.com/vtex/cli-plugin-admin) commands to toolbelt to enable devs to develop faster admin apps, faster.

#### How should this be manually tested?

On one terminal (assuming you have already cloned this repo and checked-out to this branch):
```
yarn
yarn watch
```

On another terminal
```
vtex-test raccoon
```

#### Screenshots or example usage

https://user-images.githubusercontent.com/33183880/195111540-cb11632b-6df5-47c7-9d1e-b5033e5597d6.mov

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [x] Update `CHANGELOG.md`