### PR TITLE
Extend VBase clients with conflict handler endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Updated
+- Extend VBase client, integrating the `getConflicts` and the `resolveConflict` endpoints.
 
 ## [2.128.0] - 2021-05-25
 

--- a/src/api/clients/IOClients/infra/VBase.ts
+++ b/src/api/clients/IOClients/infra/VBase.ts
@@ -22,6 +22,7 @@ export class VBase extends InfraClient {
     })
   }
 
+  // Resolve a specific pages-graphql conflict
   public resolveConflict = (bucketKey: string, path: string, content: any) => {
     const data = [
       {
@@ -36,22 +37,17 @@ export class VBase extends InfraClient {
     })
   }
 
+  // List all conflicts in the pages-graphql bucket
   public getConflicts = async () => {
     return this.http.get(routes.Conflicts('vtex.pages-graphql/userData'), {
       metric: 'vbase-get-conflicts',
     })
   }
 
+  // Verify if there is at least one conlfict in the pages-graphql bucket
   public checkForConflicts = async () => {
-    let status: number
-    try {
-      const response = await this.http.get(routes.File('vtex.pages-graphql/userData', 'store/content.json'), {
-        metric: 'vbase-conflict',
-      })
-      status = response.status
-    } catch (error) {
-      status = error.response && error.response.status
-    }
-    return status === 409
+    const response = await this.getConflicts().then(res => res.data)
+
+    return response?.data?.length > 0
   }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

- Extend the VBase client to have more options to handle conflicts

#### What problem is this solving?

[Slack thread](https://vtex.slack.com/archives/C05CBNSEP0B/p1727825595441399)

#### How should this be manually tested?
- You can test it yarn linking all dependencies([@vtex/api](https://github.com/vtex/node-vtex-api/pull/561), this module, and the [cli-plugin-workspace](https://github.com/vtex/cli-plugin-workspace/pull/14)), and running with the alias:
vtex-test promote After that, listing to conflicts should return an empty array.

#### Screenshots or example usage

#### Types of changes

* [ ] Bug fix (a non-breaking change which fixes an issue)
* [X] New feature (a non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)
* [ ] Requires change to documentation, which has been updated accordingly.
