### PR TITLE
chore: fix pipeline config and enable SonarQube coverage

### DIFF
--- a/.vtex/deployment.yaml
+++ b/.vtex/deployment.yaml
@@ -6,13 +6,16 @@
       - name: node-ci-v2
         parameters:
           nodeVersion: "20-bookworm"
-          packManager: yarn
+          packageManager: yarn
           skipInstall: false
-          nomdeCommands:
+          sonarProjectName: toolbelt
+          nodeCommands:
             - ci:prettier-check
             - lint:node
             - ci:test
         when:
+          - event: pull_request
+            source: branch
           - event: push
             source: branch
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build": "yarn build-clean && yarn tsc && yarn oclif-dev manifest --color=256",
     "test": "jest",
     "prepublishOnly": "bash ./scripts/publishLock.sh",
-    "ci:test": "yarn test --ci",
+    "ci:test": "yarn test --ci --coverage",
     "ci:prettier-check": "prettier --check --config ./.prettierrc \"./src/**/*.{ts,tsx,js,jsx,json}\"",
     "release": "yarn build && yarn oclif-dev pack && yarn oclif-dev publish",
     "release:win": "yarn build && yarn oclif-dev pack:win && yarn oclif-dev publish:win"


### PR DESCRIPTION
## Summary
- Fix typos in `deployment.yaml`: `nomdeCommands` → `nodeCommands`, `packManager` → `packageManager` (pipeline commands were likely not running at all)
- Add `sonarProjectName: toolbelt` so the SonarQube scan reports results to the dashboard
- Add `--coverage` flag to `ci:test` so Jest generates an lcov report for SonarQube
- Add `pull_request` event trigger for SonarQube PR decoration (quality gate comments on PRs)

## Context
Part of the SonarQube rollout — Phase 2 (Tier 1 coverage quick wins).

## Test plan
- [ ] Verify `node-ci-v2` pipeline runs on this PR at http://dkcicd.vtex.systems/
- [ ] Verify the sonar scan step runs successfully
- [ ] Check http://sonarqube.vtex.systems/dashboard?id=toolbelt for the project appearing
- [ ] Verify PR decoration (SonarQube comment on this PR)
- [ ] Verify coverage > 0%