### PR TITLE
Update vtexid host to use myvtex

### DIFF
--- a/src/api/clients/IOClients/external/VTEXID.ts
+++ b/src/api/clients/IOClients/external/VTEXID.ts
@@ -7,7 +7,6 @@ import { switchOpen } from '../../../../modules/featureFlag/featureFlagDecider'
 export class VTEXID extends IOClient {
   private static readonly DEFAULT_TIMEOUT = 10000
   private static readonly DEFAULT_RETRIES = 2
-  private static readonly BASE_URL = 'https://vtexid.vtex.com.br'
   private static readonly API_PATH_PREFIX = '/api/vtexid'
   private static readonly TOOLBELT_API_PATH_PREFIX = `${VTEXID.API_PATH_PREFIX}/toolbelt`
   private static readonly VTEX_ID_AUTH_COOKIE = 'VtexIdClientAutCookie'
@@ -28,27 +27,27 @@ export class VTEXID extends IOClient {
       timeout: VTEXID.DEFAULT_TIMEOUT,
       retries: VTEXID.DEFAULT_RETRIES,
       ...opts,
-      baseURL: VTEXID.BASE_URL,
+      baseURL: `https://${ioContext.account}.myvtex.com`,
     })
   }
 
-  public startToolbeltLogin({ account, secretHash, loopbackUrl }: StartToolbeltLoginInput) {
+  public startToolbeltLogin({ secretHash, loopbackUrl }: StartToolbeltLoginInput) {
     const body = querystring.stringify({
       secretHash,
       loopbackUrl,
     })
 
-    return this.http.post<string>(`${VTEXID.TOOLBELT_API_PATH_PREFIX}/start?an=${account}`, body)
+    return this.http.post<string>(`${VTEXID.TOOLBELT_API_PATH_PREFIX}/start`, body)
   }
 
-  public validateToolbeltLogin({ account, state, secret, ott }: ValidateToolbeltLoginInput) {
+  public validateToolbeltLogin({ state, secret, ott }: ValidateToolbeltLoginInput) {
     const body = querystring.stringify({
       state,
       secret,
       ott,
     })
 
-    return this.http.post<{ token: string }>(`${VTEXID.TOOLBELT_API_PATH_PREFIX}/validate?an=${account}`, body)
+    return this.http.post<{ token: string }>(`${VTEXID.TOOLBELT_API_PATH_PREFIX}/validate`, body)
   }
 
   public invalidateToolbeltToken(token: string) {
@@ -61,13 +60,11 @@ export class VTEXID extends IOClient {
 }
 
 interface StartToolbeltLoginInput {
-  account: string
   secretHash: string
   loopbackUrl: string
 }
 
 interface ValidateToolbeltLoginInput {
-  account: string
   state: string
   secret: string
   ott: string

--- a/src/lib/auth/AuthProviders/OAuthAuthenticator/LoginServer.ts
+++ b/src/lib/auth/AuthProviders/OAuthAuthenticator/LoginServer.ts
@@ -158,7 +158,6 @@ export class LoginServer {
       const vtexId = VTEXID.createClient({ account: this.loginConfig.account })
       try {
         const { token } = await vtexId.validateToolbeltLogin({
-          account: this.loginConfig.account,
           secret: this.loginConfig.secret,
           ott: body.ott,
           state: this.loginState,

--- a/src/lib/auth/AuthProviders/OAuthAuthenticator/index.ts
+++ b/src/lib/auth/AuthProviders/OAuthAuthenticator/index.ts
@@ -32,7 +32,6 @@ export class OAuthAuthenticator extends AuthProviderBase {
 
     try {
       const loginState = await vtexId.startToolbeltLogin({
-        account,
         secretHash,
         loopbackUrl: loginServer.loginCallbackUrl,
       })


### PR DESCRIPTION
#### What is the purpose of this pull request?
Use `myvtex.com` instead of `vtex.com.br` on VTEX ID client.

#### What problem is this solving?
Currently the toolbelt uses the VTEX via the path `vtexid.vtex.com.br`, this is a deprecated URL that we need to decommission and also there the work related to the mTLS implementation, where requests to `vtex.com.br` will be blocked.

#### How should this be manually tested?

Run `yarn watch` and try to login:

- Accounts with mTLS disabled and VPN Full Tunnel off. Ex: vtexgame2
- Accounts with mTLS disabled and VPN Full Tunnel on. Ex: vtexgame2
- Accounts with mTLS enabled and VPN Full Tunnel off. Ex: ismarketplacedes
-- On this scenario you should receive an erros, because in case of mTLS enabled the user should be using the VPN.
- Accounts with mTLS enabled and VPN Full Tunnel on. Ex: ismarketplacedes


#### Screenshots or example usage

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [ ] Update `CHANGELOG.md`