### PR TITLE
Make chrome debugger be opt-in instead of default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
  - Update `recommendedEdition` in `edition.ts to `edition-store@5.x`
+ - Make Chrome debugger an opt-in instead of a default open port.
 
 ## [3.0.0] - 2021-10-20
 

--- a/src/api/clients/IOClients/infra/Runtime.ts
+++ b/src/api/clients/IOClients/infra/Runtime.ts
@@ -24,7 +24,7 @@ export class Runtime {
   }
 
   public async debugDotnetApp(appName: string, appVendor: string, appMajor: string, debugInst: string) {
-    const host = 'app.io.vtex.com'
+    const host = 'ws.io.vtex.com'
     const path = `/${appVendor}.${appName}/v${appMajor}/${this.account}/${this.workspace}/_debug/dotnet`
     const clusterHeader = cluster() ? { [Headers.VTEX_UPSTREAM_TARGET]: cluster() } : null
 

--- a/src/api/modules/workspace/common/edition.ts
+++ b/src/api/modules/workspace/common/edition.ts
@@ -33,7 +33,11 @@ const promptSwitchEdition = (currEditionId: string) => {
       recommendedEdition
     )}.`
   )
-  log.warn(`For more information about editions, check ${chalk.blue('https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-edition-app')}`)
+  log.warn(
+    `For more information about editions, check ${chalk.blue(
+      'https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-edition-app'
+    )}`
+  )
   return promptConfirm(`Would you like to change the edition to ${chalk.blue(recommendedEdition)} now?`, false)
 }
 

--- a/src/commands/link.ts
+++ b/src/commands/link.ts
@@ -39,6 +39,11 @@ export default class Link extends CustomCommand {
       description: 'Allows linking the app despite Typescript errors.',
       default: false,
     }),
+    'with-debugger': oclifFlags.boolean({
+      char: 'd',
+      description: 'Start the chrome debugger tunnel after the app is linked.',
+      default: false,
+    }),
     workspace: oclifFlags.string({
       char: 'w',
       description: `Starts a development session in the specified ${ColorifyConstants.ID(
@@ -54,10 +59,8 @@ export default class Link extends CustomCommand {
 
   async run() {
     const {
-      flags,
-      flags: { account, setup, clean, unsafe, workspace },
+      flags: { account, setup, clean, unsafe, workspace, 'no-watch': noWatch, 'with-debugger': withDebugger },
     } = this.parse(Link)
-    const noWatch = flags['no-watch']
-    await appLink({ account, workspace, setup, clean, unsafe, noWatch })
+    await appLink({ account, workspace, setup, clean, unsafe, noWatch, withDebugger })
   }
 }

--- a/src/modules/apps/debugger.ts
+++ b/src/modules/apps/debugger.ts
@@ -108,7 +108,7 @@ export default function startDebuggerTunnel(
 
   const { account, workspace } = SessionManager.getSingleton()
   const appMajor = versionMajor(version)
-  const host = 'app.io.vtex.com'
+  const host = 'ws.io.vtex.com'
   const path = `/${vendor}.${name}/v${appMajor}/${account}/${workspace}/_debug/attach`
 
   return new Promise((resolve, reject) => {

--- a/src/modules/apps/link.ts
+++ b/src/modules/apps/link.ts
@@ -54,6 +54,7 @@ interface LinkOptions {
   clean?: boolean
   setup?: boolean
   noWatch?: boolean
+  withDebugger?: boolean
 }
 
 const DELETE_SIGN = chalk.red('D')
@@ -317,6 +318,10 @@ export async function appLink(options: LinkOptions) {
   let debuggerStarted = false
   const onBuild = async () => {
     if (debuggerStarted) {
+      return
+    }
+    if (!options.withDebugger) {
+      log.info('Debugger flag not set. To open a chrome debugger server, link your app using the --with-debugger flag.')
       return
     }
     const startDebugger = async () => {


### PR DESCRIPTION
#### What is the purpose of this pull request?
To make the chrome debugger tunnel be an explicit opt-in instead of a default open port.

#### What problem is this solving?
This wastes resources on our cloud if the user is not actively using it. This allows us to intentionally measure the usage of this feature. 

#### How should this be manually tested?
Try linking an app normally and see that it doesn't start the chrome debugger server. By using `--with-debugger` in your linking flow, the previous behavior is restored.

#### Types of changes
- [x] Breaking change (fix or feature that would cause existing functionality to change)

#### Chores checklist
- [x] Update `CHANGELOG.md`