### PR TITLE
chore: Update secret references in AWS publication

### DIFF
--- a/.github/workflows/publish-stable-aws.yml
+++ b/.github/workflows/publish-stable-aws.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Trigger publish-stable-brew
         uses: peter-evans/repository-dispatch@v1
         with:
-          token: ${{ secrets.REPO_GHA_PAT }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           repository: vtex/homebrew-vtex
           event-type: publish-stable-brew
   publish-failed:


### PR DESCRIPTION
#### What is the purpose of this pull request?

Use `GITHUB_TOKEN` in `publish-stable-aws` instead of `REPO_GHA_PAT`

#### What problem is this solving?

The former secret is deprecated

#### How should this be manually tested?

Run the failed `publish-stable-aws` action

#### Screenshots or example usage

None

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [ ] Update `CHANGELOG.md`