### PR TITLE
Showing URL when opening browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [4.1.1]
+
 ### Updated
+
 - Extend VBase client, integrating the `getConflicts` and the `resolveConflict` endpoints.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- The URL is now shown as a log when opening browser windows.
+
 ## [4.1.0] - 2024-08-01
 
 ### Changed
+
 - Pack toolbelt using nodejs 20
 - Allow specific builder config to override the common config for pinned dependencies
 
@@ -2134,13 +2139,13 @@ I know you're excited, yeah, gimme a hug homie <3
 
 **TL;DR:** You don't need to type the sandbox name on `watch` or set the cookies anymore.
 
-# 
+#
 
 **First big important note:** If you have any credentials cached, please `logout` and `login` again.
 
 **Second big important note:** Delete the previous `vtex_workspace` and `vtex_sandbox` cookies that you have setted before.
 
-# 
+#
 
 - [`#58`](https://github.com/vtex/toolbelt/issues/58)
 - [`#48`](https://github.com/vtex/toolbelt/issues/48) (closed due to deprecation)

--- a/src/__tests__/modules/featureFlag/featureFlagDecider.test.ts
+++ b/src/__tests__/modules/featureFlag/featureFlagDecider.test.ts
@@ -1,0 +1,112 @@
+import chalk from 'chalk'
+import { switchOpen } from '../../../modules/featureFlag/featureFlagDecider'
+
+jest.mock('open')
+jest.mock('opn')
+jest.mock('../../../api/clients/IOClients/apps/ToolbeltConfig')
+jest.mock('../../../api/logger')
+jest.mock('../../../api/error/ErrorReport')
+import open from 'open'
+import opn from 'opn'
+import { GlobalConfig, ToolbeltConfig, VersionCheckRes } from '../../../api/clients/IOClients/apps/ToolbeltConfig'
+import logger from '../../../api/logger'
+import { IOClientFactory } from '../../../api/clients/IOClients/IOClientFactory'
+import { ErrorReport, LogToUserOptions, CustomErrorReportBaseConstructorArgs } from '../../../api/error/ErrorReport'
+
+const getGlobalConfigMock = jest.fn()
+const logErrorForUserMock = jest.fn()
+
+class ToolbeltConfigMock extends ToolbeltConfig {
+  public async versionValidate(_: string) {
+    return { minVersion: '', validVersion: true, message: '' } as VersionCheckRes
+  }
+
+  public async getGlobalConfig(): Promise<GlobalConfig> {
+    return getGlobalConfigMock()
+  }
+}
+
+class ErrorReportMock extends ErrorReport {
+  public logErrorForUser(_?: LogToUserOptions) {
+    logErrorForUserMock()
+    return this
+  }
+}
+
+describe('featureFlagDecider', () => {
+  beforeAll(() => {
+    const clientMock = new ToolbeltConfigMock(IOClientFactory.createIOContext(), {})
+    jest.spyOn(ToolbeltConfig, 'createClient').mockReturnValue(clientMock)
+
+    const errorMock = new ErrorReportMock({ shouldRemoteReport: false } as CustomErrorReportBaseConstructorArgs)
+    jest.spyOn(ErrorReport, 'createAndMaybeRegisterOnTelemetry').mockReturnValue(errorMock)
+  })
+
+  beforeEach(() => {
+    getGlobalConfigMock.mockClear()
+    logErrorForUserMock.mockClear()
+  })
+
+  describe('switchOpen', () => {
+    let url: string
+    let options: object
+
+    beforeAll(() => {
+      url = 'https://vtex.myvtex.com'
+      options = {}
+    })
+
+    test('should log properly', async () => {
+      getGlobalConfigMock.mockReturnValue({
+        featureFlags: {
+          FEATURE_FLAG_NEW_OPEN_PACKAGE: true,
+        },
+      })
+
+      await switchOpen(url, options)
+
+      expect(getGlobalConfigMock).toHaveBeenCalled()
+      expect(logger.info).toHaveBeenCalledTimes(2)
+      expect(logger.info).lastCalledWith(`${chalk.cyan(url)}`)
+    })
+
+    test('should use open when FEATURE_FLAG_NEW_OPEN_PACKAGE is true', async () => {
+      getGlobalConfigMock.mockReturnValue({
+        featureFlags: {
+          FEATURE_FLAG_NEW_OPEN_PACKAGE: true,
+        },
+      })
+
+      await switchOpen(url, options)
+
+      expect(getGlobalConfigMock).toHaveBeenCalled()
+      expect(open).toHaveBeenCalled()
+    })
+
+    test('should use opn when FEATURE_FLAG_NEW_OPEN_PACKAGE is false', async () => {
+      getGlobalConfigMock.mockReturnValue({
+        featureFlags: {
+          FEATURE_FLAG_NEW_OPEN_PACKAGE: false,
+        },
+      })
+
+      await switchOpen(url, options)
+
+      expect(getGlobalConfigMock).toHaveBeenCalled()
+      expect(opn).toHaveBeenCalled()
+    })
+
+    test('should show a debug log in case of errors', async () => {
+      const errorMsg = 'fake error'
+      getGlobalConfigMock.mockImplementation(() => {
+        throw new Error(errorMsg)
+      })
+
+      await switchOpen(url, options)
+
+      expect(getGlobalConfigMock).toHaveBeenCalled()
+      expect(ErrorReport.createAndMaybeRegisterOnTelemetry).toHaveBeenCalled()
+      expect(ErrorReport)
+    })
+  })
+})

--- a/src/api/clients/IOClients/apps/ToolbeltConfig.ts
+++ b/src/api/clients/IOClients/apps/ToolbeltConfig.ts
@@ -2,13 +2,13 @@ import { InstanceOptions, IOClient, IOContext } from '@vtex/api'
 import { NodeToRender } from '@vtex/toolbelt-message-renderer'
 import { IOClientFactory } from '../IOClientFactory'
 
-interface VersionCheckRes {
+export interface VersionCheckRes {
   minVersion: string
   validVersion: boolean
   message: string
 }
 
-interface GlobalConfig {
+export interface GlobalConfig {
   config: Record<string, any>
   messages: Record<string, NodeToRender>
   featureFlags: Record<string, any>

--- a/src/api/error/ErrorReport.ts
+++ b/src/api/error/ErrorReport.ts
@@ -17,7 +17,7 @@ interface CustomErrorReportCreateArgs extends ErrorReportCreateArgs {
   shouldRemoteReport?: boolean
 }
 
-interface CustomErrorReportBaseConstructorArgs extends ErrorReportBaseConstructorArgs {
+export interface CustomErrorReportBaseConstructorArgs extends ErrorReportBaseConstructorArgs {
   shouldRemoteReport: boolean
 }
 
@@ -31,7 +31,7 @@ interface ErrorEnv {
 }
 
 type ErrorLogLevel = 'error' | 'debug'
-interface LogToUserOptions {
+export interface LogToUserOptions {
   coreLogLevelDefault?: ErrorLogLevel
   requestDataLogLevelDefault?: ErrorLogLevel
   logLevels?: {

--- a/src/modules/featureFlag/featureFlagDecider.ts
+++ b/src/modules/featureFlag/featureFlagDecider.ts
@@ -3,11 +3,19 @@ import open from 'open'
 import { ErrorReport } from '../../api/error/ErrorReport'
 import { ErrorKinds } from '../../api/error/ErrorKinds'
 import opn from 'opn'
+import logger from '../../api/logger'
+import chalk from 'chalk'
 
 export async function switchOpen(url: string, options) {
   try {
     const configClient = ToolbeltConfig.createClient()
+    console.log(configClient.getGlobalConfig)
     const { featureFlags } = await configClient.getGlobalConfig()
+
+    console.log(featureFlags)
+
+    logger.info('Your browser should open automatically. You can also use the url below.')
+    logger.info(`${chalk.cyan(url)}`)
 
     if (featureFlags.FEATURE_FLAG_NEW_OPEN_PACKAGE) {
       return open(url, options)

--- a/src/modules/featureFlag/featureFlagDecider.ts
+++ b/src/modules/featureFlag/featureFlagDecider.ts
@@ -9,10 +9,7 @@ import chalk from 'chalk'
 export async function switchOpen(url: string, options) {
   try {
     const configClient = ToolbeltConfig.createClient()
-    console.log(configClient.getGlobalConfig)
     const { featureFlags } = await configClient.getGlobalConfig()
-
-    console.log(featureFlags)
 
     logger.info('Your browser should open automatically. You can also use the url below.')
     logger.info(`${chalk.cyan(url)}`)


### PR DESCRIPTION
#### What is the purpose of this pull request?
As requested in #1245, the goal of this PR is to display the URL that will be opened in the browser to allow the user to open it manually in case of errors.

#### What problem is this solving?
Some users using Unix distributions were not able to login using `vtex login` because the `open` and `opn` packages do not work properly in their OSs.

#### How should this be manually tested?
1. Add the `.vtex/dev/bin` folder to the PATH, as mentioned in the CONTRIBUTING file;
2. run `yarn watch` in the root folder of the repository
3. run `vtex-test login`
4. see the url

#### Screenshots or example usage
![Screenshot 2025-04-30 at 15 27 40](https://github.com/user-attachments/assets/19aab921-6139-4c00-8a7a-3ddabeb8f1ff)


#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [x] Update `CHANGELOG.md`