### PR TITLE
[XTNSNS-2000] Enables refreshing login token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.4.0]
+
 ### Added
 
 - Toolbelt now auto-refreshes user access tokens after 12 hours, avoiding the need to login every 24 hours.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Toolbelt now auto-refreshes user access tokens after 12 hours, avoiding the need to login every 24 hours.
+
 ## [4.3.2]
 
 ### Fixed
+
 - Update the dependency to a functional version for vtex/node-stats-lite
 - Update the bin/run to match the best v8 cache implementation given a nodejs version
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "4.4.0-beta",
+  "version": "4.4.0",
   "description": "The platform for e-commerce apps",
   "bin": "bin/run",
   "main": "lib/api/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex",
-  "version": "4.3.2",
+  "version": "4.4.0-beta",
   "description": "The platform for e-commerce apps",
   "bin": "bin/run",
   "main": "lib/api/index.js",

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "request": "~2.88.0",
     "semver": "^7.7.3",
     "semver-diff": "~2.1.0",
+    "set-cookie-parser": "^3.1.0",
     "supports-hyperlinks": "^2.1.0",
     "tar": "~4.4.10",
     "tslib": "^1.0.0",

--- a/src/api/clients/IOClients/external/VTEXID.test.ts
+++ b/src/api/clients/IOClients/external/VTEXID.test.ts
@@ -1,0 +1,141 @@
+import type { IOContext, InstanceOptions } from '@vtex/api'
+import { VTEXID, RefreshFailedError } from './VTEXID'
+
+function buildIoContext(account = 'testaccount'): IOContext {
+  return {
+    account,
+    userAgent: 'toolbelt-jest',
+    workspace: 'master',
+    authToken: '',
+    region: 'aws-us-east-1',
+    production: false,
+    product: '',
+    route: { id: '', params: {} },
+    requestId: '',
+    operationId: '',
+    platform: '',
+    logger: {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      sendLog: jest.fn(),
+    } as unknown as IOContext['logger'],
+  }
+}
+
+function buildClient() {
+  return new VTEXID(buildIoContext(), {} as InstanceOptions)
+}
+
+function mockPostRaw(client: VTEXID, impl: jest.Mock) {
+  ;(client as unknown as { http: { postRaw: jest.Mock } }).http.postRaw = impl
+}
+
+function successBody() {
+  return { status: 'Success' as const, userId: null, refreshAfter: null }
+}
+
+describe('VTEXID.refreshToken', () => {
+  let client: VTEXID
+  let postRaw: jest.Mock
+
+  beforeEach(() => {
+    client = buildClient()
+    postRaw = jest.fn()
+    mockPostRaw(client, postRaw)
+  })
+
+  it('returns token and refreshToken when status is Success and both cookies are present', async () => {
+    const jwt = 'auth.jwt.here'
+    const rt = 'new-refresh-token'
+    postRaw.mockResolvedValue({
+      data: successBody(),
+      status: 200,
+      headers: {
+        'set-cookie': [
+          `VtexIdClientAutCookie=${jwt}; Path=/; HttpOnly`,
+          `vid_rt=${encodeURIComponent(rt)}; Path=/; HttpOnly`,
+        ],
+      },
+    } as any)
+
+    await expect(client.refreshToken('old-refresh')).resolves.toEqual({
+      token: jwt,
+      refreshToken: rt,
+    })
+  })
+
+  it('throws RefreshFailedError when status is Success but only auth cookie exists', async () => {
+    postRaw.mockResolvedValue({
+      data: successBody(),
+      status: 200,
+      headers: {
+        'set-cookie': [`VtexIdClientAutCookie=only-auth; Path=/`],
+      },
+    } as any)
+
+    await expect(client.refreshToken('rt')).rejects.toThrow(/did not include both VtexIdClientAutCookie and vid_rt/)
+  })
+
+  it('throws RefreshFailedError when status is Success but only vid_rt cookie exists', async () => {
+    postRaw.mockResolvedValue({
+      data: successBody(),
+      status: 200,
+      headers: {
+        'set-cookie': [`vid_rt=only-refresh; Path=/`],
+      },
+    } as any)
+
+    await expect(client.refreshToken('rt')).rejects.toThrow(RefreshFailedError)
+  })
+
+  it('throws RefreshFailedError when status is Success but Set-Cookie is missing', async () => {
+    postRaw.mockResolvedValue({
+      data: successBody(),
+      status: 200,
+      headers: {},
+    } as any)
+
+    await expect(client.refreshToken('rt')).rejects.toThrow(RefreshFailedError)
+  })
+
+  it('throws RefreshFailedError when body status is InvalidSession', async () => {
+    postRaw.mockResolvedValue({
+      data: { status: 'InvalidSession', userId: null, refreshAfter: null },
+      status: 200,
+      headers: {
+        'set-cookie': [
+          'VtexIdClientAutCookie=auth; Path=/',
+          'vid_rt=refresh; Path=/',
+        ],
+      },
+    } as any)
+
+    await expect(client.refreshToken('rt')).rejects.toThrow('Failed to refresh: status InvalidSession')
+  })
+
+  it('throws RefreshFailedError when body status is another non-Success value', async () => {
+    postRaw.mockResolvedValue({
+      data: { status: 'Expired', userId: null, refreshAfter: null },
+      status: 200,
+      headers: {},
+    } as any)
+
+    await expect(client.refreshToken('rt')).rejects.toThrow('Failed to refresh: status Expired')
+  })
+
+  it('rejects with the underlying error when postRaw fails with 4xx', async () => {
+    const err = Object.assign(new Error('Unauthorized'), { response: { status: 401 } })
+    postRaw.mockRejectedValue(err)
+
+    await expect(client.refreshToken('rt')).rejects.toBe(err)
+  })
+
+  it('rejects with the underlying error when postRaw fails with 5xx', async () => {
+    const err = Object.assign(new Error('Bad Gateway'), { response: { status: 502 } })
+    postRaw.mockRejectedValue(err)
+
+    await expect(client.refreshToken('rt')).rejects.toBe(err)
+  })
+})

