### PR TITLE
BUGFIX: add exit 1 when commands fail

### DIFF
--- a/src/modules/apps/install.ts
+++ b/src/modules/apps/install.ts
@@ -53,6 +53,8 @@ function handleAccountNotSponsoredByVendorError(app: string) {
 }
 
 const prepareInstall = async (appsList: string[], force: boolean): Promise<void> => {
+  let exitWithError = false;
+
   for (const app of appsList) {
     ManifestValidator.validateApp(app)
     try {
@@ -79,6 +81,7 @@ const prepareInstall = async (appsList: string[], force: boolean): Promise<void>
       }
       log.info(`Installed app ${chalk.green(app)} successfully`)
     } catch (e) {
+      exitWithError = true;
       if (isNotFoundError(e)) {
         log.warn(
           `Billing app not found in current workspace. Please install it with ${chalk.green(
@@ -107,6 +110,8 @@ const prepareInstall = async (appsList: string[], force: boolean): Promise<void>
       log.warn(`The following app was not installed: ${app}`)
     }
   }
+
+  if (exitWithError) process.exit(1);
 }
 
 export default async (optionalApps: string[], options) => {

--- a/src/modules/apps/publish.ts
+++ b/src/modules/apps/publish.ts
@@ -111,7 +111,8 @@ const publisher = (workspace = 'master') => {
         )
       }
     } catch (e) {
-      log.error(`Failed to publish ${appId}`)
+      log.error(`Failed to publish ${appId}`);
+      process.exit(1);
     }
 
     await returnToPreviousAccount({ previousAccount, previousWorkspace })

--- a/src/modules/apps/unlink.ts
+++ b/src/modules/apps/unlink.ts
@@ -22,6 +22,7 @@ Make sure you typed the right app vendor, name and version.`)
         log.error(e.response.data.message)
       }
     }
+    process.exit(1);
   }
 }
 
@@ -40,6 +41,7 @@ const unlinkAllApps = async (): Promise<void> => {
     if (e?.response?.data?.message) {
       log.error(e.response.data.message)
     }
+    process.exit(1);
   }
 }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
To solve the bug exit equals 0 when some commands become failed

#### What problem is this solving?
Commands like publish, uninstall, unlink when they fail the CLI doesn't return exit code 1, If someone use this in a CI/CD, the pipeline will run "normally" and won't fail with CLI vtex 

#### How should this be manually tested?
Force some error like trying to publish a version that already exists:
`vtex publish`
The CLI must exit with status code 1 instead 0

#### Screenshots or example usage

#### Types of changes
- [x] Refactor (non-breaking change that only makes the code better)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [x] Update `CHANGELOG.md`