### PR TITLE
Update deployment to allow manual release

### DIFF
--- a/.github/workflows/create-release-and-trigger-publish.yml
+++ b/.github/workflows/create-release-and-trigger-publish.yml
@@ -8,8 +8,27 @@ on:
       - 'v[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
-  create-release:
+  check-tag:
     runs-on: ubuntu-latest
+    outputs:
+      tag_exists: ${{ steps.check.outputs.exists }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Check if tag exists
+        id: check
+        run: |
+          if git ls-remote --tags origin | grep -q "refs/tags/${GITHUB_REF_NAME}$"; then
+            echo "::set-output name=exists::true"
+          else
+            echo "::set-output name=exists::false"
+          fi
+  create-release:
+    needs: [check-tag]
+    if: needs.check_tag.outputs.tag_exists == 'false'
+    runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.set-output.outputs.created }}
     steps:
       - name: Create Release
         id: create_release
@@ -21,19 +40,24 @@ jobs:
           release_name: Release ${{ github.ref }}
           draft: false
           prerelease: false
+      - name: Set output
+        id: set-output
+        run: echo "created=true" >> $GITHUB_ENV
   trigger-publish:
+    needs: [check-tag, create-release]
     runs-on: ubuntu-latest
-    needs: [create-release]
+    if: needs.check-tag.outputs.tag_exists == 'true' || needs.create-release.result == 'success'
     steps:
-    - name: Trigger NPM publish
-      uses: peter-evans/repository-dispatch@v1
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        repository: vtex/toolbelt
-        event-type: publish-stable-npm
-    - name: Trigger AWS publish
-      uses: peter-evans/repository-dispatch@v1
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        repository: vtex/toolbelt
-        event-type: publish-stable-aws
+      # ...
+      - name: Trigger NPM publish
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repository: vtex/toolbelt
+          event-type: publish-stable-npm
+      - name: Trigger AWS publish
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repository: vtex/toolbelt
+          event-type: publish-stable-aws

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [4.1.1]
-
-### Updated
-
-- Extend VBase client, integrating the `getConflicts` and the `resolveConflict` endpoints.
+## [4.2.1]
 
 ### Fixed
 
 - The URL is now shown as a log when opening browser windows.
+
+## [4.2.0]
+
+### Updated
+
+- Extend VBase client, integrating the `getConflicts` and the `resolveConflict` endpoints.
 
 ## [4.1.0] - 2024-08-01
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "description": "The platform for e-commerce apps",
   "bin": "bin/run",
   "main": "lib/api/index.js",


### PR DESCRIPTION
#### What is the purpose of this pull request?
To allow triggering new releases manually. Also, it fixes the Changelog, since a new version was released and the changelog wasn't updated properly.

#### What problem is this solving?
Currently, when we go to `Releases` and create a new release manually, creating a new tag, the `create-release-and-trigger-publish` workflow fails with the error `Validation Failed: {"resource":"Release","code":"already_exists","field":"tag_name"}`. To fix this issue, we need to skip the `create-release` job when the tag already exists, proceeding to the next step.

#### How should this be manually tested?
-

#### Screenshots or example usage
-

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [x] Update `CHANGELOG.md`