### PR TITLE
Added Support to  with local environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.3.0]
+
+### Added
+
+- Support to `.npmrc` with local environment variable
+
 ## [4.2.2]
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "4.2.2",
+  "version": "4.3.0",
   "description": "The platform for e-commerce apps",
   "bin": "bin/run",
   "main": "lib/api/index.js",

--- a/src/api/files/ProjectFilesManager.ts
+++ b/src/api/files/ProjectFilesManager.ts
@@ -2,12 +2,64 @@ import { createReadStream, lstat, readFileSync, statSync } from 'fs-extra'
 import glob from 'globby'
 import { join } from 'path'
 import { reject } from 'ramda'
+import { PassThrough } from 'stream'
 import { BatchStream } from '../typings/types'
+
+/**
+ * Expands environment variables in .npmrc file content
+ * @param content The original .npmrc file content
+ * @returns The content with environment variables expanded
+ */
+const expandEnvironmentVariables = (content: string): string => {
+  return content.replace(/\$\{([^}]+)\}/g, (_, envVar) => {
+    const value = process.env[envVar]
+    if (value === undefined) {
+      throw new Error(`Environment variable ${envVar} is not defined`)
+    }
+    return value
+  })
+}
+
+/**
+ * Creates a stream from a string
+ * @param str The string to convert to a stream
+ * @returns A readable stream
+ */
+const stringToStream = (str: string) => {
+  const stream = new PassThrough()
+  stream.end(str)
+  return stream
+}
 
 export const createPathToFileObject = (root: string, prefix = '') => {
   return (path: string): BatchStream => {
     const realAbsolutePath = join(root, path)
     const stats = statSync(realAbsolutePath)
+
+    // Check if this is a .npmrc file that needs environment variable expansion
+    if (path.endsWith('.npmrc')) {
+      try {
+        const originalContent = readFileSync(realAbsolutePath, 'utf8')
+        const expandedContent = expandEnvironmentVariables(originalContent)
+        const expandedStream = stringToStream(expandedContent)
+
+        return {
+          path: join(prefix, path),
+          content: expandedStream,
+          byteSize: Buffer.byteLength(expandedContent, 'utf8'),
+        }
+      } catch (error) {
+        // If environment variable expansion fails, fall back to original file
+        console.warn(`Warning: Failed to expand environment variables in ${path}: ${error.message}`)
+        return {
+          path: join(prefix, path),
+          content: createReadStream(realAbsolutePath),
+          byteSize: stats.size,
+        }
+      }
+    }
+
+    // For all other files, use the original behavior
     return {
       path: join(prefix, path),
       content: createReadStream(realAbsolutePath),
@@ -52,7 +104,7 @@ export class ProjectFilesManager {
   }
 
   public async getLocalFiles(test = false): Promise<string[]> {
-    const files: string[] = await glob(['manifest.json', 'policies.json', 'node/.*', 'react/.*'], {
+    const files: string[] = await glob(['manifest.json', 'policies.json', '.npmrc', 'node/.*', 'react/.*'], {
       cwd: this.root,
       follow: true,
       ignore: this.getIgnoredPaths(test),

--- a/src/api/modules/apps/file.ts
+++ b/src/api/modules/apps/file.ts
@@ -44,7 +44,7 @@ export const getIgnoredPaths = (root: string, test = false): string[] => {
 
 export const listLocalFiles = (root: string, test = false, folder?: string): Promise<string[]> =>
   Promise.resolve(
-    glob(['manifest.json', 'policies.json', 'node/.*', 'react/.*', `${safeFolder(folder)}`], {
+    glob(['manifest.json', 'policies.json', '.npmrc', 'node/.*', 'react/.*', `${safeFolder(folder)}`], {
       cwd: root,
       follow: true,
       ignore: getIgnoredPaths(root, test),

--- a/src/modules/apps/link.ts
+++ b/src/modules/apps/link.ts
@@ -164,7 +164,7 @@ const watchAndSendChanges = async (
     throw err
   }
 
-  const defaultPatterns = ['*/**', 'manifest.json', 'policies.json', 'cypress.json']
+  const defaultPatterns = ['*/**', 'manifest.json', 'policies.json', '.npmrc', 'cypress.json']
   const linkedDepsPatterns = map(path => join(path, '**'), yarnFilesManager.symlinkedDepsDirs)
 
   const pathModifier = pipe(
@@ -173,8 +173,43 @@ const watchAndSendChanges = async (
   )
 
   const pathToChange = (path: string, remove?: boolean): ChangeToSend => {
-    const content = remove ? null : readFileSync(resolvePath(root, path)).toString('base64')
-    const byteSize = remove ? 0 : Buffer.byteLength(content)
+    if (remove) {
+      return {
+        content: null,
+        byteSize: 0,
+        path: pathModifier(path),
+      }
+    }
+
+    const filePath = resolvePath(root, path)
+    let fileContent: string
+
+    // Handle .npmrc files with environment variable expansion
+    if (path.endsWith('.npmrc')) {
+      try {
+        const originalContent = readFileSync(filePath, 'utf8')
+        // Expand environment variables in .npmrc content
+        const expandedContent = originalContent.replace(/\$\{([^}]+)\}/g, (_, envVar) => {
+          const value = process.env[envVar]
+          if (value === undefined) {
+            throw new Error(`Environment variable ${envVar} is not defined`)
+          }
+          return value
+        })
+        fileContent = expandedContent
+      } catch (error) {
+        // If environment variable expansion fails, fall back to original file
+        log.warn(`Warning: Failed to expand environment variables in ${path}: ${error.message}`)
+        fileContent = readFileSync(filePath, 'utf8')
+      }
+    } else {
+      // For all other files, read as binary and convert to base64
+      fileContent = readFileSync(filePath).toString('base64')
+    }
+
+    const content = Buffer.from(fileContent, 'utf8').toString('base64')
+    const byteSize = Buffer.byteLength(content)
+
     return {
       content,
       byteSize,


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
Enable VTEX IO applications to use private npm packages

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
The flagship customer needs to use their proprietary private npm package across different VTEX IO apps; the features in this package are unique, and there are no public options to replace it.
The Tollbelt needs to copy the `.npmrc` file to the application's compressed file, for further use of the Builder Hub

#### How should this be manually tested?
Just like the example below, add a private package to a VTEX IO Application, the compressed file will include the `.npmrc` file with any environment variables expanded.

#### Screenshots or example usage
<img width="1263" height="1116" alt="image" src="https://github.com/user-attachments/assets/22ebb6ea-24ca-48bc-a317-000660e6254f" />

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [x] Update `CHANGELOG.md`