--- a/src/api/clients/IOClients/external/VTEXID.test.ts
+++ b/src/api/clients/IOClients/external/VTEXID.test.ts
@@ -54,7 +54,7 @@ describe('VTEXID.refreshToken', () => {
       status: 200,
       headers: {
         'set-cookie': [
-          `VtexIdClientAutCookie=${jwt}; Path=/; HttpOnly`,
+          `VtexIdclientAutCookie=${jwt}; Path=/; HttpOnly`,
           `vid_rt=${encodeURIComponent(rt)}; Path=/; HttpOnly`,
         ],
       },
@@ -71,11 +71,11 @@ describe('VTEXID.refreshToken', () => {
       data: successBody(),
       status: 200,
       headers: {
-        'set-cookie': [`VtexIdClientAutCookie=only-auth; Path=/`],
+        'set-cookie': [`VtexIdclientAutCookie=only-auth; Path=/`],
       },
     } as any)
 
-    await expect(client.refreshToken('rt')).rejects.toThrow(/did not include both VtexIdClientAutCookie and vid_rt/)
+    await expect(client.refreshToken('rt')).rejects.toThrow(/did not include both VtexIdclientAutCookie and vid_rt/)
   })
 
   it('throws RefreshFailedError when status is Success but only vid_rt cookie exists', async () => {
@@ -106,7 +106,7 @@ describe('VTEXID.refreshToken', () => {
       status: 200,
       headers: {
         'set-cookie': [
-          'VtexIdClientAutCookie=auth; Path=/',
+          'VtexIdclientAutCookie=auth; Path=/',
           'vid_rt=refresh; Path=/',
         ],
       },

--- a/src/api/clients/IOClients/external/VTEXID.ts
+++ b/src/api/clients/IOClients/external/VTEXID.ts
@@ -47,7 +47,22 @@ export class VTEXID extends IOClient {
       ott,
     })
 
-    return this.http.post<{ token: string }>(`${VTEXID.TOOLBELT_API_PATH_PREFIX}/validate`, body)
+    return this.http.post<{ token: string; refresh_token?: string }>(
+      `${VTEXID.TOOLBELT_API_PATH_PREFIX}/validate`,
+      body
+    )
+  }
+
+  public refreshToken(refreshToken: string) {
+    return this.http.post<{ token: string }>(
+      `${VTEXID.API_PATH_PREFIX}/refreshtoken/admin`,
+      null,
+      {
+        headers: {
+          Cookie: `vid_rt=${refreshToken}`,
+        },
+      }
+    )
   }
 
   public invalidateToolbeltToken(token: string) {

--- a/src/api/clients/IOClients/external/VTEXID.ts
+++ b/src/api/clients/IOClients/external/VTEXID.ts
@@ -18,7 +18,7 @@ export class VTEXID extends IOClient {
   private static readonly DEFAULT_RETRIES = 2
   private static readonly API_PATH_PREFIX = '/api/vtexid'
   private static readonly TOOLBELT_API_PATH_PREFIX = `${VTEXID.API_PATH_PREFIX}/toolbelt`
-  private static readonly VTEX_ID_AUTH_COOKIE = 'VtexIdClientAutCookie'
+  private static readonly VTEX_ID_AUTH_COOKIE = 'VtexIdclientAutCookie'
   private static readonly VTEX_ID_REFRESH_TOKEN_COOKIE = 'vid_rt'
 
   public static createClient(customContext: Partial<IOContext> = {}, customOptions: Partial<InstanceOptions> = {}) {
@@ -85,7 +85,7 @@ export class VTEXID extends IOClient {
 
     if (token == null || newRefreshToken == null || token === '' || newRefreshToken === '') {
       throw new RefreshFailedError(
-        'Failed to refresh: Set-Cookie headers did not include both VtexIdClientAutCookie and vid_rt cookies.'
+        'Failed to refresh: Set-Cookie headers did not include both VtexIdclientAutCookie and vid_rt cookies.'
       )
     }
 

--- a/src/api/clients/IOClients/external/VTEXID.ts
+++ b/src/api/clients/IOClients/external/VTEXID.ts
@@ -1,8 +1,17 @@
 import { InstanceOptions, IOClient, IOContext } from '@vtex/api'
 import querystring from 'querystring'
+import { parseSetCookie } from 'set-cookie-parser'
 import { storeUrl } from '../../../storeUrl'
 import { IOClientFactory } from '../IOClientFactory'
 import { switchOpen } from '../../../../modules/featureFlag/featureFlagDecider'
+
+interface RefreshResponse {
+  status: string
+  userId: string | null
+  refreshAfter: string | null
+}
+
+export class RefreshFailedError extends Error {}
 
 export class VTEXID extends IOClient {
   private static readonly DEFAULT_TIMEOUT = 10000
@@ -10,6 +19,7 @@ export class VTEXID extends IOClient {
   private static readonly API_PATH_PREFIX = '/api/vtexid'
   private static readonly TOOLBELT_API_PATH_PREFIX = `${VTEXID.API_PATH_PREFIX}/toolbelt`
   private static readonly VTEX_ID_AUTH_COOKIE = 'VtexIdClientAutCookie'
+  private static readonly VTEX_ID_REFRESH_TOKEN_COOKIE = 'vid_rt'
 
   public static createClient(customContext: Partial<IOContext> = {}, customOptions: Partial<InstanceOptions> = {}) {
     return IOClientFactory.createClient<VTEXID>(VTEXID, customContext, customOptions, { requireAuth: false })
@@ -53,16 +63,33 @@ export class VTEXID extends IOClient {
     )
   }
 
-  public refreshToken(refreshToken: string) {
-    return this.http.post<{ token: string }>(
+  public async refreshToken(refreshToken: string): Promise<{ token: string; refreshToken: string }> {
+    const { data, headers } = await this.http.postRaw<RefreshResponse>(
       `${VTEXID.API_PATH_PREFIX}/refreshtoken/admin`,
       null,
       {
         headers: {
-          Cookie: `vid_rt=${refreshToken}`,
+          Cookie: `${VTEXID.VTEX_ID_REFRESH_TOKEN_COOKIE}=${refreshToken}`,
         },
       }
     )
+
+    if (data.status !== 'Success') {
+      throw new RefreshFailedError(`Failed to refresh: status ${data.status}.`)
+    }
+
+    const setCookieHeader = headers['set-cookie']
+    const cookieMap = parseSetCookie(setCookieHeader ?? [], { map: true })
+    const token = cookieMap[VTEXID.VTEX_ID_AUTH_COOKIE]?.value
+    const newRefreshToken = cookieMap[VTEXID.VTEX_ID_REFRESH_TOKEN_COOKIE]?.value
+
+    if (token == null || newRefreshToken == null || token === '' || newRefreshToken === '') {
+      throw new RefreshFailedError(
+        'Failed to refresh: Set-Cookie headers did not include both VtexIdClientAutCookie and vid_rt cookies.'
+      )
+    }
+
+    return { token, refreshToken: newRefreshToken }
   }
 
   public invalidateToolbeltToken(token: string) {

--- a/src/api/session/SessionManager.login.test.ts
+++ b/src/api/session/SessionManager.login.test.ts
@@ -1,0 +1,217 @@
+import jwt from 'jsonwebtoken'
+import type { AuthProviderBase } from '../../lib/auth/AuthProviders'
+import { SessionManager } from './SessionManager'
+import type { SessionsPersisterBase } from './SessionsPersister'
+import { VTEXID } from '../clients/IOClients/external/VTEXID'
+
+jest.mock('../clients/IOClients/external/VTEXID', () => ({
+  VTEXID: {
+    createClient: jest.fn(),
+    invalidateBrowserAuthCookie: jest.fn(),
+  },
+}))
+
+jest.mock('../logger', () => ({
+  __esModule: true,
+  default: {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}))
+
+const createClientMock = VTEXID.createClient as jest.MockedFunction<typeof VTEXID.createClient>
+
+function signJwt(expOffsetSeconds: number, sub = 'user@vtex.com') {
+  return jwt.sign({ sub, exp: Math.floor(Date.now() / 1000) + expOffsetSeconds }, 'test-secret')
+}
+
+function createPersister(overrides: Partial<Record<string, jest.Mock>> = {}): SessionsPersisterBase {
+  const base = {
+    clearData: jest.fn(),
+    getAccount: jest.fn(() => ''),
+    saveAccount: jest.fn(),
+    getLastAccount: jest.fn(() => ''),
+    saveLastAccount: jest.fn(),
+    getWorkspace: jest.fn(() => 'master'),
+    saveWorkspace: jest.fn(),
+    getLastWorkspace: jest.fn(() => ''),
+    saveLastWorkspace: jest.fn(),
+    getToken: jest.fn(() => ''),
+    saveToken: jest.fn(),
+    getLogin: jest.fn(() => ''),
+    saveLogin: jest.fn(),
+    getAccountToken: jest.fn(() => ''),
+    saveAccountToken: jest.fn(),
+    getAccountRefreshToken: jest.fn(() => ''),
+    saveAccountRefreshToken: jest.fn(),
+  }
+  return { ...base, ...overrides } as unknown as SessionsPersisterBase
+}
+
+const workspaceCreation = {
+  promptCreation: false,
+  creator: jest.fn(),
+  onError: jest.fn(),
+}
+
+describe('SessionManager.login', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    createClientMock.mockReturnValue({
+      refreshToken: jest.fn(),
+      invalidateToolbeltToken: jest.fn().mockResolvedValue(undefined),
+    } as any)
+  })
+
+  it('uses a valid cached account token and does not call refresh or OAuth', async () => {
+    const cached = signJwt(3600)
+    const persister = createPersister({
+      getAccountToken: jest.fn(() => cached),
+    })
+    const oauthLogin = jest.fn()
+    const sm = new SessionManager({
+      sessionsPersister: persister,
+      authProviders: { oauth: { login: oauthLogin } as AuthProviderBase },
+    })
+
+    await sm.login('acme', { workspaceCreation, useCachedToken: true, authMethod: 'oauth' })
+
+    expect(oauthLogin).not.toHaveBeenCalled()
+    expect(createClientMock).not.toHaveBeenCalled()
+    expect(sm.token).toBe(cached)
+  })
+
+  it('refreshes when cached token is invalid but a refresh token exists', async () => {
+    const expired = signJwt(-3600)
+    const refreshedJwt = signJwt(7200)
+    const persister = createPersister({
+      getAccountToken: jest.fn(() => expired),
+      getAccountRefreshToken: jest.fn(() => 'stored-refresh'),
+    })
+    const refreshToken = jest.fn().mockResolvedValue({ token: refreshedJwt, refreshToken: 'new-refresh' })
+    createClientMock.mockReturnValue({
+      refreshToken,
+      invalidateToolbeltToken: jest.fn().mockResolvedValue(undefined),
+    } as any)
+
+    const oauthLogin = jest.fn()
+    const sm = new SessionManager({
+      sessionsPersister: persister,
+      authProviders: { oauth: { login: oauthLogin } as AuthProviderBase },
+    })
+
+    await sm.login('acme', { workspaceCreation, useCachedToken: true, authMethod: 'oauth' })
+
+    expect(createClientMock).toHaveBeenCalledWith({ account: 'acme' })
+    expect(refreshToken).toHaveBeenCalledWith('stored-refresh')
+    expect(oauthLogin).not.toHaveBeenCalled()
+    expect(persister.saveAccountToken).toHaveBeenCalledWith('acme', refreshedJwt)
+    expect(persister.saveAccountRefreshToken).toHaveBeenCalledWith('acme', 'new-refresh')
+    expect(sm.token).toBe(refreshedJwt)
+  })
+
+  it('falls back to OAuth when refresh throws', async () => {
+    const expired = signJwt(-3600)
+    const oauthJwt = signJwt(3600)
+    const persister = createPersister({
+      getAccountToken: jest.fn(() => expired),
+      getAccountRefreshToken: jest.fn(() => 'bad-refresh'),
+    })
+    const refreshToken = jest.fn().mockRejectedValue(new Error('refresh failed'))
+    createClientMock.mockReturnValue({
+      refreshToken,
+      invalidateToolbeltToken: jest.fn().mockResolvedValue(undefined),
+    } as any)
+
+    const oauthLogin = jest.fn().mockResolvedValue({
+      login: 'u@v.io',
+      token: oauthJwt,
+      refreshToken: 'from-oauth',
+    })
+    const sm = new SessionManager({
+      sessionsPersister: persister,
+      authProviders: { oauth: { login: oauthLogin } as AuthProviderBase },
+    })
+
+    await sm.login('acme', { workspaceCreation, useCachedToken: true, authMethod: 'oauth' })
+
+    expect(refreshToken).toHaveBeenCalled()
+    expect(oauthLogin).toHaveBeenCalledWith('acme', 'master')
+    expect(persister.saveAccountToken).toHaveBeenCalledWith('acme', oauthJwt)
+    expect(persister.saveAccountRefreshToken).toHaveBeenCalledWith('acme', 'from-oauth')
+  })
+
+  it('falls back to OAuth when there is no stored refresh token', async () => {
+    const expired = signJwt(-3600)
+    const oauthJwt = signJwt(3600)
+    const persister = createPersister({
+      getAccountToken: jest.fn(() => expired),
+      getAccountRefreshToken: jest.fn(() => ''),
+    })
+    const oauthLogin = jest.fn().mockResolvedValue({
+      login: 'u@v.io',
+      token: oauthJwt,
+      refreshToken: 'rt-oauth',
+    })
+    const sm = new SessionManager({
+      sessionsPersister: persister,
+      authProviders: { oauth: { login: oauthLogin } as AuthProviderBase },
+    })
+
+    await sm.login('acme', { workspaceCreation, useCachedToken: true, authMethod: 'oauth' })
+
+    expect(createClientMock).not.toHaveBeenCalled()
+    expect(oauthLogin).toHaveBeenCalledWith('acme', 'master')
+    expect(persister.saveAccountRefreshToken).toHaveBeenCalledWith('acme', 'rt-oauth')
+  })
+
+  it('ignores a valid cache when useCachedToken is false and still refreshes if a refresh token exists', async () => {
+    const cachedValid = signJwt(3600)
+    const refreshedJwt = signJwt(7200)
+    const persister = createPersister({
+      getAccountToken: jest.fn(() => cachedValid),
+      getAccountRefreshToken: jest.fn(() => 'rt'),
+    })
+    const refreshToken = jest.fn().mockResolvedValue({ token: refreshedJwt, refreshToken: 'rt2' })
+    createClientMock.mockReturnValue({
+      refreshToken,
+      invalidateToolbeltToken: jest.fn().mockResolvedValue(undefined),
+    } as any)
+
+    const oauthLogin = jest.fn()
+    const sm = new SessionManager({
+      sessionsPersister: persister,
+      authProviders: { oauth: { login: oauthLogin } as AuthProviderBase },
+    })
+
+    await sm.login('acme', { workspaceCreation, useCachedToken: false, authMethod: 'oauth' })
+
+    expect(refreshToken).toHaveBeenCalledWith('rt')
+    expect(oauthLogin).not.toHaveBeenCalled()
+    expect(sm.token).toBe(refreshedJwt)
+  })
+
+  it('does not persist refresh token from OAuth when login omits refreshToken', async () => {
+    const expired = signJwt(-3600)
+    const oauthJwt = signJwt(3600)
+    const persister = createPersister({
+      getAccountToken: jest.fn(() => expired),
+      getAccountRefreshToken: jest.fn(() => ''),
+    })
+    const oauthLogin = jest.fn().mockResolvedValue({
+      login: 'u@v.io',
+      token: oauthJwt,
+    })
+    const sm = new SessionManager({
+      sessionsPersister: persister,
+      authProviders: { oauth: { login: oauthLogin } as AuthProviderBase },
+    })
+
+    await sm.login('acme', { workspaceCreation, useCachedToken: true, authMethod: 'oauth' })
+
+    expect(persister.saveAccountToken).toHaveBeenCalledWith('acme', oauthJwt)
+    expect(persister.saveAccountRefreshToken).not.toHaveBeenCalled()
+  })
+})

--- a/src/api/session/SessionManager.ts
+++ b/src/api/session/SessionManager.ts
@@ -260,8 +260,7 @@ export class SessionManager implements ISessionManager {
 
     try {
       const vtexId = VTEXID.createClient({ account })
-      const response = await vtexId.refreshToken(storedRefreshToken)
-      const { token, refreshToken } = response
+      const { token, refreshToken } = await vtexId.refreshToken(storedRefreshToken)
       this.saveTokens(account, token, refreshToken)
       return true
     } catch (err) {

--- a/src/api/session/SessionManager.ts
+++ b/src/api/session/SessionManager.ts
@@ -164,10 +164,16 @@ export class SessionManager implements ISessionManager {
     if (useCachedToken && cachedToken.isValid()) {
       this.state.tokenObj = cachedToken
     } else {
-      // Tokens are scoped by workspace - logging into master will grant cacheability
-      const { token } = await this.authProviders[authMethod].login(newAccount, 'master')
-      this.state.tokenObj = new Token(token)
-      this.sessionPersister.saveAccountToken(newAccount, this.state.tokenObj.token)
+      const refreshed = await this.tryRefreshToken(newAccount)
+      if (!refreshed) {
+        // Tokens are scoped by workspace - logging into master will grant cacheability
+        const { token, refreshToken } = await this.authProviders[authMethod].login(newAccount, 'master')
+        this.state.tokenObj = new Token(token)
+        this.sessionPersister.saveAccountToken(newAccount, this.state.tokenObj.token as string)
+        if (refreshToken) {
+          this.sessionPersister.saveAccountRefreshToken(newAccount, refreshToken)
+        }
+      }
     }
 
     this.state.account = newAccount
@@ -258,13 +264,31 @@ export class SessionManager implements ISessionManager {
     this.sessionPersister.saveLastAccount(this.state.lastAccount)
   }
 
+  private async tryRefreshToken(account: string): Promise<boolean> {
+    const storedRefreshToken = this.sessionPersister.getAccountRefreshToken(account)
+    if (!storedRefreshToken) {
+      return false
+    }
+
+    try {
+      const vtexId = VTEXID.createClient({ account })
+      const { token } = await vtexId.refreshToken(storedRefreshToken)
+      this.state.tokenObj = new Token(token)
+      this.sessionPersister.saveAccountToken(account, this.state.tokenObj.token as string)
+      return true
+    } catch (err) {
+      logger.debug(`Refresh token failed, falling back to OAuth: ${(err as Error).message}`)
+      return false
+    }
+  }
+
   private async invalidateTokens({ invalidateBrowserAuthCookie }: LogoutOptions) {
     const vtexId = VTEXID.createClient()
     try {
-      await vtexId.invalidateToolbeltToken(this.token)
+      await vtexId.invalidateToolbeltToken(this.token as string)
       logger.info('Invalidated local token')
     } catch (err) {
-      const errReport = ErrorReport.createAndMaybeRegisterOnTelemetry({ originalError: err })
+      const errReport = ErrorReport.createAndMaybeRegisterOnTelemetry({ originalError: err as Error })
       logger.error('Unable to invalidate local token')
       errReport.logErrorForUser({
         coreLogLevelDefault: 'debug',

--- a/src/api/session/SessionManager.ts
+++ b/src/api/session/SessionManager.ts
@@ -160,21 +160,9 @@ export class SessionManager implements ISessionManager {
       this.state.lastWorkspace = null
     }
 
-    const cachedToken = new Token(this.sessionPersister.getAccountToken(newAccount))
-    if (useCachedToken && cachedToken.isValid()) {
-      this.state.tokenObj = cachedToken
-    } else {
-      const refreshed = await this.tryRefreshToken(newAccount)
-      if (!refreshed) {
-        // Tokens are scoped by workspace - logging into master will grant cacheability
-        const { token, refreshToken } = await this.authProviders[authMethod].login(newAccount, 'master')
-        this.state.tokenObj = new Token(token)
-        this.sessionPersister.saveAccountToken(newAccount, this.state.tokenObj.token as string)
-        if (refreshToken) {
-          this.sessionPersister.saveAccountRefreshToken(newAccount, refreshToken)
-        }
-      }
-    }
+    const usedCached = useCachedToken && this.tryCachedToken(newAccount)
+    const refreshed = !usedCached && (await this.tryRefreshToken(newAccount))
+    if (!usedCached && !refreshed) await this.authProviderLogin(authMethod, newAccount)
 
     this.state.account = newAccount
     this.state.workspace = 'master'
@@ -272,13 +260,36 @@ export class SessionManager implements ISessionManager {
 
     try {
       const vtexId = VTEXID.createClient({ account })
-      const { token } = await vtexId.refreshToken(storedRefreshToken)
-      this.state.tokenObj = new Token(token)
-      this.sessionPersister.saveAccountToken(account, this.state.tokenObj.token as string)
+      const response = await vtexId.refreshToken(storedRefreshToken)
+      const { token, refreshToken } = response
+      this.saveTokens(account, token, refreshToken)
       return true
     } catch (err) {
       logger.debug(`Refresh token failed, falling back to OAuth: ${(err as Error).message}`)
       return false
+    }
+  }
+
+  private tryCachedToken(account: string): boolean {
+    const cachedToken = new Token(this.sessionPersister.getAccountToken(account))
+    if (cachedToken.isValid()) {
+      this.state.tokenObj = cachedToken
+      return true
+    }
+    return false
+  }
+
+  private async authProviderLogin(authMethod: string, account: string): Promise<void> {
+    // Tokens are scoped by workspace - logging into master will grant cacheability
+    const { token, refreshToken } = await this.authProviders[authMethod].login(account, 'master')
+    this.saveTokens(account, token, refreshToken)
+  }
+
+  private saveTokens(account, token: string, refreshToken: string | null) {
+    this.state.tokenObj = new Token(token)
+    this.sessionPersister.saveAccountToken(account, token)
+    if (refreshToken) {
+      this.sessionPersister.saveAccountRefreshToken(account, refreshToken)
     }
   }
 

--- a/src/api/session/SessionManager.ts
+++ b/src/api/session/SessionManager.ts
@@ -285,7 +285,7 @@ export class SessionManager implements ISessionManager {
     this.saveTokens(account, token, refreshToken)
   }
 
-  private saveTokens(account, token: string, refreshToken: string | null) {
+  private saveTokens(account: string, token: string, refreshToken?: string): void {
     this.state.tokenObj = new Token(token)
     this.sessionPersister.saveAccountToken(account, token)
     if (refreshToken) {

--- a/src/api/session/SessionsPersister.ts
+++ b/src/api/session/SessionsPersister.ts
@@ -26,6 +26,9 @@ export abstract class SessionsPersisterBase {
 
   public abstract getAccountToken(account: string): string
   public abstract saveAccountToken(account: string, token: string)
+
+  public abstract getAccountRefreshToken(account: string): string
+  public abstract saveAccountRefreshToken(account: string, refreshToken: string): void
 }
 
 export class SessionsPersister extends SessionsPersisterBase {
@@ -119,5 +122,13 @@ export class SessionsPersister extends SessionsPersisterBase {
 
   public saveAccountToken(account: string, token: string) {
     this.tokenCacheStore.set(account, token)
+  }
+
+  public getAccountRefreshToken(account: string) {
+    return this.tokenCacheStore.get(`${account}_refresh_token`)
+  }
+
+  public saveAccountRefreshToken(account: string, refreshToken: string) {
+    this.tokenCacheStore.set(`${account}_refresh_token`, refreshToken)
   }
 }

--- a/src/lib/auth/AuthProviders/AuthProviderBase.ts
+++ b/src/lib/auth/AuthProviders/AuthProviderBase.ts
@@ -1,8 +1,9 @@
 export interface LoginResult {
   login: string
   token: string
+  refreshToken?: string
 }
 
 export abstract class AuthProviderBase {
-  public abstract async login(account: string, workspace: string): Promise<LoginResult>
+  public abstract login(account: string, workspace: string): Promise<LoginResult>
 }

--- a/src/lib/auth/AuthProviders/OAuthAuthenticator/LoginServer.ts
+++ b/src/lib/auth/AuthProviders/OAuthAuthenticator/LoginServer.ts
@@ -39,8 +39,8 @@ export class LoginServer {
 
   private loginState?: string
 
-  private tokenPromise: Promise<string>
-  private resolveTokenPromise: (val: string) => void
+  private tokenPromise: Promise<LoginCallbackResult>
+  private resolveTokenPromise: (val: LoginCallbackResult) => void
   private rejectTokenPromise: (err: any) => void
 
   constructor(private loginConfig: LoginConfig) {
@@ -53,7 +53,7 @@ export class LoginServer {
     })
   }
 
-  get token() {
+  get token(): Promise<LoginCallbackResult> {
     return this.tokenPromise
   }
 
@@ -157,13 +157,13 @@ export class LoginServer {
 
       const vtexId = VTEXID.createClient({ account: this.loginConfig.account })
       try {
-        const { token } = await vtexId.validateToolbeltLogin({
+        const { token, refresh_token: refreshToken } = await vtexId.validateToolbeltLogin({
           secret: this.loginConfig.secret,
           ott: body.ott,
           state: this.loginState,
         })
 
-        this.resolveTokenPromise(token)
+        this.resolveTokenPromise({ token, refreshToken })
         ctx.status = 200
         ctx.set('content-type', 'text/html')
         ctx.body = SUCCESS_PAGE
@@ -188,4 +188,9 @@ export class LoginServer {
 interface LoginConfig {
   account: string
   secret: string
+}
+
+interface LoginCallbackResult {
+  token: string
+  refreshToken?: string
 }

--- a/src/lib/auth/AuthProviders/OAuthAuthenticator/LoginServer.ts
+++ b/src/lib/auth/AuthProviders/OAuthAuthenticator/LoginServer.ts
@@ -53,7 +53,7 @@ export class LoginServer {
     })
   }
 
-  get token(): Promise<LoginCallbackResult> {
+  get tokens(): Promise<LoginCallbackResult> {
     return this.tokenPromise
   }
 

--- a/src/lib/auth/AuthProviders/OAuthAuthenticator/index.ts
+++ b/src/lib/auth/AuthProviders/OAuthAuthenticator/index.ts
@@ -59,7 +59,7 @@ export class OAuthAuthenticator extends AuthProviderBase {
         )
       }
 
-      const { token, refreshToken } = await loginServer.token
+      const { token, refreshToken } = await loginServer.tokens
       const decodedToken = jwt.decode(token)
       const login: string = decodedToken.sub
       this.closeChromeTabIfMac(loginServer.loginCallbackUrl)

--- a/src/lib/auth/AuthProviders/OAuthAuthenticator/index.ts
+++ b/src/lib/auth/AuthProviders/OAuthAuthenticator/index.ts
@@ -59,11 +59,11 @@ export class OAuthAuthenticator extends AuthProviderBase {
         )
       }
 
-      const token = await loginServer.token
+      const { token, refreshToken } = await loginServer.token
       const decodedToken = jwt.decode(token)
       const login: string = decodedToken.sub
       this.closeChromeTabIfMac(loginServer.loginCallbackUrl)
-      return { login, token }
+      return { login, token, refreshToken }
     } finally {
       loginServer.close()
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8073,6 +8073,11 @@ set-blocking@^2.0.0:
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
 
+set-cookie-parser@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/set-cookie-parser/-/set-cookie-parser-3.1.0.tgz#e0b1d94c8660c68e6a24dc4e2b5c9e955ccf7e28"
+  integrity sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==
+
 set-getter@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/set-getter/-/set-getter-0.1.0.tgz#d769c182c9d5a51f409145f2fba82e5e86e80376"


### PR DESCRIPTION
#### What is the purpose of this pull request?
To include VTEX ID refresh token mechanism.

#### What problem is this solving?
Currently agents executing on top of VTEX Toolbelt often have their tokens expired. We are implementing a mechanism that allows them to refresh the token implicitely allowing sessions to run for a longer time.

#### How should this be manually tested?

Steps:
1. Remove your tokens from the vtex folder
2. Login in a VTEX Account
3. Ensure that the tokens are stored as `{"account": "account.token"}` (`~/vtex/session/tokens.json` file)
4. Invalidate token using logout
5. Link the new toolbelt version
6. Login in the same account using toolbelt
7. Ensure that the refresh token is now saved in the tokens file as `{"account": "account.token", "account_refresh_token": "account.refresh.token"}`

If you want to test the refresh token usability, execute the steps above and wait at least 12 hours. Then:
1. Manually invalidate the account token in the tokens file (mentioned above) by erasing or modifying the value
2. Execute vtex login the linked toolbelt
3. Confirm it works

If you dont want to invalidate the token manually, tou can wait at least 24 hours and then just `vtex login` to the account you have a token stored. If this new login happens under a week after the first one, the refresh token will be successfully used.

We also added unit testing for the known scenarios and possible responses from VTEX ID.

#### Screenshots or example usage

#### Types of changes
- [x] Refactor (non-breaking change that only makes the code better)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [ ] Update `CHANGELOG.md`