### PR TITLE
Allow specific builder config to override the common config for pinned dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Allow specific builder config to override the common config for pinned dependencies
+
 ## [4.0.4] - 2023-11-03
 
 ### Fixed

--- a/src/api/pinnedDependencies.ts
+++ b/src/api/pinnedDependencies.ts
@@ -48,8 +48,8 @@ export const fixPinnedDependencies = async (
       }
 
       const pinnedDepsForBuilder = {
-        ...pinnedDeps.builders[builder]?.[builderMajorLocator],
         ...pinnedDeps.common,
+        ...pinnedDeps.builders[builder]?.[builderMajorLocator],
       }
 
       return fixBuilderFolderPinnedDeps(appRoot, builder, pinnedDepsForBuilder)


### PR DESCRIPTION
#### What is the purpose of this pull request?
Change the logic that handles pinned dependencies to allow configs for specific builders to have higher precedence than the common configs.

This won't cause any problems, since the Typescript is currently the only common pinned dep and there are currently no builders trying to change its value either. You can see the current pinned dependencies config [here](https://github.com/vtex/builder-hub/blob/master/node/request/handlers/pinnedDependencies.ts#L15).

#### What problem is this solving?
With the current logic it's impossible to allow other Typescript versions to be used in any builders. A new node builder major is being created (PR [here](https://github.com/vtex/builder-hub/pull/1184)) to upgrade TS and it needs this change to properly work.

#### How should this be manually tested?
First test the existing use cases:
1. Load the repo of an existing Node.js app.
2. Bump typescript to ^5.0.0 within the app's node/package.json.
3. Link the app with this version of the toolbelt.
4. Verify that the typescript version was fixed back to 3.9.7.

Afterwards, you can test with the new builder:
1. Link the builder-hub version in [this PR](https://github.com/vtex/builder-hub/pull/1184).
2. Change the app's manifest.json to point to the new builder.
3. Bump @types/node to ^16.0.0 within the app's node/package.json.
4. Bump typescript to ^5.0.0 within the app's node/package.json.
5. Link the app with this version of the toolbelt.
6. Verify that the typescript version was not changed back to 3.9.7.

#### Screenshots or example usage

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [ ] Update `CHANGELOG.md`