### PR TITLE
feature:pipeline-support

### DIFF
--- a/src/commands/deprecate.ts
+++ b/src/commands/deprecate.ts
@@ -18,6 +18,10 @@ export default class Deprecate extends CustomCommand {
   static flags = {
     ...CustomCommand.globalFlags,
     yes: oclifFlags.boolean({ description: 'Answers yes to all prompts.', char: 'y', default: false }),
+    pipeline: oclifFlags.boolean({
+      char: 'p',
+      description: `Runs the command in ${ColorifyConstants.ID('pipeline')} mode.`,
+    })
   }
 
   static strict = false
@@ -41,11 +45,11 @@ export default class Deprecate extends CustomCommand {
   async run() {
     const {
       raw,
-      flags: { yes },
+      flags: { yes, pipeline },
     } = this.parse(Deprecate)
 
     const allArgs = this.getAllArgs(raw)
 
-    await appsDeprecate(allArgs, { yes })
+    await appsDeprecate(allArgs, { yes }, pipeline)
   }
 }

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -4,6 +4,7 @@ import { CustomCommand } from '../api/oclif/CustomCommand'
 import authLogin from '../modules/auth/login'
 
 import { ColorifyConstants } from '../api/constants/Colors'
+import loginWithPipeline from '../modules/auth/pipeline'
 
 export default class Login extends CustomCommand {
   static description = `Logs in to a ${ColorifyConstants.ID('VTEX account')}.`
@@ -15,10 +16,22 @@ export default class Login extends CustomCommand {
 
   static flags = {
     ...CustomCommand.globalFlags,
+    pipeline: oclifFlags.boolean({
+      char: 'p',
+      description: `Runs the command in ${ColorifyConstants.ID('pipeline')} mode.`,
+    }),
     workspace: oclifFlags.string({
       char: 'w',
       description: `Logs in the specified ${ColorifyConstants.ID('workspace')}.`,
     }),
+    vtexApiKey: oclifFlags.string({
+      char: 'k',
+      description: `VTEX API Key.`,
+    }),
+    vtexApiToken: oclifFlags.string({
+      char: 't',
+      description: `VTEX API`
+    })
   }
 
   static args = [
@@ -28,9 +41,13 @@ export default class Login extends CustomCommand {
   async run() {
     const {
       args: { account },
-      flags: { workspace },
+      flags: { workspace, pipeline, vtexApiKey, vtexApiToken },
     } = this.parse(Login)
 
-    await authLogin({ account, workspace })
+    if(!pipeline) {
+      await authLogin({ account, workspace })
+    }else{
+      await loginWithPipeline({ account, workspace }, vtexApiKey, vtexApiToken)
+    }
   }
 }

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -17,6 +17,10 @@ export default class Publish extends CustomCommand {
       char: 'w',
       description: `Uses the specified ${ColorifyConstants.ID('workspace')} in the app registry.`,
     }),
+    pipeline: oclifFlags.boolean({
+      char: 'p',
+      description: `Runs the command in ${ColorifyConstants.ID('pipeline')} mode.`,
+    }),
     force: oclifFlags.boolean({
       char: 'f',
       description: 'Publishes the app independently of SemVer rules.',
@@ -27,9 +31,9 @@ export default class Publish extends CustomCommand {
   async run() {
     const {
       args: { path },
-      flags: { yes, workspace, force, tag },
+      flags: { yes, workspace, force, tag, pipeline },
     } = this.parse(Publish)
 
-    await appsPublish(path, { yes, workspace, force, tag })
+    await appsPublish(path, { yes, workspace, force, tag }, pipeline)
   }
 }

--- a/src/commands/release.ts
+++ b/src/commands/release.ts
@@ -1,3 +1,4 @@
+import { flags as oclifFlags } from '@oclif/command'
 import { CustomCommand } from '../api/oclif/CustomCommand'
 import appsRelease, { releaseTypeAliases, supportedReleaseTypes, supportedTagNames } from '../modules/release'
 
@@ -17,6 +18,10 @@ export default class Release extends CustomCommand {
 
   static flags = {
     ...CustomCommand.globalFlags,
+    pipeline: oclifFlags.boolean({
+      char: 'p',
+      description: `Runs the command in ${ColorifyConstants.ID('pipeline')} mode.`,
+    })
   }
 
   static args = [
@@ -32,9 +37,9 @@ export default class Release extends CustomCommand {
 
   async run() {
     const {
+      flags: { pipeline },
       args: { releaseType, tagName },
     } = this.parse(Release)
-
-    await appsRelease(releaseType, tagName)
+    await appsRelease(releaseType, tagName, pipeline)
   }
 }

--- a/src/lib/auth/AuthProviders/ApiTokenAuthenticator/index.ts
+++ b/src/lib/auth/AuthProviders/ApiTokenAuthenticator/index.ts
@@ -1,0 +1,38 @@
+import axios from 'axios'
+
+export class ApiTokenAuthenticator {
+    public async login(apiKey: string, apiToken: string, account: string) {
+        const url = `https://api.vtexcommercestable.com.br/api/vtexid/apptoken/login?an=${account}`
+
+        const body = {
+            appKey: apiKey,
+            appToken: apiToken
+        }
+
+        try{
+            const response  = await axios.post(url, body, {
+                headers: {
+                    'Content-Type': 'application/json'
+                }
+            })
+
+            if(response.status === 200){
+                const { data } = response
+
+                if(data?.token){
+                    const token = data.token
+                    return token
+                }else{
+                    throw new Error('Invalid credentials')
+                }
+
+            }else{
+                throw new Error('Invalid credentials')
+            }
+
+
+        }catch(error){
+            throw new Error(error)
+        }
+    }
+}

--- a/src/modules/apps/deprecate.ts
+++ b/src/modules/apps/deprecate.ts
@@ -70,7 +70,7 @@ const prepareAndDeprecateApps = async (appsList: string[]): Promise<any> => {
   await returnToPreviousAccount({ previousAccount: originalAccount, previousWorkspace: originalWorkspace })
 }
 
-export default async (optionalApps: string[], options) => {
+export default async (optionalApps: string[], options, pipeline: boolean = false) => {
   const preConfirm = options.y || options.yes
 
   const { account, workspace } = SessionManager.getSingleton()
@@ -79,9 +79,12 @@ export default async (optionalApps: string[], options) => {
 
   const appsList = optionalApps.length > 0 ? optionalApps : [(await ManifestEditor.getManifestEditor()).appLocator]
 
-  if (!preConfirm && !(await promptDeprecate(appsList))) {
-    return
+  if(!pipeline){
+    if (!preConfirm && !(await promptDeprecate(appsList))) {
+      return
+    }
   }
+  
 
   log.debug(`Deprecating app${appsList.length > 1 ? 's' : ''}: ${appsList.join(', ')}`)
   return prepareAndDeprecateApps(appsList)

--- a/src/modules/apps/publish.ts
+++ b/src/modules/apps/publish.ts
@@ -120,7 +120,7 @@ const publisher = (workspace = 'master') => {
   return { publishApp, publishApps }
 }
 
-export default async (path: string, options) => {
+export default async (path: string, options, pipeline: boolean) => {
   log.debug(`Starting to publish app in ${conf.getEnvironment()}`)
 
   const { account } = SessionManager.getSingleton()
@@ -136,7 +136,7 @@ export default async (path: string, options) => {
 
   const yesFlag = options.y || options.yes
 
-  if (!yesFlag) {
+  if (!pipeline && !yesFlag) {
     const confirmVersion = await promptConfirm(
       `Are you sure that you want to release version ${chalk.bold(`${versionMsg} of ${appNameMsg}?`)}`,
       false

--- a/src/modules/auth/login.ts
+++ b/src/modules/auth/login.ts
@@ -55,7 +55,7 @@ export interface LoginOptions {
   postLoginOps?: PostLoginOps[]
 }
 
-const getTargetLogin = async ({ account: optionAccount, workspace: optionWorkspace }: LoginOptions) => {
+export const getTargetLogin = async ({ account: optionAccount, workspace: optionWorkspace }: LoginOptions) => {
   const {
     account: previousAccount,
     workspace: previousWorkspace,

--- a/src/modules/auth/pipeline.ts
+++ b/src/modules/auth/pipeline.ts
@@ -1,0 +1,58 @@
+import { SessionManager } from '../../api/session/SessionManager'
+import { handleErrorCreatingWorkspace, workspaceCreator } from '../../api/modules/workspace/create'
+import log from '../../api/logger'
+
+const vtexApiKeyLabel = 'VTEX_API_KEY';
+const vtexApiTokenLabel = 'VTEX_API_TOKEN';
+
+export interface LoginOptions {
+    account?: string
+    workspace?: string
+}
+
+export default async (opts: LoginOptions, vtexApiKey?: string, vtexApiToken?: string) => {
+    if (!vtexApiKey || !vtexApiToken || !opts.account) {
+        const credentials = getCredentialsInEnvirovmentVariables();
+        if (credentials) {
+            vtexApiKey = credentials.vtexApiKey;
+            vtexApiToken = credentials.vtexApiToken;
+            const sessionManager = SessionManager.getSingleton()
+            await sessionManager.loginUsingPipeline(
+                opts.account, 
+                { 
+                    vtexApiKey,
+                    targetWorkspace: opts.workspace,
+                    workspaceCreation: {
+                        promptCreation: true,
+                        creator: workspaceCreator,
+                        onError: handleErrorCreatingWorkspace,
+                      },
+                    vtexApiToken
+                })
+            log.info('You are now logged in');
+        } else {
+            log.error('VTEX_API_KEY and VTEX_API_TOKEN must be provided');
+        }
+    }
+}
+
+
+interface credentialsType {
+    vtexApiKey: string,
+    vtexApiToken: string,
+}
+
+function getCredentialsInEnvirovmentVariables(): credentialsType | null {
+    try {
+        const vtexApiKey = process.env[vtexApiKeyLabel];
+        const vtexApiToken = process.env[vtexApiTokenLabel];
+
+        if (vtexApiKey && vtexApiToken) {
+            return { vtexApiKey, vtexApiToken };
+        } else {
+            return null;
+        }
+    } catch (error) {
+
+    }
+}

--- a/src/modules/release/index.ts
+++ b/src/modules/release/index.ts
@@ -59,7 +59,8 @@ Valid release tags are: ${supportedTagNames.join(', ')}`)
 
 export default async (
   releaseType = 'patch', // This arg. can also be a valid (semver) version.
-  tagName = 'beta'
+  tagName = 'beta',
+  pipeline = false
 ) => {
   const utils = new ReleaseUtils()
   utils.checkGit()
@@ -78,9 +79,12 @@ export default async (
   const tagText = `v${newVersion}`
   const changelogVersion = `\n\n## [${newVersion}] - ${year}-${month}-${day}`
 
-  if (!(await utils.confirmRelease())) {
-    // Abort release.
-    return
+
+  if(!pipeline){
+    if (!(await utils.confirmRelease())) {
+      // Abort release.
+      return
+    }
   }
   log.info('Starting release...')
   try {
@@ -93,7 +97,7 @@ export default async (
     await utils.commit(tagText)
     await utils.tag(tagText)
     await utils.push(tagText)
-    await utils.postRelease()
+    if(!pipeline) await utils.postRelease();
   } catch (e) {
     log.error(`Failed to release \n${e}`)
   }


### PR DESCRIPTION
#### What is the purpose of this pull request?
The purpose of this pull request is to introduce pipeline support in the VTEX TOOLBELT CLI, aiming to optimize the workflow in CI/CD pipelines. This is achieved by adding a -p or --pipeline flag to the login command, allowing automatic login using VTEX_API_KEY and VTEX_API_TOKEN environment variables, and also adding this flag to the release, publish, deprecate commands to remove unnecessary confirmations in these automated contexts.

#### What problem is this solving?
This change addresses the issue of having to manually confirm actions or perform logins, which is impractical in continuous integration and delivery environments, where automatic and interaction-free processes are essential for efficiency and scalability.

#### How should this be manually tested?

To manually test this feature, you can follow these steps:

* Configure the VTEX_API_KEY and VTEX_API_TOKEN environment variables with your VTEX credentials.
* Run the login command with the -p or --pipeline flag to verify automatic login.
* Use the release, publish, deprecate commands with the -p or --pipeline flag to confirm that no manual confirmations are requested and that the commands execute as expected in a pipeline scenario.

#### Screenshots or example usage
<img width="580" alt="image" src="https://github.com/vtex/toolbelt/assets/32481277/8810beb7-f9dc-480d-a872-45a178ada1e7">

Below are examples of how the commands can be executed with the new -p or --pipeline flag, illustrating the practical use of this new feature:

**this examples is using unix/linux environment**

Login with pipeline:

``` export VTEX_API_KEY=vtexappkey-store-key ```
``` export VTEX_API_TOKEN={{token}} ```

USING CLI:
``` vtex login -p ```
or
``` vtex login --pipeline ```

---

#### Release

``` vtex release -p [type] [tagname] ```
or
``` vtex release --pipeline ```
---
#### publish

``` vtex publish -p ```
or
``` vtex publish --pipeline ```
---
#### deprecate
``` vtex deprecate -p ```
or
``` vtex deprecate --pipeline ```



#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [] Update `CHANGELOG.md`