### PR TITLE
Remove references to upstream header

### DIFF
--- a/src/api/clients/IOClients/IOClientFactory.ts
+++ b/src/api/clients/IOClients/IOClientFactory.ts
@@ -98,13 +98,11 @@ export class IOClientFactory {
   }
 
   private static createInstanceOptions(customOptions: Partial<InstanceOptions> = {}) {
-    const clusterHeader = env.cluster() ? { [Headers.VTEX_UPSTREAM_TARGET]: env.cluster() } : null
     const traceHeader = TraceConfig.shouldTrace() ? { [Headers.VTEX_TRACE]: TraceConfig.jaegerDebugID } : null
 
     const defaultOptions = {
       timeout: (env.envTimeout || IOClientFactory.DEFAULT_TIMEOUT) as number,
       headers: {
-        ...clusterHeader,
         ...traceHeader,
       },
     }

--- a/src/api/clients/IOClients/infra/Runtime.ts
+++ b/src/api/clients/IOClients/infra/Runtime.ts
@@ -1,7 +1,6 @@
 import { IOContext } from '@vtex/api'
 import * as url from 'url'
 import WebSocket from 'ws'
-import { cluster } from '../../../env'
 import logger from '../../../logger'
 import { Headers } from '../../../constants/Headers'
 import { SessionManager } from '../../../session/SessionManager'
@@ -26,14 +25,12 @@ export class Runtime {
   public async debugDotnetApp(appName: string, appVendor: string, appMajor: string, debugInst: string) {
     const host = 'app.io.vtex.com'
     const path = `/${appVendor}.${appName}/v${appMajor}/${this.account}/${this.workspace}/_debug/dotnet`
-    const clusterHeader = cluster() ? { [Headers.VTEX_UPSTREAM_TARGET]: cluster() } : null
 
     const clientOptions = {
       headers: {
         Authorization: SessionManager.getSingleton().token,
         Host: host,
         [Headers.VTEX_RUNTIME_API]: 'true',
-        ...clusterHeader,
       },
     }
 

--- a/src/api/conf.ts
+++ b/src/api/conf.ts
@@ -50,11 +50,3 @@ export const getEnvironment = (): Environment => {
 export enum Region {
   Production = 'aws-us-east-1',
 }
-
-export const saveCluster = (cluster: string) => {
-  conf.set('cluster', cluster)
-}
-
-export const getCluster = () => {
-  return conf.get('cluster') || CLUSTER_DEFAULT_VALUE
-}

--- a/src/api/constants/Headers.ts
+++ b/src/api/constants/Headers.ts
@@ -7,10 +7,6 @@ export enum Headers {
   // Specify a specific pod to receive the request
   VTEX_STICKY_HOST = 'x-vtex-sticky-host',
 
-  // Specify the target cluster for the request.
-  // Works only on myvtexdev domain
-  VTEX_UPSTREAM_TARGET = 'x-vtex-upstream-target',
-
   // LinkID used by builder-hub to create logs/tracing correlation between all
   // relink/link operations related to a initial link
   VTEX_LINK_ID = 'x-vtex-bh-link-id',

--- a/src/api/env.ts
+++ b/src/api/env.ts
@@ -1,4 +1,4 @@
-import { Region, getCluster } from './conf'
+import { Region } from './conf'
 
 export const envTimeout = process.env.VTEX_API_TIMEOUT as number | string
 
@@ -6,24 +6,12 @@ export function colossusEndpoint() {
   return process.env.VTEX_COLOSSUS_ENDPOINT || `https://infra.io.vtex.com/colossus/v0`
 }
 
-export function cluster() {
-  return process.env.VTEX_CLUSTER || getCluster() || ''
-}
-
+// TODO (@pedro823): the following functions were related to a cluster feature which is now
+// deprecated. We should remove these functions later on.
 export function region(): string {
-  return cluster() || Region.Production
+  return Region.Production
 }
 
 export function publicEndpoint(): string {
-  return cluster() ? 'myvtexdev.com' : 'myvtex.com'
-}
-
-export function clusterIdDomainInfix(): string {
-  const upstreamCluster = cluster()
-  return upstreamCluster ? `.${upstreamCluster}` : ''
-}
-
-export function envCookies(): string {
-  const upstreamCluster = cluster()
-  return upstreamCluster ? `VtexIoClusterId=${upstreamCluster}` : ''
+  return 'myvtex.com'
 }

--- a/src/api/modules/url.ts
+++ b/src/api/modules/url.ts
@@ -1,7 +1,7 @@
-import { clusterIdDomainInfix, publicEndpoint } from '../env'
+import { publicEndpoint } from '../env'
 import { SessionManager } from '../session/SessionManager'
 
 export default () => {
   const { account, workspace } = SessionManager.getSingleton()
-  return `https://${workspace}--${account}${clusterIdDomainInfix()}.${publicEndpoint()}`
+  return `https://${workspace}--${account}.${publicEndpoint()}`
 }

--- a/src/lib/sse/CustomEventSource.ts
+++ b/src/lib/sse/CustomEventSource.ts
@@ -1,5 +1,4 @@
 import EventSource from 'eventsource'
-import { cluster, envCookies } from '../../api/env'
 import userAgent from '../../user-agent'
 import { Headers } from '../../api/constants/Headers'
 import { SessionManager } from '../../api/session/SessionManager'
@@ -47,8 +46,6 @@ export class CustomEventSource {
       headers: {
         authorization: `bearer ${token}`,
         'user-agent': userAgent,
-        ...(envCookies() ? { cookie: envCookies() } : null),
-        ...(cluster() ? { [Headers.VTEX_UPSTREAM_TARGET]: cluster() } : null),
         ...additionalHeaders,
         ...traceHeader,
       },

--- a/src/modules/apps/debugger.ts
+++ b/src/modules/apps/debugger.ts
@@ -1,7 +1,6 @@
 import streamToString from 'get-stream'
 import net from 'net'
 import WebSocket from 'ws'
-import { cluster } from '../../api/env'
 import { Headers } from '../../api/constants/Headers'
 import { ManifestEditor } from '../../api/manifest'
 import { SessionManager } from '../../api/session/SessionManager'
@@ -35,7 +34,6 @@ function webSocketTunnelHandler(host: string, path: string, server: net.Server):
         Host: host,
         'user-agent': userAgent,
         [Headers.VTEX_RUNTIME_API]: 'true',
-        ...(cluster() ? { [Headers.VTEX_UPSTREAM_TARGET]: cluster() } : null),
       },
     })
 

--- a/src/oclif/hooks/init.ts
+++ b/src/oclif/hooks/init.ts
@@ -1,4 +1,3 @@
-import axios from 'axios'
 import os from 'os'
 import help from '@oclif/plugin-help'
 
@@ -6,7 +5,6 @@ import * as Config from '@oclif/config'
 import { HookKeyOrOptions } from '@oclif/config/lib/hooks'
 import { error } from '@oclif/errors'
 import { FeatureFlag } from '../../api/modules/featureFlag'
-import { envCookies } from '../../api/env'
 import { CLIPreTasks } from '../../CLIPreTasks/CLIPreTasks'
 import { TelemetryCollector } from '../../lib/telemetry/TelemetryCollector'
 import { hrTimeToMs } from '../../lib/utils/hrTimeToMs'
@@ -316,13 +314,6 @@ export default async function(options: HookKeyOrOptions<'init'>) {
 
     console.log(renderedCommands)
   }
-
-  axios.interceptors.request.use(config => {
-    if (envCookies()) {
-      config.headers.Cookie = `${envCookies()}; ${config.headers.Cookie || ''}`
-    }
-    return config
-  })
 
   process.on('unhandledRejection', onError)
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
This PR removes references to upstream headers. 

`vtex config [get|set]` is a command that doesn't work anymore, and headers/cookies referred in this PR would only work on `*.myvtexdev.com`, which is deprecated and doesn't resolve to anywhere.

Therefore, it is best for us to just plainly remove references to this feature and provide other means to focus requests on a desired infrastructure.

#### Types of changes
- [x] Refactor (non-breaking change that only makes the code better)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [x] Update `CHANGELOG.md`